### PR TITLE
remove second guide title in python otel guide

### DIFF
--- a/guides/opentelemetry-python.mdx
+++ b/guides/opentelemetry-python.mdx
@@ -5,7 +5,6 @@ sidebarTitle: Python Using OTel
 tags:
     ['guides', 'python']
 ---
-# Send OpenTelemetry data from a Python app to Axiom
 
 This guide explains how to send OpenTelemetry data from a Python app to Axiom using the [Python OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/instrumentation/).
 


### PR DESCRIPTION
- title appears to be duplicate, this PR removes the second one 