### PR TITLE
Add tip about order of virtual fields in query-data/virtual-fields.mdx

### DIFF
--- a/query-data/virtual-fields.mdx
+++ b/query-data/virtual-fields.mdx
@@ -61,7 +61,9 @@ The list of APL scalar functions:
 - [Conditional functions](/apl/scalar-functions/conditional-function)
 - [IP functions](/apl/scalar-functions/ip-functions)
 
-<CallOut kind="tip">Virtual fields may reference other virtual fields, but the order of the fields is important. Ensure that the referenced field is specified *before* the field that references it. </CallOut>
+<Tip>
+Virtual fields may reference other virtual fields. The order of the fields is important. Ensure that the referenced field is specified before the field that references it.
+</Tip>
 
 {/*
 ### Literals

--- a/query-data/virtual-fields.mdx
+++ b/query-data/virtual-fields.mdx
@@ -61,6 +61,8 @@ The list of APL scalar functions:
 - [Conditional functions](/apl/scalar-functions/conditional-function)
 - [IP functions](/apl/scalar-functions/ip-functions)
 
+<CallOut kind="tip">Virtual fields may reference other virtual fields, but the order of the fields is important. Ensure that the referenced field is specified *before* the field that references it. </CallOut>
+
 {/*
 ### Literals
 


### PR DESCRIPTION
vfield order is important if one references the other 

I've no idea about .mdx stuff so lmk if the <callout> is wrong or whatever :)  