### PR TITLE
Update map fields and regions

### DIFF
--- a/apl/data-types/map-fields.mdx
+++ b/apl/data-types/map-fields.mdx
@@ -6,6 +6,12 @@ tags: ['axiom documentation', 'documentation', 'axiom', 'map fields', 'object fi
 
 Map fields are a special type of field that can hold a collection of nested key-value pairs within a single field. You can think of the content of a map field as a JSON object.
 
+<Note>
+Currently, Axiom automatically creates map fields in datasets that use [OpenTelemetry](/send-data/opentelemetry). You cannot create map fields yourself.
+
+Support for creating your own map fields is coming in early 2025. To express interest in the feature, [contact Axiom](https://axiom.co/contact).
+</Note>
+
 ## Benefits and drawbacks of map fields
 
 The benefit of map fields is that you can store additional attributes without adding more fields. This is particularly useful when the shape of your data is unpredictable (for example, additional attributes added by OpenTelemetry instrumentation). Using map fields means that you can avoid reaching the field limit of a dataset.
@@ -42,7 +48,3 @@ If an entity name has spaces (` `), dots (`.`), or dashes (`-`), you can only us
 - `where ['map.field'].property1.property2 == 14`
 
 For more information, see [Entity names](/apl/entities/entity-names#quote-identifiers).
-
-## Add custom fields
-
-The possibility to add custom fields is coming in early 2025. To express interest in the feature, [contact Axiom](https://axiom.co/contact).

--- a/restapi/introduction.mdx
+++ b/restapi/introduction.mdx
@@ -92,8 +92,8 @@ Below is a list of the types of data used within the Axiom API:
 | **Map**     | A data structure with a list of values assigned to a unique key.  | \{ "key": "value" \}   |
 | **List**    | A data structure with only a list of values separated by a comma. | ["value", 4567, 45.67] |
 
-## EU region
+## Regions
 
-All examples in the Axiom API reference use the default US base domain `https://api.axiom.co`. For example, if your organization uses the US region, send data to Axiom with the URL `https://api.axiom.co/v1/datasets/DATASET_NAME/ingest`.
+All examples in the Axiom API reference use the base domain `https://api.axiom.co`, which is the default for the US region. If your organization uses the EU region, change the base domain in the examples to `https://api.eu.axiom.co`.
 
-If your organization uses the EU region, change the base domain in the examples to `https://api.eu.axiom.co`. For example, if your organization uses the EU region, send data to Axiom with the URL `https://api.eu.axiom.co/v1/datasets/DATASET_NAME/ingest`.
+For more information on regions, see [Regions](/reference/regions).


### PR DESCRIPTION
This PR resolves the following issues:
- [Map fields](https://axiom.co/docs/apl/data-types/map-fields)
  - Make clear that customers can’t create map fields themselves.
  - Remove custom map fields section, add note component after first section.
- [Regions](https://axiom.co/docs/reference/regions)
    - EU region is still in intro page of API docs.
    - Change heading of section, make text shorter, link to general Regions page.