### PR TITLE
Describe required permissions for PagerDuty token

### DIFF
--- a/monitor-data/monitors.mdx
+++ b/monitor-data/monitors.mdx
@@ -117,7 +117,7 @@ For more information on creating an incoming webhook in Slack, see the [Slack do
 Create a PagerDuty notifier to use all the incident management features of PagerDuty with Axiom.
 
 1. In PagerDuty’s Events V2 API, create a new service named **Axiom** with the default settings. Copy the integration key. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/services-and-integrations#create-a-service)
-1. In PagerDuty, create a general-access REST API key with the default settings. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/api-access-keys#generate-a-general-access-rest-api-key).
+1. In PagerDuty, create a general-access REST API key. Don’t select the **Read-only API Key** checkbox. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/api-access-keys#generate-a-general-access-rest-api-key).
 1. In Axiom, go to the Monitors tab.
 1. Click **Manage notifiers**, and then click **New notifier**.
 1. Click **PagerDuty**, and then enter the integration key and API key.

--- a/monitor-data/monitors.mdx
+++ b/monitor-data/monitors.mdx
@@ -117,10 +117,9 @@ For more information on creating an incoming webhook in Slack, see the [Slack do
 Create a PagerDuty notifier to use all the incident management features of PagerDuty with Axiom.
 
 1. In PagerDuty’s Events V2 API, create a new service named **Axiom** with the default settings. Copy the integration key. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/services-and-integrations#create-a-service)
-1. In PagerDuty, create a general-access REST API key. Don’t select the **Read-only API Key** checkbox. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/api-access-keys#generate-a-general-access-rest-api-key).
 1. In Axiom, go to the Monitors tab.
 1. Click **Manage notifiers**, and then click **New notifier**.
-1. Click **PagerDuty**, and then enter the integration key and API key.
+1. Click **PagerDuty**, and then enter the integration key.
 1. Click **Create**.
 
 ### Custom webhook

--- a/monitor-data/monitors.mdx
+++ b/monitor-data/monitors.mdx
@@ -116,9 +116,11 @@ For more information on creating an incoming webhook in Slack, see the [Slack do
 
 Create a PagerDuty notifier to use all the incident management features of PagerDuty with Axiom.
 
-To configure a new “Service” in PagerDuty using the Events V2 API, go to **Configuration** > **Services** > **Add New Service** and create a new Service named ‘Axiom’ with all the default settings. Take note of the Integration Key provided and enter this when creating a PagerDuty notifier in Axiom.
+First, configure a new “Service” in PagerDuty using the Events V2 API. To do this, go to **Configuration** > **Services** > **Add New Service** and create a new Service named ‘Axiom’ with all the default settings. Take note of the Integration Key provided. 
 
-You will also need to provide an API Access Key with the right permissions which can be generated at **pagerduty.com/api_keys**.
+Next, create a PagerDuty API Access Key at **pagerduty.com/api_keys**. Ensure the 'Read-only API Key' box is left unchecked.
+
+To finish creating your PagerDuty notifier, navigate to the Notifiers page in Axiom and click the New notifier button. Select PagetDuty and enter the Integration Key and API Access Key in the correponding fields.
 
 ### Custom webhook
 

--- a/monitor-data/monitors.mdx
+++ b/monitor-data/monitors.mdx
@@ -116,11 +116,12 @@ For more information on creating an incoming webhook in Slack, see the [Slack do
 
 Create a PagerDuty notifier to use all the incident management features of PagerDuty with Axiom.
 
-First, configure a new “Service” in PagerDuty using the Events V2 API. To do this, go to **Configuration** > **Services** > **Add New Service** and create a new Service named ‘Axiom’ with all the default settings. Take note of the Integration Key provided. 
-
-Next, create a PagerDuty API Access Key at **pagerduty.com/api_keys**. Ensure the 'Read-only API Key' box is left unchecked.
-
-To finish creating your PagerDuty notifier, navigate to the Notifiers page in Axiom and click the New notifier button. Select PagetDuty and enter the Integration Key and API Access Key in the correponding fields.
+1. In PagerDuty’s Events V2 API, create a new service named **Axiom** with the default settings. Copy the integration key. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/services-and-integrations#create-a-service)
+1. In PagerDuty, create a general-access REST API key with the default settings. For more information, see the [PagerDuty documentation](https://support.pagerduty.com/main/docs/api-access-keys#generate-a-general-access-rest-api-key).
+1. In Axiom, go to the Monitors tab.
+1. Click **Manage notifiers**, and then click **New notifier**.
+1. Click **PagerDuty**, and then enter the integration key and API key.
+1. Click **Create**.
 
 ### Custom webhook
 


### PR DESCRIPTION
The PagerDuty notifier has been updated to no longer require an API token. This PR ensures the docs reflect this change. 