### PR TITLE
Revert "Add support for OTel semconv versions 1.33, 1.34 (#318)"

### DIFF
--- a/reference/system-requirements.mdx
+++ b/reference/system-requirements.mdx
@@ -22,8 +22,6 @@ Axiom supports the following versions of OTel semantic conventions:
 
 | Version | Date when supported added | Schema in OTel docs |
 | --- | --- | --- |
-| 1.34.0 | 27-06-2025 | [1.34.0](https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.34.0) |
-| 1.33.0 | 27-06-2025 | [1.33.0](https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.33.0) |
 | 1.32.0 (default) | 12-06-2025 | [1.32.0](https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.32.0) |
 | 1.31.0 | 12-06-2025 | [1.31.0](https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.31.0) |
 | 1.30.0 | 12-06-2025 | [1.30.0](https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.30.0) |


### PR DESCRIPTION
This reverts commit 6da2947b761626a8489e581f4352d87da6c85920.