### PR TITLE
docs: limit next-axiom token permissions to ingest only

### DIFF
--- a/send-data/nextjs.mdx
+++ b/send-data/nextjs.mdx
@@ -37,7 +37,7 @@ The rest of this page explains how to send data from your Next.js app to Axiom u
 
 - [Create an Axiom account](https://app.axiom.co/).
 - [Create a dataset in Axiom](/reference/datasets) where you send your data.
-- [Create an API token in Axiom](/reference/tokens) with permissions to ingest to the created dataset.
+- [Create an API token in Axiom](/reference/tokens) with permissions to ingest data to the dataset.
 - [A new or existing Next.js app](https://nextjs.org/).
 
 ## Install next-axiom

--- a/send-data/nextjs.mdx
+++ b/send-data/nextjs.mdx
@@ -37,7 +37,7 @@ The rest of this page explains how to send data from your Next.js app to Axiom u
 
 - [Create an Axiom account](https://app.axiom.co/).
 - [Create a dataset in Axiom](/reference/datasets) where you send your data.
-- [Create an API token in Axiom](/reference/tokens) with permissions to create, read, update, and delete datasets.
+- [Create an API token in Axiom](/reference/tokens) with permissions to ingest to the created dataset.
 - [A new or existing Next.js app](https://nextjs.org/).
 
 ## Install next-axiom


### PR DESCRIPTION
Previously the docs mentioned that the token should have Create, Update and delete permissions for the datasets, but in reality it just needs ingest permissions.