### PR TITLE
Fix incorrect description of `substring` function

### DIFF
--- a/apl/scalar-functions/string-functions.mdx
+++ b/apl/scalar-functions/string-functions.mdx
@@ -38,14 +38,14 @@ tags:
 | [strcmp()](#strcmp)                                 | Compares two strings.                                                                                                      |
 | [strlen()](#strlen)                                 | Returns the length, in characters, of the input string.                                                                    |
 | [strrep()](#strrep)                                 | Repeats given string provided number of times (default = 1).                                                               |
-| [substring()](#substring)                           | Extracts a substring from a source string starting from some index to the end of the string.                               |
+| [substring()](#substring)                           | Extracts a substring from a source string.                                                                                 |
 | [toupper()](#toupper)                               | Converts a string to upper case.                                                                                           |
 | [tolower()](#tolower)                               | Converts a string to lower case.                                                                                           |
 | [trim()](#trim)                                     | Removes all leading and trailing matches of the specified cutset.                                                          |
 | [trim_regex()](#trim-regex)                         | Removes all leading and trailing matches of the specified regular expression.                                              |
 | [trim_end()](#trim-end)                             | Removes trailing match of the specified cutset.                                                                            |
 | [trim_end_regex()](#trim-end-regex)                 | Removes trailing match of the specified regular expression.                                                                |
-| [trim_start()](#trim-start)                         | Removes leading match of the specified cutset.                                                                 |
+| [trim_start()](#trim-start)                         | Removes leading match of the specified cutset.                                                                             |
 | [trim_start_regex()](#trim-start-regex)             | Removes leading match of the specified regular expression.                                                                 |
 | [url_decode()](#url-decode)                         | The function converts encoded URL into a regular URL representation.                                                       |
 | [url_encode()](#url-encode)                         | The function converts characters of the input URL into a format that can be transmitted over the Internet.                 |
@@ -1056,7 +1056,7 @@ project repeat_string = strrep( "axiom", 3, "::" )
 
 ## substring()
 
-Extracts a substring from a source string starting from some index to the end of the string.
+Extracts a substring from a source string.
 
 ### Arguments
 


### PR DESCRIPTION
the `substring` function doesn't go to the end of the string, it goes to start + offset or end, whichever is first.