### PR TITLE
Introduce tool calling to AI engineering

### DIFF
--- a/ai-engineering/observe.mdx
+++ b/ai-engineering/observe.mdx
@@ -23,7 +23,39 @@ The easiest way to get started is by wrapping your existing AI model client. The
 
 The `wrapAISDKModel` function takes an existing AI model object and returns an instrumented version that will automatically generate trace data for every call.
 
-```typescript
+<CodeGroup>
+
+```typescript OpenAI
+// src/shared/openai.ts
+
+import { createOpenAI } from '@ai-sdk/openai';
+import { wrapAISDKModel } from '@axiomhq/ai';
+
+const openaiProvider = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+// Wrap the model to enable automatic tracing
+export const gpt4o = wrapAISDKModel(openaiProvider('gpt-4o'));
+export const gpt4oMini = wrapAISDKModel(openaiProvider('gpt-4o-mini'));
+```
+
+```typescript Anthropic
+// src/shared/anthropic.ts
+
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { wrapAISDKModel } from '@axiomhq/ai';
+
+const anthropicProvider = createAnthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+// Wrap the model to enable automatic tracing
+export const claude35Sonnet = wrapAISDKModel(anthropicProvider('claude-3-5-sonnet-20241022'));
+export const claude35Haiku = wrapAISDKModel(anthropicProvider('claude-3-5-haiku-20241022'));
+```
+
+```typescript Google Gemini
 // src/shared/gemini.ts
 
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -34,9 +66,26 @@ const geminiProvider = createGoogleGenerativeAI({
 });
 
 // Wrap the model to enable automatic tracing
-export const geminiFlash = wrapAISDKModel(geminiProvider('gemini-2.5-flash-preview-04-17'));
+export const gemini20Flash = wrapAISDKModel(geminiProvider('gemini-2.0-flash-exp'));
+export const gemini15Pro = wrapAISDKModel(geminiProvider('gemini-1.5-pro'));
 ```
 
+```typescript Grok
+// src/shared/grok.ts
+
+import { createXai } from '@ai-sdk/xai';
+import { wrapAISDKModel } from '@axiomhq/ai';
+
+const grokProvider = createXai({
+  apiKey: process.env.XAI_API_KEY,
+});
+
+// Wrap the model to enable automatic tracing
+export const grokBeta = wrapAISDKModel(grokProvider('grok-beta'));
+export const grok2Mini = wrapAISDKModel(grokProvider('grok-2-mini'));
+```
+
+</CodeGroup>
 
 ### Adding context with `withSpan`
 
@@ -47,7 +96,7 @@ While `wrapAISDKModel` handles the automatic instrumentation, the `withSpan` fun
 
 import { withSpan } from '@axiomhq/ai';
 import { generateText } from 'ai';
-import { geminiFlash } from '@/shared/gemini';
+import { gpt4o } from '@/shared/openai';
 
 export default async function Page() {
   const userId = 123;
@@ -58,7 +107,7 @@ export default async function Page() {
     span.setAttribute('user_id', userId);
 
     return generateText({
-      model: geminiFlash, // Use the wrapped model
+      model: gpt4o, // Use the wrapped model
       messages: [
         {
           role: 'user',
@@ -83,13 +132,16 @@ The `wrapTool` helper takes your tool's name and its definition and returns an i
 import { tool } from 'ai';
 import { z } from 'zod';
 import { wrapTool } from '@axiomhq/ai';
-
-// ...
+import { generateText } from 'ai';
+import { gpt4o } from '@/shared/openai';
 
 // In your generateText call, provide wrapped tools
 const { text, toolResults } = await generateText({
-  model: geminiFlash,
-  messages: // ...,
+  model: gpt4o,
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'How do I get from Paris to Berlin?' },
+  ],
   tools: {
     // Wrap each tool with its name
     findDirections: wrapTool(
@@ -120,14 +172,14 @@ Here's how all three instrumentation functions work together in a single, real-w
 
 import { withSpan, wrapAISDKModel, wrapTool } from '@axiomhq/ai';
 import { generateText, tool } from 'ai';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
 
 // 1. Create and wrap the AI model client
-const geminiProvider = createGoogleGenerativeAI({
-  apiKey: process.env.GEMINI_API_KEY,
+const openaiProvider = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
 });
-const geminiFlash = wrapAISDKModel(geminiProvider('gemini-2.5-flash-preview-04-17'));
+const gpt4o = wrapAISDKModel(openaiProvider('gpt-4o'));
 
 // 2. Define and wrap your tool(s)
 const findDirectionsTool = wrapTool(
@@ -151,7 +203,7 @@ export default async function Page() {
     span.setAttribute('user_id', userId);
 
     return generateText({
-      model: geminiFlash, // Use the wrapped model
+      model: gpt4o, // Use the wrapped model
       messages: [
         { role: 'system', content: 'You are a helpful assistant.' },
         { role: 'user', content: 'How do I get from Paris to Berlin?' },

--- a/ai-engineering/observe.mdx
+++ b/ai-engineering/observe.mdx
@@ -72,6 +72,43 @@ export default async function Page() {
 }
 ```
 
