### PR TITLE
Add reference to extract() and extract_all() in parse docs, small fixes

### DIFF
--- a/apl/scalar-functions/string-functions.mdx
+++ b/apl/scalar-functions/string-functions.mdx
@@ -201,7 +201,7 @@ The value of the first argument whose value isn’t null (or not-empty for strin
 
 ## extract()
 
-Convert the extracted substring to the indicated type.
+Retrieve the first substring matching a regular expression from a source string.
 
 ### Arguments
 
@@ -238,7 +238,7 @@ extract("x=([0-9.]+)", 1, "axiom x=65.6|po") == "65.6"
 
 ## extract_all()
 
-retrieve a subset of matching groups.
+Retrieve all substrings matching a regular expression from a source string. Optionally, retrieve only a subset of the matching groups.
 
 ### Arguments
 

--- a/apl/tabular-operators/count-operator.mdx
+++ b/apl/tabular-operators/count-operator.mdx
@@ -135,8 +135,8 @@ This query returns the number of HTTP requests that resulted in an error (HTTP s
 
 ## List of related operators
 
-- [**summarize**](/apl/tabular-operators/summarize-operator): The `summarize` operator is used to aggregate data based on one or more fields, allowing you to calculate sums, averages, and other statistics, including counts. Use `summarize` when you need to group data before counting.
-- [**extend**](/apl/tabular-operators/extend-operator): The `extend` operator adds calculated fields to a dataset. You can use `extend` alongside `count` if you want to add additional calculated data to your query results.
-- [**project**](/apl/tabular-operators/project-operator): The `project` operator selects specific fields from a dataset. While `count` returns the total number of records, `project` can limit or change which fields you see.
-- [**where**](/apl/tabular-operators/where-operator): The `where` operator filters rows based on a condition. Use `where` with `count` to only count records that meet certain criteria.
-- [**take**](/apl/tabular-operators/take-operator): The `take` operator returns a specified number of records. You can use `take` to limit results before applying `count` if you're interested in counting a sample of records.
+- [summarize](/apl/tabular-operators/summarize-operator): The `summarize` operator is used to aggregate data based on one or more fields, allowing you to calculate sums, averages, and other statistics, including counts. Use `summarize` when you need to group data before counting.
+- [extend](/apl/tabular-operators/extend-operator): The `extend` operator adds calculated fields to a dataset. You can use `extend` alongside `count` if you want to add additional calculated data to your query results.
+- [project](/apl/tabular-operators/project-operator): The `project` operator selects specific fields from a dataset. While `count` returns the total number of records, `project` can limit or change which fields you see.
+- [where](/apl/tabular-operators/where-operator): The `where` operator filters rows based on a condition. Use `where` with `count` to only count records that meet certain criteria.
+- [take](/apl/tabular-operators/take-operator): The `take` operator returns a specified number of records. You can use `take` to limit results before applying `count` if you're interested in counting a sample of records.

--- a/apl/tabular-operators/distinct-operator.mdx
+++ b/apl/tabular-operators/distinct-operator.mdx
@@ -140,6 +140,6 @@ This query provides a distinct list of HTTP status codes that occurred in the lo
 
 ## List of related operators
 
-- [**count**](/apl/tabular-operators/count-operator): Returns the total number of rows. Use it to count occurrences of data rather than filtering for distinct values.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Allows you to aggregate data and perform calculations like sums or averages while grouping by distinct values.
-- [**project**](/apl/tabular-operators/project-operator): Selects specific fields from the dataset. Use it when you want to control which fields are returned before applying `distinct`.
+- [count](/apl/tabular-operators/count-operator): Returns the total number of rows. Use it to count occurrences of data rather than filtering for distinct values.
+- [summarize](/apl/tabular-operators/summarize-operator): Allows you to aggregate data and perform calculations like sums or averages while grouping by distinct values.
+- [project](/apl/tabular-operators/project-operator): Selects specific fields from the dataset. Use it when you want to control which fields are returned before applying `distinct`.

--- a/apl/tabular-operators/extend-operator.mdx
+++ b/apl/tabular-operators/extend-operator.mdx
@@ -137,5 +137,5 @@ This query creates a new field `status_category` that labels each HTTP request a
 
 ## List of related operators
 
-- [**project**](/apl/tabular-operators/project-operator): Use `project` to select specific fields or rename them. Unlike `extend`, it does not add new fields.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` to aggregate data, which differs from `extend` that only adds new calculated fields without aggregation.
+- [project](/apl/tabular-operators/project-operator): Use `project` to select specific fields or rename them. Unlike `extend`, it does not add new fields.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` to aggregate data, which differs from `extend` that only adds new calculated fields without aggregation.

--- a/apl/tabular-operators/extend-valid-operator.mdx
+++ b/apl/tabular-operators/extend-valid-operator.mdx
@@ -150,6 +150,6 @@ In this query, the `extract` function retrieves the first letter of the city nam
 
 ## List of related operators
 
-- [**extend**](/apl/tabular-operators/extend-operator): Use `extend` to add calculated fields unconditionally, without validating data.
-- [**project**](/apl/tabular-operators/project-operator): Use `project` to select and rename fields, without performing conditional extensions.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` for aggregation, often used before extending fields with further calculations.
+- [extend](/apl/tabular-operators/extend-operator): Use `extend` to add calculated fields unconditionally, without validating data.
+- [project](/apl/tabular-operators/project-operator): Use `project` to select and rename fields, without performing conditional extensions.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` for aggregation, often used before extending fields with further calculations.

--- a/apl/tabular-operators/limit-operator.mdx
+++ b/apl/tabular-operators/limit-operator.mdx
@@ -139,6 +139,6 @@ This query limits the output to 5 unauthorized access attempts (`401` status cod
 
 ## List of related operators
 
-- [**take**](/apl/tabular-operators/take-operator): Similar to `limit`, but explicitly focuses on row sampling.
-- [**top**](/apl/tabular-operators/top-operator): Retrieves the top **N** rows sorted by a specific field.
-- [**sample**](/apl/tabular-operators/sample-operator): Randomly samples **N** rows from the dataset.
+- [take](/apl/tabular-operators/take-operator): Similar to `limit`, but explicitly focuses on row sampling.
+- [top](/apl/tabular-operators/top-operator): Retrieves the top **N** rows sorted by a specific field.
+- [sample](/apl/tabular-operators/sample-operator): Randomly samples **N** rows from the dataset.

--- a/apl/tabular-operators/order-operator.mdx
+++ b/apl/tabular-operators/order-operator.mdx
@@ -141,6 +141,6 @@ This query sorts the security logs by time to display the most recent log entrie
 
 ## List of related operators
 
-- [**top**](/apl/tabular-operators/top-operator): The `top` operator returns the top N records based on a specific sorting criteria, which is similar to `order` but only retrieves a fixed number of results.
-- [**summarize**](/apl/tabular-operators/summarize-operator): The `summarize` operator groups data and often works in combination with `order` to rank summarized values.
-- [**extend**](/apl/tabular-operators/extend-operator): The `extend` operator can be used to create calculated fields, which can then be used as sorting criteria in the `order` operator.
+- [top](/apl/tabular-operators/top-operator): The `top` operator returns the top N records based on a specific sorting criteria, which is similar to `order` but only retrieves a fixed number of results.
+- [summarize](/apl/tabular-operators/summarize-operator): The `summarize` operator groups data and often works in combination with `order` to rank summarized values.
+- [extend](/apl/tabular-operators/extend-operator): The `extend` operator can be used to create calculated fields, which can then be used as sorting criteria in the `order` operator.

--- a/apl/tabular-operators/parse-operator.mdx
+++ b/apl/tabular-operators/parse-operator.mdx
@@ -372,5 +372,7 @@ By following these best practices and understanding the capabilities of the pars
 
 ## List of related operators
 
-- [**extend**](/apl/tabular-operators/extend-operator): Use the `extend` operator when you want to add calculated fields without parsing text.
-- [**project**](/apl/tabular-operators/project-operator): Use `project` to select and rename fields after parsing text.
+- [extend](/apl/tabular-operators/extend-operator): Use the `extend` operator when you want to add calculated fields without parsing text.
+- [project](/apl/tabular-operators/project-operator): Use `project` to select and rename fields after parsing text.
+- [extract](/apl/scalar-functions/string-functions#extract): Use `extract` to retrieve the first substring matching a regular expression from a source string.
+- [extract_all](/apl/scalar-functions/string-functions#extract-all): Use `extract_all` to retrieve all substrings matching a regular expression from a source string.

--- a/apl/tabular-operators/project-away-operator.mdx
+++ b/apl/tabular-operators/project-away-operator.mdx
@@ -161,6 +161,6 @@ Here’s how you can use wildcards in `project-away`:
 
 ## List of related operators
 
-- [**project**](/apl/tabular-operators/project-operator): The `project` operator lets you select specific fields to include, rather than excluding them.
-- [**extend**](/apl/tabular-operators/extend-operator): The `extend` operator is used to add new fields, whereas `project-away` is for removing fields.
-- [**summarize**](/apl/tabular-operators/summarize-operator): While `project-away` removes fields, `summarize` is useful for aggregating data across multiple fields.
+- [project](/apl/tabular-operators/project-operator): The `project` operator lets you select specific fields to include, rather than excluding them.
+- [extend](/apl/tabular-operators/extend-operator): The `extend` operator is used to add new fields, whereas `project-away` is for removing fields.
+- [summarize](/apl/tabular-operators/summarize-operator): While `project-away` removes fields, `summarize` is useful for aggregating data across multiple fields.

--- a/apl/tabular-operators/project-keep-operator.mdx
+++ b/apl/tabular-operators/project-keep-operator.mdx
@@ -139,9 +139,9 @@ This query narrows down the data to track HTTP status codes by users, helping id
 
 ## List of related operators
 
-- [**project**](/apl/tabular-operators/project-operator): Use `project` to explicitly specify the fields you want in your result, while also allowing transformations or calculations on those fields.
-- [**extend**](/apl/tabular-operators/extend-operator): Use `extend` to add new fields or modify existing ones without dropping any fields.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` when you need to perform aggregation operations on your dataset, grouping data as necessary.
+- [project](/apl/tabular-operators/project-operator): Use `project` to explicitly specify the fields you want in your result, while also allowing transformations or calculations on those fields.
+- [extend](/apl/tabular-operators/extend-operator): Use `extend` to add new fields or modify existing ones without dropping any fields.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` when you need to perform aggregation operations on your dataset, grouping data as necessary.
 
 ## Wildcard
 

--- a/apl/tabular-operators/project-operator.mdx
+++ b/apl/tabular-operators/project-operator.mdx
@@ -153,6 +153,6 @@ The query extracts only the timestamp, user ID, and HTTP status for analysis of 
 
 ## List of related operators
 
-- [**extend**](/apl/tabular-operators/extend-operator): Use `extend` to add new fields or calculate values without removing any existing fields.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` to aggregate data across groups of rows, which is useful when you’re calculating totals or averages.
-- [**where**](/apl/tabular-operators/where-operator): Use `where` to filter rows based on conditions, often paired with `project` to refine your dataset further.
+- [extend](/apl/tabular-operators/extend-operator): Use `extend` to add new fields or calculate values without removing any existing fields.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` to aggregate data across groups of rows, which is useful when you’re calculating totals or averages.
+- [where](/apl/tabular-operators/where-operator): Use `where` to filter rows based on conditions, often paired with `project` to refine your dataset further.

--- a/apl/tabular-operators/project-reorder-operator.mdx
+++ b/apl/tabular-operators/project-reorder-operator.mdx
@@ -182,7 +182,7 @@ Reorder specific fields and keep others in original order:
 
 ## List of related operators
 
-- [**project**](/apl/tabular-operators/project-operator): Use the `project` operator to select and rename fields without changing their order.
-- [**extend**](/apl/tabular-operators/extend-operator): `extend` adds new calculated fields while keeping the original ones in place.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` to perform aggregations on fields, which can then be reordered using `project-reorder`.
-- [**sort**](/apl/tabular-operators/sort-operator): Sorts rows based on field values, and the results can then be reordered with `project-reorder`.
+- [project](/apl/tabular-operators/project-operator): Use the `project` operator to select and rename fields without changing their order.
+- [extend](/apl/tabular-operators/extend-operator): `extend` adds new calculated fields while keeping the original ones in place.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` to perform aggregations on fields, which can then be reordered using `project-reorder`.
+- [sort](/apl/tabular-operators/sort-operator): Sorts rows based on field values, and the results can then be reordered with `project-reorder`.

--- a/apl/tabular-operators/sample-operator.mdx
+++ b/apl/tabular-operators/sample-operator.mdx
@@ -141,6 +141,6 @@ This query helps you quickly spot failed requests (HTTP 500 responses) and inves
 
 ## List of related operators
 
-- [**take**](/apl/tabular-operators/take-operator): Use `take` when you want to return the first N rows in the dataset rather than a random subset.
-- [**where**](/apl/tabular-operators/where-operator): Use `where` to filter rows based on conditions rather than sampling randomly.
-- [**top**](/apl/tabular-operators/top-operator): Use `top` to return the highest N rows based on a sorting criterion.
+- [take](/apl/tabular-operators/take-operator): Use `take` when you want to return the first N rows in the dataset rather than a random subset.
+- [where](/apl/tabular-operators/where-operator): Use `where` to filter rows based on conditions rather than sampling randomly.
+- [top](/apl/tabular-operators/top-operator): Use `top` to return the highest N rows based on a sorting criterion.

--- a/apl/tabular-operators/sort-operator.mdx
+++ b/apl/tabular-operators/sort-operator.mdx
@@ -150,7 +150,7 @@ This query sorts security logs by status code first (in ascending order) and the
 
 ## List of related operators
 
-- [**top**](/apl/tabular-operators/top-operator): Use `top` to return a specified number of rows with the highest or lowest values, but unlike `sort`, `top` limits the result set.
-- [**project**](/apl/tabular-operators/project-operator): Use `project` to select and reorder fields without changing the order of rows.
-- [**extend**](/apl/tabular-operators/extend-operator): Use `extend` to create calculated fields that can then be used in conjunction with `sort` to refine your results.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Use `summarize` to group and aggregate data before applying `sort` for detailed analysis.
+- [top](/apl/tabular-operators/top-operator): Use `top` to return a specified number of rows with the highest or lowest values, but unlike `sort`, `top` limits the result set.
+- [project](/apl/tabular-operators/project-operator): Use `project` to select and reorder fields without changing the order of rows.
+- [extend](/apl/tabular-operators/extend-operator): Use `extend` to create calculated fields that can then be used in conjunction with `sort` to refine your results.
+- [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` to group and aggregate data before applying `sort` for detailed analysis.

--- a/apl/tabular-operators/summarize-operator.mdx
+++ b/apl/tabular-operators/summarize-operator.mdx
@@ -180,6 +180,6 @@ Returns a table that shows the heatmap in each interval [0, 30], [30, 20, 10], a
 
 ## List of related operators
 
-- [**count**](/apl/tabular-operators/count-operator): Use when you only need to count rows without grouping by specific fields.
-- [**extend**](/apl/tabular-operators/extend-operator): Use to add new calculated fields to a dataset.
-- [**project**](/apl/tabular-operators/project-operator): Use to select specific fields or create new calculated fields, often in combination with `summarize`.
+- [count](/apl/tabular-operators/count-operator): Use when you only need to count rows without grouping by specific fields.
+- [extend](/apl/tabular-operators/extend-operator): Use to add new calculated fields to a dataset.
+- [project](/apl/tabular-operators/project-operator): Use to select specific fields or create new calculated fields, often in combination with `summarize`.

--- a/apl/tabular-operators/take-operator.mdx
+++ b/apl/tabular-operators/take-operator.mdx
@@ -140,6 +140,6 @@ This query retrieves the first 10 security log entries, useful for quick investi
 
 ## List of related operators
 
-- [**limit**](/apl/tabular-operators/limit-operator): Similar to `take`, but explicitly limits the result set and often used for pagination or performance optimization.
-- [**sort**](/apl/tabular-operators/sort-operator): Used in combination with `take` when you want to fetch a subset of sorted data.
-- [**where**](/apl/tabular-operators/where-operator): Filters rows based on a condition before using `take` for sampling specific subsets.
+- [limit](/apl/tabular-operators/limit-operator): Similar to `take`, but explicitly limits the result set and often used for pagination or performance optimization.
+- [sort](/apl/tabular-operators/sort-operator): Used in combination with `take` when you want to fetch a subset of sorted data.
+- [where](/apl/tabular-operators/where-operator): Filters rows based on a condition before using `take` for sampling specific subsets.

--- a/apl/tabular-operators/top-operator.mdx
+++ b/apl/tabular-operators/top-operator.mdx
@@ -142,6 +142,6 @@ This query shows the top 3 most common HTTP status codes in security logs.
 
 ## List of related operators
 
-- [**order**](/apl/tabular-operators/order-operator): Use when you need full control over row ordering without limiting the number of results.
-- [**summarize**](/apl/tabular-operators/summarize-operator): Useful when aggregating data over fields and obtaining summarized results.
-- [**take**](/apl/tabular-operators/take-operator): Returns the first N rows without sorting. Use when ordering is not necessary.
+- [order](/apl/tabular-operators/order-operator): Use when you need full control over row ordering without limiting the number of results.
+- [summarize](/apl/tabular-operators/summarize-operator): Useful when aggregating data over fields and obtaining summarized results.
+- [take](/apl/tabular-operators/take-operator): Returns the first N rows without sorting. Use when ordering is not necessary.

--- a/apl/tabular-operators/where-operator.mdx
+++ b/apl/tabular-operators/where-operator.mdx
@@ -208,6 +208,6 @@ The `has` operator is case insensitive. Use `has` if you’re unsure about the c
 
 ## List of related operators
 
-- [**count**](/apl/tabular-operators/count-operator): Use `count` to return the number of records that match specific criteria.
-- [**distinct**](/apl/tabular-operators/distinct-operator): Use `distinct` to return unique values in a dataset, complementing filtering.
-- [**take**](/apl/tabular-operators/take-operator): Use `take` to return a specific number of records, typically in combination with `where` for pagination.
+- [count](/apl/tabular-operators/count-operator): Use `count` to return the number of records that match specific criteria.
+- [distinct](/apl/tabular-operators/distinct-operator): Use `distinct` to return unique values in a dataset, complementing filtering.
+- [take](/apl/tabular-operators/take-operator): Use `take` to return a specific number of records, typically in combination with `where` for pagination.


### PR DESCRIPTION
Preview: https://axiom-mano-axm-6393-add-reference-to-extract-and-extract_al.mintlify.app/apl/tabular-operators/parse-operator