### PR TITLE
Add Learn about Axiom page instead of FAQs

### DIFF
--- a/get-help/faq.mdx
+++ b/get-help/faq.mdx
@@ -1,86 +1,109 @@
 ---
-title: 'Frequently asked questions'
-description: 'Learn more about Axiom.'
-sidebarTitle: 'FAQs'
-icon: question
+title: "Learn about Axiom"
+description: "This section explains the most important concepts that allow you to gain a deep understanding of Axiom."
+sidebarTitle: Overview
 tags:
-    ['axiom documentation', 'documentation', 'axiom', 'axiom', 'run axiom', 'retain data', 'faq', 'frwquently asked questions']
+    ['axiom documentation', 'documentation', 'axiom', 'run axiom', 'retain data', 'faq', 'frequently asked questions']
 ---
 
-This page aims to offer a deeper understanding of Axiom. If you can’t find an answer to your questions, please feel free to  [contact our team](https://axiom.co/contact).
+This page allows you to better understand Axiom and its offering.
 
-## What is Axiom?
+## About Axiom
+
+Axiom is logging re-invented for high-scale engineering teams:
+
+- **Cloud-native architecture** delivers higher performance at lower costs.
+- **Built-in distributed tracing** provides E2E visibility and faster problem resolution.
+- **Integrated data routing** ends vendor lock-in.
+- **Option to deploy Axiom in your cloud** for unlimited log management at a fixed price.
 
 Axiom is a log management and analytics solution that reduces the cost and management overhead of logging as much data as you want.
 
-With Axiom, organizations no longer need to choose between their data and their costs. Axiom has been built from the ground-up to allow for highly efficient data ingestion and storage, and then a zero-to-infinite query scaling that allows you to query all your data, all the time.
+## Axiom’s unique approach
 
-Organizations use Axiom for continuous monitoring and observability, as well as an event store for running analytics and deriving insights from all their event data.
+Axiom’s mission is to operationalize every bit of event data in your organization. Axiom frees you from having to ignore or delete data due to cost considerations, whatever its source.
 
-Axiom consists of a datastore and a user-experience that work in tandem to provide a completely unique log-management and analytics experience.
+With Axiom, you no longer need to choose between data and costs. Axiom has been built from the ground up to allow for highly efficient data ingestion and storage. A zero-to-infinite query scaling that allows you to query all your data, all the time.
 
-## Can I run Axiom in my own cloud/infrastructure?
+Many organizations use Axiom for continuous monitoring and observability, as well as an event store for running analytics and deriving insights from all their event data.
 
-Axiom enables you to store data in your own storage with the Bring Your Own Bucket (BYOB) feature. You provide your own S3-compatible object storage, and the Axiom control plane handles ingest, query execution, and all other background tasks. This is not an on-premises solution, but it enables you to maintain control over your data at rest.
+### Differences from other logging solutions
 
-Using Axiom as a cloud SaaS product without the BYOB option is safe, affordable, and the best choice for most use cases. Billed month-to-month on our [Team plan](https://axiom.co/pricing) for ingest workloads up to 50TB/mo, and with no upper limit on our annual [Enterprise plan](https://axiom.co/pricing), Axiom supports tens of thousands of organizations today. However, if you are a large enterprise customer and your organization requires data sovereignty for compliance reasons or secondary workloads, using Axiom with the BYOB premium option is the answer.
+The limitations of other logging solutions are the following:
 
-Axiom BYOB is available exclusively on our annual [Enterprise plan](https://axiom.co/pricing).
+- Other logging solutions tend to place restrictions on how much data you can collect, either on purpose or as a side effect of their architectures.
+- There is a non-trivial cost in increasing your data ingest as clusters need to be scaled.
+- You need to make a choice between hot and cold data, and about what you archive. This means that your data is in two or three different places and your queries can be fast or slow depending on where the data is.
+- You need to carefully limit the data that you ingest and/or sample your data to keep costs under control.
 
-## How is Axiom different than other logging solutions?
+The following makes Axiom different:
 
-At Axiom, our goal is that no organization has to ignore or delete a single piece of data no matter its source: logs, events, frontend, backends, audits, etc.
+- Decoupled ingest and querying pipelines.
+- Stateless ingest pipeline that requires minimal compute/memory to storage.
+- Ingest all data into object storage, enabling the cheapest storage possible for all ingested data.
+- Query scale-out with cloud functions, requiring no constantly running servers waiting for a query to be processed. Instead, enjoy zero-to-infinity querying instantly.
 
-We found that existing solutions would place restrictions on how much data can be collected either on purpose or as a side-effect of their architectures.
+### Benefits of Axiom’s approach
 
-For example, state of the art in logging is running stateful clusters that need shared knowledge of ingestion and will use a mixture of local SSD-based storage and remote object storage.
+- The most efficient ingestion pipeline for massive amounts of data.
+- Store more data for less by exclusively using inexpensive object storage for all data.
+- Query all data at any time, irrespective of its age.
+- Reduce the total cost of ownership of your log management and analytics pipelines with simple scale and maintenance.
+- Free your organization to do more with its event data.
 
-### Side-effects of legacy vendors
+## Start using Axiom
 
-1. There is a non-trivial cost in increasing your data ingest as clusters need to be scaled and more SSD storage and IOPs need to be provided
+There are different ways you can start using Axiom.
 
-2. The choice needs to be made between hot and cold data, and also what is archived. Now your data is in 2-3 different places and queries can be fast or slow depending on where the data is
+### Try Axiom without registration
 
-The end result is needing to carefully consider all data that is ingested, and putting limits and/or sampling to control the DevOps and cost burden.
+To get started with Axiom straight away, go to the interactive [Axiom Playground](https://play.axiom.co/) and check out the [Get started guide](/getting-started-guide/getting-started).
 
-### The ways Axiom is different
+### Try Axiom for free
 
-1. Decoupled ingest and querying pipelines
+Axiom’s Personal plan is free forever with a generous allowance. It is available to all customers. All you need to do is [create an Axiom account](https://app.axiom.co/register).
 
-2. Stateless ingest pipeline that requires minimal compute/memory to storage as much as 1.5TB/day per vCPU
+### Choose pricing plan
 
-3. Ingests all data into object storage, enabling the cheapest storage possible for all ingested data
+Axiom offers transparent pricing with no hidden fees.
 
-4. Enables querying scale-out with cloud functions, requiring no constantly-running servers waiting for a query to be processed. Instead, enjoy zero-to-infinity querying instantly
+- **Personal plan:** Axiom’s free forever Personal plan is available to all customers.
+- **Team plan:** With unlimited users included starting at $25/month, Axiom’s Team plan is a great choice for growing companies and for Enterprise organizations who want to run a proof-of-concept. The Team plan is billed on a monthly basis.
+- **Enterprise plan:** Axiom’s Enterprise plan tailors the license details to your organization’s needs. The Enterprise plan is billed on an annual basis.
 
-### The benefits of Axiom’s approach
+For more information, see [Pricing](https://axiom.co/pricing).
 
-1. The most efficient ingestion pipeline for massive amounts of data
+## Choose deployment option
 
-2. Store more data for less by exclusively using inexpensive object storage for all data
+Axiom offers two deployment options:
 
-3. Query data that’s 10 milliseconds or 10 years old at any time
+- **Axiom Cloud:** Axiom manages compute and storage in its cloud. Axiom Cloud is available for all pricing plans.
+- **Bring Your Own Cloud (BYOC):** Compute and storage operate in your private cloud, while Axiom handles updates. BYOC is available as an additional feature for the Enterprise plan.
 
-4. Reduce the total cost of ownership of your log management and analytics pipelines with simple scale and maintenance that Axiom provides
+### Run Axiom in your own cloud
 
-5. Free your organization to do more with it’s data
+Axiom enables you to store data in your own storage with the Bring Your Own Cloud (BYOC) feature. You provide your own S3-compatible object storage, and the Axiom control plane handles ingest, query execution, and all other background tasks. This is not an on-premises solution, but it enables you to maintain control over your data at rest.
 
-## How long can I retain data for with Axiom?
+Using Axiom as a cloud SaaS product without the BYOC option is safe, affordable, and the best choice for most use cases. Billed month-to-month on our Team plan for ingest workloads up to 50TB/mo, and with no upper limit on our annual Enterprise plan, Axiom supports tens of thousands of organizations today. However, if you are a large enterprise customer and your organization requires data sovereignty for compliance reasons or secondary workloads, using Axiom with the BYOC premium option is the answer.
 
-Axiom’s free forever [Personal plan](https://axiom.co/pricing) provides a generous 30 days of retention.
+## Get your data into Axiom
 
-Axiom’s [Team plan](https://axiom.co/pricing) provides 95 days of retention, ensuring a complete picture of your data for over 3 months.
+Axiom accepts data from numerous sources without pre-processing. It stores events at full fidelity, making them queryable in their original format or with schemas applied at query time.
 
-Retention on Axiom’s [Enterprise plan](https://axiom.co/pricing) can be customised to your needs, with the option for unlimited retention so your organization has access to all its data, all the time.
+You can likely point your existing collectors to Axiom, such Vector, Cribl, OpenTelemetry, Fluent Bit, or Fluentd. For the complete list of supported data sources, see [Send data]((/send-data/ingest).
 
-## Can I try Axiom for free?
+## Query and route data
 
-Yes. Axiom’s [Personal plan](https://axiom.co/pricing) is free forever with a generous allowance, and is available to all customers.
+After sending your data to Axiom, you can query it using the Axiom Processing Language (APL), a proprietary query language optimized for timestamped event data. APL similar to Kusto or Splunk Search Processing Language (SPL), and more advanced than SQL. For more information, see [Introduction to APL](/apl/introduction).
 
-With unlimited users included, Axiom’s [Team plan](https://axiom.co/pricing) starting at $25/mo is a great choice for growing companies, and for Enterprise organizations who want to run a proof-of-concept.
+## Retain data
 
-## How is Axiom licensed?
+The data retention period determines how long Axiom stores your data. By default, the data retention period is defined by your pricing plan and is the same for all datasets:
 
-Axiom’s [Team plan](https://axiom.co/pricing) is billed on a monthly basis.
+- **Personal plan** provides a generous 30 days of retention.
+- **Team plan** provides 95 days of retention, ensuring a complete picture of your data for over 3 months.
+- **Enterprise plan** allows you to customize the data retention period to your needs, with the option for unlimited retention so your organization has access to all its data, all the time.
 
-Axiom’s [Enterprise plan](https://axiom.co/pricing) is billed on an annual basis, with license details tailored to your organization’s needs.
+You can [specify shorter retention periods](/reference/datasets#change-data-retention-period) for individual datasets.
+
+For more information, see [Pricing](https://axiom.co/pricing).

--- a/mint.json
+++ b/mint.json
@@ -78,12 +78,12 @@
           "group": "Learn about Axiom",
           "icon": "book-font",
           "pages": [
+            "get-help/faq",
             "getting-started-guide/event-data",
             "getting-started-guide/observability",
             "getting-started-guide/glossary"
           ]
-        },
-        "get-help/faq"
+        }
       ]
     },
     {


### PR DESCRIPTION
Replace the FAQ with Learn about Axiom overview page with better structure, new concepts, and input from [Axiom FAQ for Enterprise customers](https://www.notion.so/axiomhq/Axiom-FAQ-for-Enterprise-customers-14afc65a301980028b38f66a7d0b5548)

Preview: https://axiom-mano-sort-out-faq.mintlify.app/get-help/faq