+### Instrumenting tool calls with `wrapTool`
+
+For many AI capabilities, the LLM call is only part of the story. If your capability uses tools to interact with external data or services, observing the performance and outcome of those tools is critical. The Axiom AI SDK provides the `wrapTool` and `wrapTools` functions to automatically instrument your Vercel AI SDK tool definitions.
+
+The `wrapTool` helper takes your tool's name and its definition and returns an instrumented version. This wrapper creates a dedicated child span for every tool execution, capturing its arguments, output, and any errors.
+
+```typescript
+// src/app/generate-text/page.tsx
+import { tool } from 'ai';
+import { z } from 'zod';
+import { wrapTool } from '@axiomhq/ai';
+
+// ...
+
+// In your generateText call, provide wrapped tools
+const { text, toolResults } = await generateText({
+  model: geminiFlash,
+  messages: // ...,
+  tools: {
+    // Wrap each tool with its name
+    findDirections: wrapTool(
+      'findDirections', // The name of the tool
+      tool({
+        description: 'Find directions to a location',
+        inputSchema: z.object({
+          from: z.string(),
+          to: z.string(),
+        }),
+        execute: async (params) => {
+          // Your tool logic here...
+          return { directions: `To get from ${params.from} to ${params.to}, use a teleporter.` };
+        },
+      })
+    )
+  }
+});
+```
 
 ## Setting up instrumentation
 
@@ -100,6 +137,9 @@ Key attributes include:
 * `gen_ai.prompt`: The full, rendered prompt or message history sent to the model (as a JSON string).
 * `gen_ai.completion`: The full response from the model, including tool calls (as a JSON string).
 * `gen_ai.response.finish_reasons`: The reason the model stopped generating tokens (e.g., `stop`, `tool-calls`).
+* **`gen_ai.tool.name`**: The name of the executed tool.
+* **`gen_ai.tool.arguments`**: The arguments passed to the tool (as a JSON string).
+* **`gen_ai.tool.message`**: The result returned by the tool (as a JSON string).
 
 ## Visualizing traces in the console
 

