### PR TITLE
fix: broken link bug due to special character encoding

### DIFF
--- a/guides/javascript.mdx
+++ b/guides/javascript.mdx
@@ -17,8 +17,8 @@ JavaScript is a versatile, high-level programming language primarily used for cr
 
 To send data from a JavaScript app to Axiom, use one of the following libraries of the Axiom JavaScript SDK:
 
-- [@axiomhq/js](#use-axiomhq-js)
-- [@axiomhq/logging](#use-axiomhq-logging)
+- <a href="#use-%40axiomhq%2Fjs">@axiomhq/js</a>
+- <a href="#use-%40axiomhq%2Flogging">@axiomhq/logging</a>
 
 The choice between these options depends on your individual requirements:
 


### PR DESCRIPTION
- Link was broken due to `use-axiomhq-js` was getting converted to `use-%40axiomhq%2Fjs`