### PR TITLE
Update syslog-proxy.mdx

### DIFF
--- a/send-data/syslog-proxy.mdx
+++ b/send-data/syslog-proxy.mdx
@@ -66,7 +66,7 @@ brew install axiom-syslog-proxy
 Run the following to install the Axiom Syslog Proxy using `go get`:
 
 ```shell
-go get -u github.com/axiomhq/axiom-syslog-proxy/cmd/axiom-syslog-proxy
+go install github.com/axiomhq/axiom-syslog-proxy/cmd/axiom-syslog-proxy@latest
 ```
 
 ### Install from GitHub source


### PR DESCRIPTION
Update install to use go install instead of go get and bias for recent golang editions.
Spotted by an eagle eyed customer.