### PR TITLE
Change OpenTelemetry traces example of redact operator

### DIFF
--- a/apl/tabular-operators/redact-operator.mdx
+++ b/apl/tabular-operators/redact-operator.mdx
@@ -94,25 +94,25 @@ The query replaces all characters matching the pattern `.*` with the character `
 </Tab>
 <Tab title="OpenTelemetry traces">
 
-In OpenTelemetry traces, use `redact` to anonymize trace IDs with their hashes while preserving the service structure.
+In OpenTelemetry traces, use `redact` to anonymize Kubernetes node names with their hashes while preserving the service structure.
 
 **Query**
 
 ```kusto
 ['otel-demo-traces']
-| redact replaceHash=true @'.*' on trace_id
+| redact replaceHash=true @'.*' on ['resource.k8s.node.name']
 ```
 
-[Run in Playground](https://play.axiom.co/axiom-play-qf1k/query?initForm=%7B%22apl%22%3A%22%5B'otel-demo-traces'%5D%20%7C%20redact%20replaceHash%3Dtrue%20%40'.*'%20on%20trace_id%22%7D)
+[Run in Playground](https://play.axiom.co/axiom-play-qf1k/query?initForm=%7B%22apl%22%3A%22%5B'otel-demo-traces'%5D%20%7C%20redact%20replaceHash%3Dtrue%20%40'.*'%20on%20%5B'resource.k8s.node.name'%5D%22%7D)
 
 **Output**
 
-| _time               | trace_id          | service.name       |
+| _time               | resource.k8s.node.name          | service.name       |
 |---------------------|-------------------|--------------------|
 | 2025-01-01 12:00:00 | `QQXRv6VU`   | `frontend`         |
 | 2025-01-01 12:05:00 | `Q1urOteW`   | `checkoutservice`  |
 
-The query replaces trace IDs with hashed values while keeping the rest of the trace intact.
+The query replaces Kubernetes node names with hashed values while keeping the rest of the trace intact.
 
 </Tab>
 <Tab title="Security logs">


### PR DESCRIPTION
This PR updates the OpenTelemetry traces example of the `redact` operator.

Previously, the example redacted the trace ID which didn't make sense since it didn't redact sensitive information.
This PR changes the example to redact Kubernetes node names. This is not the best example for redacting PII, but this is the closest we have in this dataset in the Playground.

Context: https://watchlyhq.slack.com/archives/C03HV6C998A/p1738146054154909?thread_ts=1738146009.726379&cid=C03HV6C998A