### PR TITLE
Fix _apl endpoint example

### DIFF
--- a/apl/tutorial.mdx
+++ b/apl/tutorial.mdx
@@ -9,7 +9,7 @@ In this tutorial, you’ll explore how to use APL in Axiom’s Query tab to run 
 
 ## Prerequisites
 
-- Sign up and log in to [Axiom Account](https://app.axiom.co/)
+- Sign up and log in to [Axiom Account](https://app.axiom.co/register)
 - Ingest data into your dataset or you can run queries on [Play Sandbox](https://axiom.co/play)
 
 ## Overview of APL

--- a/guides/opentelemetry-python.mdx
+++ b/guides/opentelemetry-python.mdx
@@ -12,7 +12,7 @@ This guide explains how to send OpenTelemetry data from a Python app to Axiom us
 ## Prerequisites
 
 - Install Python version 3.7 or higher.
-- Create an Axiom account. To sign up for a free account, go to the [Axiom app](https://app.axiom.co/).
+- Create an Axiom account. To sign up for a free account, go to the [Axiom app](https://app.axiom.co/register).
 - Create a dataset in Axiom. This is where the Python app sends telemetry data. For more information, see [Data Settings](/reference/datasets).
 - Create an API key in Axiom with permissions to query and ingest data. For more information, see [Access Settings](/reference/tokens).
 

--- a/restapi/endpoints/queryApl.mdx
+++ b/restapi/endpoints/queryApl.mdx
@@ -1,4 +1,4 @@
 ---
 title: Run query
-openapi: "v1 post /datasets/_apl"
+openapi: "v1 post /datasets/_apl?format=tabular"
 ---

--- a/restapi/versions/v1.json
+++ b/restapi/versions/v1.json
@@ -124,7 +124,7 @@
         "x-codegen-request-body-name": "payload"
       }
     },
-    "/datasets/_apl": {
+    "/datasets/_apl?format=tabular": {
       "post": {
         "tags": [
           "Datasets"


### PR DESCRIPTION
Preview: https://axiom-mano-query-api-fix.mintlify.app/restapi/endpoints/queryApl

Source: https://linear.app/axiom/issue/AXM-6687/apl-query-api-docs-are-outdated