### PR TITLE
Add Axiom regions to AWS Lambda

### DIFF
--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -74,6 +74,12 @@ AXIOM_TOKEN: API_TOKEN
 AXIOM_DATASET: DATASET_NAME
 ```
 
+Optionally, you can also set the region by setting `AXIOM_URL` to the [region](https://axiom.co/docs/reference/regions#axiom-api-reference) you use. Defaults to `US`.
+
+```bash
+AXIOM_URL: URL
+```
+
 <Info>
 <ReplaceDatasetToken />
 </Info>

--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -12,6 +12,7 @@ popularityOrder: 5
 import AwsDisclaimer from "/snippets/aws-disclaimer.mdx"
 import Prerequisites from "/snippets/standard-prerequisites.mdx"
 import ReplaceDatasetToken from "/snippets/replace-dataset-token.mdx"
+import ReplaceDomain from "/snippets/replace-domain.mdx"
 
 <Frame>
   <img src="/doc-assets/shots/aws/blog-monitor-aws-lambda.png" alt="Axiom Lambda Extension logo" />
@@ -72,16 +73,12 @@ Add the Axiom dataset name and API token to the list of environment variables. F
 ```bash
 AXIOM_TOKEN: API_TOKEN
 AXIOM_DATASET: DATASET_NAME
-```
-
-Optionally, you can also set the region by setting `AXIOM_URL` to the [region](https://axiom.co/docs/reference/regions#axiom-api-reference) you use. Defaults to `US`.
-
-```bash
-AXIOM_URL: URL
+AXIOM_URL: AXIOM_DOMAIN
 ```
 
 <Info>
 <ReplaceDatasetToken />
+<ReplaceDomain />
 </Info>
 
 </Step>
@@ -113,6 +110,7 @@ resource "aws_lambda_function" "test_lambda" {
     variables = {
       AXIOM_TOKEN   = "API_TOKEN"
       AXIOM_DATASET = "DATASET_NAME"
+      AXIOM_URL     = "AXIOM_DOMAIN"
     }
   }
 
@@ -127,6 +125,7 @@ Replace `AWS_REGION` with the AWS Region to send the request to. For example, `u
 Replace `ARCH` with the system architecture type. For example, `arm64`.
 Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
 <ReplaceDatasetToken />
+<ReplaceDomain />
 </Info>
 
 </Accordion>
@@ -153,6 +152,7 @@ module "lambda_function" {
   environment_variables = {
     AXIOM_TOKEN   = "API_TOKEN"
     AXIOM_DATASET = "DATASET_NAME"
+    AXIOM_URL     = "AXIOM_DOMAIN"
   }
 }
 ```
@@ -162,6 +162,7 @@ Replace `AWS_REGION` with the AWS Region to send the request to. For example, `u
 Replace `ARCH` with the system architecture type. For example, `arm64`.
 Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
 <ReplaceDatasetToken />
+<ReplaceDomain />
 </Info>
 
 </Accordion>


### PR DESCRIPTION
There is no mention for the Region setting in all docs, so it's easy to miss this. 

In our case, we were getting 403: Insufficient permissions as a result.