### PR TITLE
Add note for allowed APL operators for Flow

### DIFF
--- a/process-data/flows.mdx
+++ b/process-data/flows.mdx
@@ -33,10 +33,8 @@ To set up a flow configuration:
 
     <Note>
     If you only specify the name of the dataset in the query, Axiom routes all events to the destination.
-    </Note>
 
-    <Note>
-    You can only use filter (such as `where` and `search`) and column transformation (such as `project` and `extend`) tabular operators when specificying the APL query to use in your flow configuration.
+    In the APL query, you can only use filters (such as `where` and `search`) and column transformations (such as `project` and `extend`).
     </Note>
 
 1. Click **Preview** to check whether the query you specified transforms your data as desired. The **Input event** section displays the original data stored in Axiom. The **Output event** section displays the transformed data that Axiom sends to the destination. The original data in the Axiom dataset isn’t affected by the transformation.

--- a/process-data/flows.mdx
+++ b/process-data/flows.mdx
@@ -35,6 +35,10 @@ To set up a flow configuration:
     If you only specify the name of the dataset in the query, Axiom routes all events to the destination.
     </Note>
 
+    <Note>
+    You can only use filter (such as `where` and `search`) and column transformation (such as `project` and `extend`) operators when specificying an APL query to use in your flow configuration.
+    </Note>
+
 1. Click **Preview** to check whether the query you specified transforms your data as desired. The **Input event** section displays the original data stored in Axiom. The **Output event** section displays the transformed data that Axiom sends to the destination. The original data in the Axiom dataset isn’t affected by the transformation.
 1. In the **Destination** section, click **Add a destination**, and then select an existing destination where you want to route data or click **Create new destination**.
 1. In the top right, click **Create**.

--- a/process-data/flows.mdx
+++ b/process-data/flows.mdx
@@ -36,7 +36,7 @@ To set up a flow configuration:
     </Note>
 
     <Note>
-    You can only use filter (such as `where` and `search`) and column transformation (such as `project` and `extend`) operators when specificying an APL query to use in your flow configuration.
+    You can only use filter (such as `where` and `search`) and column transformation (such as `project` and `extend`) tabular operators when specificying the APL query to use in your flow configuration.
     </Note>
 
 1. Click **Preview** to check whether the query you specified transforms your data as desired. The **Input event** section displays the original data stored in Axiom. The **Output event** section displays the transformed data that Axiom sends to the destination. The original data in the Axiom dataset isn’t affected by the transformation.


### PR DESCRIPTION
The complete list is 
```
where
search
project
project-away
project-keep
project-rename
project-reorder
extend
extend-valid
redact
parse
parse-kv
```
It feels simpler to refer to these as 'filter and transformation' operators but open to alternatives.