### PR TITLE
Add docs to cover vector axiom sink changes and migration

### DIFF
--- a/send-data/vector.mdx
+++ b/send-data/vector.mdx
@@ -18,7 +18,7 @@ Follow the [quickstart guide in the Vector documentation](https://vector.dev/doc
 
 ## timestamp field
 
-Before Vector version v0.42.0 the Axiom sink was based on an Elasticsearch endpoint. This constrained us to Elasticsearch wire
+Before Vector version v0.42.0 the Axiom sink was based on an Elasticsearch endpoint, which constrained it to Elasticsearch wire
 semantics. If you are using Vector version v0.41.1 or earlier, then the following semantics are applicable:
 
 > Logs and metrics sent via Vector should use `@timestamp` as the timestamp field like: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`, not `_time`. Axiom accepts many date strings and timestamps without knowing the format in advance, including Unix Epoch, RFC3339, and ISO 8601.
@@ -74,6 +74,7 @@ type = "remap"
 inputs = ["VECTOR_SOURCE_ID"]
 source = '''
   . = del(.FIELD_TO_REMOVE)
+'''
 
 [sinks.SINK_ID]
 type = "axiom"
@@ -163,7 +164,6 @@ To send AWS S3 logs using the Axiom sink, create a configuration file, for examp
 type = "aws_s3"
 bucket = "my-bucket"  # replace with your bucket name
 region = "us-west-2"  # replace with the AWS region of your bucket
-
 
 [sinks.axiom]
 type = "axiom"
@@ -277,11 +277,10 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Check out the [advanced configuration on Batch, Buffer configuration, and Encoding on Vector Documentation](https://vector.dev/docs/reference/configuration/sinks/axiom/)
 
-## Migrate from pre v0.42.0 Vector new newer Vector version
+## Migrate from legacy ( v0.41.1 and earlier ) Vector to a more recent version
 
-As timestamp field handling changes, we need to address any pinning of
-the timestamp field in our user defined vector remap logic so that we
-now use the `_time` field:
+As timestamp field handling changed, it may be necessary
+to change any references to remap logic to use the `_time` field instead, and remove the now redundant `timestamp` field:
 
 ```vrl
 # file: example.vrl
@@ -313,7 +312,7 @@ token = "your-token" # no change
 codec = "json"
 ```
 
-## Use zstd compression with Vector and Axiom
+## Use `zstd` compression with Vector and Axiom
 
 The changes to the Vector Axiom Sink enable the `zstd` compression
 algorithm by default, however an explicit algorithm can be set if

--- a/send-data/vector.mdx
+++ b/send-data/vector.mdx
@@ -18,7 +18,16 @@ Follow the [quickstart guide in the Vector documentation](https://vector.dev/doc
 
 ## timestamp field
 
-Logs and metrics sent via vector should use `@timestamp` as the timestamp field like: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`, not `_time`. Axiom accepts many date strings and timestamps without knowing the format in advance, including Unix Epoch, RFC3339, and ISO 8601.
+Before Vector version v0.43.0 the Axiom sink was based on an Elasticsearch endpoint. This constrained us to Elasticsearch wire
+semantics. If you are using Vector version v0.42.0 or earlier, then the following semantics are applicable:
+
+> Logs and metrics sent via Vector should use `@timestamp` as the timestamp field like: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`, not `_time`. Axiom accepts many date strings and timestamps without knowing the format in advance, including Unix Epoch, RFC3339, and ISO 8601.
+
+As and from Vector version v0.43.0 the Vector Axiom sink is based integrated against the native Axiom ingest endpoint.
+
+> This means the Vector Axiom sink is no longer constrained by Elasticsearch semantics, and the `_time` field can be used with its usual behaviour.
+
+See below for migration example.
 
 ## Configuration
 
@@ -267,3 +276,64 @@ token = "your_api_token"  # replace with your Axiom API token
 ```
 
 Check out the [advanced configuration on Batch, Buffer configuration, and Encoding on Vector Documentation](https://vector.dev/docs/reference/configuration/sinks/axiom/)
+
+## Migrate from pre v0.43.0 Vector new newer Vector version
+
+As timestamp field handling changes, we need to address any pinning of
+the timestamp field in our user defined vector remap logic so that we
+now use the `_time` field:
+
+```vrl
+# file: example.vrl
+
+# We set _time to an explicit, rather than allow axiom to default to `now`
+. = set!(value: ., path: ["_time"],  data: .timestamp)
+
+# We remove the original value, as it is effectively a duplicate
+del(.timestamp)
+```
+
+And a sample vector configuration file:
+
+```toml
+# ... rest of your config file
+
+[transforms.migrate]
+type = "remap"
+inputs = [ "k8s"]
+file= 'example.vrl' # as above
+
+[sinks.debug]
+type = "axiom"
+inputs = [ "migrate" ]
+dataset = "my-axiom-dataset" # no change
+token = "your-token" # no change
+
+[sinks.debug.encoding]
+codec = "json"
+```
+
+## Use zstd compression with Vector and Axiom
+
+The changes to the Vector Axiom Sink enable the `zstd` compression
+algorithm by default, however an explicit algorithm can be set if
+appropriate for your use case:
+
+```toml
+# ... rest of your config file
+
+[transforms.migrate]
+type = "remap"
+inputs = [ "k8s"]
+file= 'example.vrl' # as above
+
+[sinks.debug]
+type = "axiom"
+compression = "gzip" # Typically does not compress as well as zstd!
+inputs = [ "migrate" ]
+dataset = "my-axiom-dataset" # no change
+token = "your-token" # no change
+
+[sinks.debug.encoding]
+codec = "json"
+```

--- a/send-data/vector.mdx
+++ b/send-data/vector.mdx
@@ -18,12 +18,12 @@ Follow the [quickstart guide in the Vector documentation](https://vector.dev/doc
 
 ## timestamp field
 
-Before Vector version v0.43.0 the Axiom sink was based on an Elasticsearch endpoint. This constrained us to Elasticsearch wire
-semantics. If you are using Vector version v0.42.0 or earlier, then the following semantics are applicable:
+Before Vector version v0.42.0 the Axiom sink was based on an Elasticsearch endpoint. This constrained us to Elasticsearch wire
+semantics. If you are using Vector version v0.41.1 or earlier, then the following semantics are applicable:
 
 > Logs and metrics sent via Vector should use `@timestamp` as the timestamp field like: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`, not `_time`. Axiom accepts many date strings and timestamps without knowing the format in advance, including Unix Epoch, RFC3339, and ISO 8601.
 
-As and from Vector version v0.43.0 the Vector Axiom sink is based integrated against the native Axiom ingest endpoint.
+As and from Vector version v0.42.0 the Vector Axiom sink is based integrated against the native Axiom ingest endpoint.
 
 > This means the Vector Axiom sink is no longer constrained by Elasticsearch semantics, and the `_time` field can be used with its usual behaviour.
 
@@ -88,7 +88,7 @@ Replace `FIELD_TO_REMOVE` with the field you want to remove.
 Any changes to Vector’s `file` method can make the code example above outdated. If this happens, please refer to the [official Vector documentation on the `file` method](https://vector.dev/docs/reference/configuration/sources/file/), and we kindly ask you to inform us of the issue using the feedback tool at the bottom of this page.
 </Note>
 
-## Send Kubernetes logs to Axiom 
+## Send Kubernetes logs to Axiom
 
 Send Kubernetes logs to Axiom using the Kubernetes source.
 
@@ -126,7 +126,7 @@ TOKEN is used to ingest or query data to your dataset. API token can be generate
 
 [See creating an API token for more](/reference/tokens)
 
-## Send Docker logs to Axiom 
+## Send Docker logs to Axiom
 
 To send Docker logs using the Axiom sink, you need to create a configuration file, for example, `vector.toml`, with the following content:
 
@@ -154,7 +154,7 @@ vector --config /path/to/vector.toml
 
 Vector collects logs from Docker and forward them to Axiom using the Axiom sink. You can view and analyze your logs in your dataset.
 
-## Send AWS S3 logs to Axiom 
+## Send AWS S3 logs to Axiom
 
 To send AWS S3 logs using the Axiom sink, create a configuration file, for example, `vector.toml`, with the following content:
 
@@ -164,7 +164,7 @@ type = "aws_s3"
 bucket = "my-bucket"  # replace with your bucket name
 region = "us-west-2"  # replace with the AWS region of your bucket
 
-  
+
 [sinks.axiom]
 type = "axiom"
 inputs = ["my_s3_source"]
@@ -174,7 +174,7 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Finally, run Vector with the configuration file using `vector --config ./vector.toml`. This starts Vector and begins reading logs from the specified S3 bucket and sending them to the specified Axiom dataset.
 
-## Send Kafka logs to Axiom 
+## Send Kafka logs to Axiom
 
 To send Kafka logs using the Axiom sink, you need to create a configuration file, for example, `vector.toml`, with the following code:
 
@@ -195,7 +195,7 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Finally, you can start Vector with your configuration file: `vector --config /path/to/your/vector.toml`
 
-## Send NGINX metrics to Axiom 
+## Send NGINX metrics to Axiom
 
 To send NGINX metrics using Vector to the Axiom sink, first enable NGINX to emit metrics, then use Vector to capture and forward those metrics. Here is a step-by-step guide:
 
@@ -239,7 +239,7 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Finally, you can start Vector with your configuration file: `vector --config /path/to/your/vector.toml`
 
-## Send Syslog logs to Axiom 
+## Send Syslog logs to Axiom
 
 To send Syslog logs using the Axiom sink, you need to create a configuration file, for example, `vector.toml`, with the following code:
 
@@ -253,11 +253,11 @@ mode="tcp"
 [sinks.axiom]
 type="axiom"
 inputs = [ "my_source_id" ] # required
-dataset="your_dataset_name" # replace with the name of your Axiom dataset 
+dataset="your_dataset_name" # replace with the name of your Axiom dataset
 token="your_api_token" # replace with your Axiom API token
 ```
 
-## Send Prometheus metrics to Axiom 
+## Send Prometheus metrics to Axiom
 
 To send Prometheus scrape metrics using the Axiom sink, you need to create a configuration file, for example, `vector.toml`, with the following code:
 
@@ -277,7 +277,7 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Check out the [advanced configuration on Batch, Buffer configuration, and Encoding on Vector Documentation](https://vector.dev/docs/reference/configuration/sinks/axiom/)
 
-## Migrate from pre v0.43.0 Vector new newer Vector version
+## Migrate from pre v0.42.0 Vector new newer Vector version
 
 As timestamp field handling changes, we need to address any pinning of
 the timestamp field in our user defined vector remap logic so that we

--- a/send-data/vector.mdx
+++ b/send-data/vector.mdx
@@ -16,18 +16,11 @@ Vector is a lightweight and ultra-fast tool for building observability pipelines
 
 Follow the [quickstart guide in the Vector documentation](https://vector.dev/docs/setup/quickstart/) to install Vector, and to configure sources and sinks.
 
-## timestamp field
+<Warning>
+If you use Vector version v0.41.1 or earlier, use the `@timestamp` field instead of `_time` to specify the timestamp of the events. For more information, see [Timestamp in legacy Vector versions](#timestamp-in-legacy-vector-versions).
 
-Before Vector version v0.42.0 the Axiom sink was based on an Elasticsearch endpoint, which constrained it to Elasticsearch wire
-semantics. If you are using Vector version v0.41.1 or earlier, then the following semantics are applicable:
-
-> Logs and metrics sent via Vector should use `@timestamp` as the timestamp field like: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`, not `_time`. Axiom accepts many date strings and timestamps without knowing the format in advance, including Unix Epoch, RFC3339, and ISO 8601.
-
-As and from Vector version v0.42.0 the Vector Axiom sink is based integrated against the native Axiom ingest endpoint.
-
-> This means the Vector Axiom sink is no longer constrained by Elasticsearch semantics, and the `_time` field can be used with its usual behaviour.
-
-See below for migration example.
+If you upgrade from Vector version v0.41.1 or earlier to a newer version, update your configuration. For more information, see [Upgrade from legacy Vector version](#upgrade-from-legacy-vector-version).
+</Warning>
 
 ## Configuration
 
@@ -277,61 +270,66 @@ token = "your_api_token"  # replace with your Axiom API token
 
 Check out the [advanced configuration on Batch, Buffer configuration, and Encoding on Vector Documentation](https://vector.dev/docs/reference/configuration/sinks/axiom/)
 
-## Migrate from legacy ( v0.41.1 and earlier ) Vector to a more recent version
+## Timestamp in legacy Vector versions
 
-As timestamp field handling changed, it may be necessary
-to change any references to remap logic to use the `_time` field instead, and remove the now redundant `timestamp` field:
+If you use Vector version v0.41.1 or earlier, use the `@timestamp` field instead of `_time` to specify the timestamp in the event data you send to Axiom. For example: `{"@timestamp":"2022-04-14T21:30:30.658Z..."}`. For more information, see [Requirements of the timestamp field](/reference/field-restrictions#requirements-of-the-timestamp-field). In the case of Vector version v0.41.1 or earlier, the requirements explained on the page apply to the `@timestamp` field, not to `_time`.
 
-```vrl
-# file: example.vrl
+If you use Vector version v0.42.0 or newer, use the `_time` field as usual for other collectors.
 
-# We set _time to an explicit, rather than allow axiom to default to `now`
+### Upgrade from legacy Vector version
+
+If you upgrade from Vector version v0.41.1 or earlier to a newer version, change all references from the `timestamp` field to the `_time` field and remap the logic.
+
+Example `vrl` file:
+
+```vrl example.vrl
+# Set time explicitly rather than allowing Axiom to default to the current time
 . = set!(value: ., path: ["_time"],  data: .timestamp)
 
-# We remove the original value, as it is effectively a duplicate
+# Remove the original value as it is effectively a duplicate
 del(.timestamp)
 ```
 
-And a sample vector configuration file:
+Example Vector configuration file:
 
 ```toml
-# ... rest of your config file
+# ...
 
 [transforms.migrate]
 type = "remap"
 inputs = [ "k8s"]
-file= 'example.vrl' # as above
+file= 'example.vrl' # See above
 
 [sinks.debug]
 type = "axiom"
 inputs = [ "migrate" ]
-dataset = "my-axiom-dataset" # no change
-token = "your-token" # no change
+dataset = "my-axiom-dataset" # No change
+token = "your-token" # No change
 
 [sinks.debug.encoding]
 codec = "json"
 ```
 
-## Use `zstd` compression with Vector and Axiom
+### Set compression algorithm
 
-The changes to the Vector Axiom Sink enable the `zstd` compression
-algorithm by default, however an explicit algorithm can be set if
-appropriate for your use case:
+Upgrading to Vector version v0.42.0 or newer automatically enables the `zstd` compression algorithm by default.
+
+To set another compression algorithm, use the example below:
 
 ```toml
-# ... rest of your config file
+# ...
 
 [transforms.migrate]
 type = "remap"
 inputs = [ "k8s"]
-file= 'example.vrl' # as above
+file= 'example.vrl' # See above
 
 [sinks.debug]
 type = "axiom"
-compression = "gzip" # Typically does not compress as well as zstd!
+compression = "gzip" # Set the compression algorithm
 inputs = [ "migrate" ]
-dataset = "my-axiom-dataset" # no change
-token = "your-token" # no change
+dataset = "my-axiom-dataset" # No change
+token = "your-token" # No change
 
 [sinks.debug.encoding]
 codec = "json"


### PR DESCRIPTION
Changes the vector docs to align with changes scheduled for the next vector release, fixing #88
Should not be merged until the next vector release is scheduled!

Signed-off-by: Darach Ennis <darach@gmail.com>