--- a/ai-engineering/observe.mdx
+++ b/ai-engineering/observe.mdx
@@ -110,6 +110,68 @@ const { text, toolResults } = await generateText({
 });
 ```
 
+### Complete instrumentation example
+
+<Accordion title="Full end-to-end code example">
+Here's how all three instrumentation functions work together in a single, real-world example:
+
+```typescript
+// src/app/page.tsx
+
+import { withSpan, wrapAISDKModel, wrapTool } from '@axiomhq/ai';
+import { generateText, tool } from 'ai';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { z } from 'zod';
+
+// 1. Create and wrap the AI model client
+const geminiProvider = createGoogleGenerativeAI({
+  apiKey: process.env.GEMINI_API_KEY,
+});
+const geminiFlash = wrapAISDKModel(geminiProvider('gemini-2.5-flash-preview-04-17'));
+
+// 2. Define and wrap your tool(s)
+const findDirectionsTool = wrapTool(
+  'findDirections', // The tool name must be passed to the wrapper
+  tool({
+    description: 'Find directions to a location',
+    inputSchema: z.object({ from: z.string(), to: z.string() }),
+    execute: async ({ from, to }) => ({
+      directions: `To get from ${from} to ${to}, use a teleporter.`,
+    }),
+  })
+);
+
+// 3. In your application logic, use `withSpan` to add context
+//    and call the AI model with your wrapped tools.
+export default async function Page() {
+  const userId = 123;
+
+  const { text } = await withSpan({ capability: 'get_directions', step: 'generate_ai_response' }, async (span) => {
+    // You have access to the OTel span to add custom attributes
+    span.setAttribute('user_id', userId);
+
+    return generateText({
+      model: geminiFlash, // Use the wrapped model
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'How do I get from Paris to Berlin?' },
+      ],
+      tools: {
+        findDirections: findDirectionsTool, // Use the wrapped tool
+      },
+    });
+  });
+
+  return <p>{text}</p>;
+}
+```
+
+This demonstrates the three key steps to rich observability:
+1. **`wrapAISDKModel`**: Automatically captures telemetry for the LLM provider call
+2. **`wrapTool`**: Instruments the tool execution with detailed spans
+3. **`withSpan`**: Creates a parent span that ties everything together under a business capability
+</Accordion>
+
 ## Setting up instrumentation
 
 The Axiom AI SDK is built on the OpenTelemetry standard. To send traces, you need to configure a Node.js or edge-compatible tracer that exports data to Axiom.

--- a/ai-engineering/observe.mdx
+++ b/ai-engineering/observe.mdx
@@ -5,6 +5,7 @@ keywords: ["ai engineering", "rudder", "observe", "telemetry", "withspan", "open
 ---
 
 import { Badge } from "/snippets/badge.jsx";
+import AIEngineeringInstrumentationSnippet from '/snippets/ai-engineering-instrumentation.mdx'
 
 The **Observe** stage is about understanding how your deployed generative AI capabilities perform in the real world. After creating and evaluating a capability, observing its production behavior is crucial for identifying unexpected issues, tracking costs, and gathering the data needed for future improvements.
 
@@ -80,37 +81,7 @@ The Axiom AI SDK is built on the OpenTelemetry standard. To send traces, you nee
 
 You must configure an OTLP trace exporter pointing to your Axiom instance. This is typically done in a dedicated instrumentation file that is loaded before your application starts.
 
-```typescript
-// src/instrumentation.node.ts
-
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { Resource } from '@opentelemetry/resources';
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-import { initAxiomAI, tracer } from '@axiomhq/ai';
-
-// Configure the SDK to export traces to Axiom
-const sdk = new NodeSDK({
-  resource: new Resource({
-    [ATTR_SERVICE_NAME]: 'nextjs-otel-example',
-  }),
-  spanProcessor: new SimpleSpanProcessor(
-    new OTLPTraceExporter({
-      url: `https://api.axiom.co/v1/traces`,
-      headers: {
-        Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
-        'X-Axiom-Dataset': process.env.AXIOM_DATASET!,
-      },
-    }),
-  ),
-});
-sdk.start();
-
-// Initialize the Axiom AI SDK with the tracer
-initAxiomAI({ tracer });
-```
-
+<AIEngineeringInstrumentationSnippet />
 
 Your Axiom credentials (`AXIOM_TOKEN` and `AXIOM_DATASET`) should be set as environment variables.
 

--- a/ai-engineering/overview.mdx
+++ b/ai-engineering/overview.mdx
@@ -21,7 +21,7 @@ The core stages are:
 
 * **Create**: Define a new AI capability, prototype it with various models, and gather reference examples to establish ground truth.
 * **Measure**: Systematically evaluate the capability's performance against reference data using custom graders to score for accuracy, quality, and cost.
-* **Observe**: Cultivate the capability in production by collecting rich telemetry on every execution. Use online evaluations to monitor for performance degradation and discover edge cases.
+* **Observe**: Cultivate the capability in production by collecting rich telemetry on every LLM call and tool execution. Use online evaluations to monitor for performance degradation and discover edge cases.
 * **Iterate**: Use insights from production to refine prompts, augment reference datasets, and improve the capability over time.
 
 ### What's next?

--- a/ai-engineering/quickstart.mdx
+++ b/ai-engineering/quickstart.mdx
@@ -4,6 +4,8 @@ description: "Install and configure the Axiom AI SDK to begin capturing telemetr
 keywords: ["ai engineering", "getting started", "install", "setup", "configuration", "opentelemetry"]
 ---
 
+import AIEngineeringInstrumentationSnippet from '/snippets/ai-engineering-instrumentation.mdx'
+
 This guide provides the steps to install and configure the [`@axiomhq/ai`](https://github.com/axiomhq/ai) SDK. Once configured, you can follow the Rudder workflow to create, measure, observe, and iterate on your AI capabilities.
 
 ## Prerequisites
@@ -98,41 +100,7 @@ bun add \
 
 </CodeGroup>
 
-```typescript
-// src/instrumentation.ts
-
-import 'dotenv/config'; // Make sure to load environment variables
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-import { initAxiomAI } from '@axiomhq/ai';
-
-const tracer = trace.getTracer("my-tracer");
-
-// Configure the NodeSDK to export traces to your Axiom dataset
-const sdk = new NodeSDK({
-  resource: resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: 'my-ai-app', // Replace with your service name
-  }),
-  spanProcessor: new SimpleSpanProcessor(
-    new OTLPTraceExporter({
-      url: `https://api.axiom.co/v1/traces`,
-      headers: {
-        Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
-        'X-Axiom-Dataset': process.env.AXIOM_DATASET!,
-      },
-    }),
-  ),
-});
-
-// Start the SDK
-sdk.start();
-
-// Initialize the Axiom AI SDK with the configured tracer
-initAxiomAI({ tracer });
-```
+<AIEngineeringInstrumentationSnippet />
 
 ## Environment variables
 

--- a/ai-engineering/quickstart.mdx
+++ b/ai-engineering/quickstart.mdx
@@ -118,6 +118,6 @@ GEMINI_API_KEY="<YOUR_GEMINI_API_KEY>"
 
 ## What's next?
 
-Now that your application is configured to send telemetry to Axiom, the next step is to start instrumenting your AI model calls.
+Now that your application is configured to send telemetry to Axiom, the next step is to start instrumenting your AI model and tool calls.
 
 Learn more about that in the [Observe](/ai-engineering/observe) page of the Rudder workflow.

--- a/snippets/ai-engineering-instrumentation.mdx
+++ b/snippets/ai-engineering-instrumentation.mdx
@@ -1,0 +1,36 @@
+```typescript
+// src/instrumentation.ts
+
+import 'dotenv/config'; // Make sure to load environment variables
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { trace } from "@opentelemetry/api";
+import { initAxiomAI } from '@axiomhq/ai';
+
+const tracer = trace.getTracer("my-tracer");
+
+// Configure the NodeSDK to export traces to your Axiom dataset
+const sdk = new NodeSDK({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'my-ai-app', // Replace with your service name
+  }),
+  spanProcessor: new SimpleSpanProcessor(
+    new OTLPTraceExporter({
+      url: `https://api.axiom.co/v1/traces`,
+      headers: {
+        Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
+        'X-Axiom-Dataset': process.env.AXIOM_DATASET!,
+      },
+    }),
+  ),
+});
+
+// Start the SDK
+sdk.start();
+
+// Initialize the Axiom AI SDK with the configured tracer
+initAxiomAI({ tracer });
+```


### PR DESCRIPTION
- Fixes instrumentation code block used in two pages - made consistent with docs snippet
- Introduces `wrapTool`
- Adds code group to show other model providers (OpenAI, Anthropic, Google Gemini, Grok)