### PR TITLE
Align font with marketing site

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -530,6 +530,16 @@
     "suggestEdit": true,
     "raiseIssue": true
   },
+  "font": {
+    "headings": {
+      "family": "BerkeleyMono",
+      "url": "https://axiom.co/fonts/BerkeleyMono-Regular.woff2",
+      "format": "woff2"
+    },
+    "body": {
+      "family": "Inter"
+    }
+  },
   "redirects": [
     {
       "source": "/index",


### PR DESCRIPTION
Mintlify now supports specifying global fonts: https://mintlify.com/docs/settings/global#styling

This PR aligns the fonts between the docs and marketing sites.

Preview: https://axiom-mano-align-font.mintlify.app/introduction