### PR TITLE
Add schema url to Gen AI quickstart and Next.js example

### DIFF
--- a/ai-engineering/quickstart.mdx
+++ b/ai-engineering/quickstart.mdx
@@ -123,6 +123,8 @@ To send data to Axiom, configure a tracer. For example, use a dedicated instrume
         [ATTR_SERVICE_NAME]: 'my-ai-app', // Replace with your service name
       },
       {
+        // If starting a new project it is advisable to use the latest schema version
+        // see: https://opentelemetry.io/docs/specs/semconv/
         schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
       }),
       spanProcessor: new SimpleSpanProcessor(

--- a/ai-engineering/quickstart.mdx
+++ b/ai-engineering/quickstart.mdx
@@ -121,6 +121,9 @@ To send data to Axiom, configure a tracer. For example, use a dedicated instrume
     const sdk = new NodeSDK({
       resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: 'my-ai-app', // Replace with your service name
+      },
+      {
+        schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
       }),
       spanProcessor: new SimpleSpanProcessor(
         new OTLPTraceExporter({

--- a/ai-engineering/quickstart.mdx
+++ b/ai-engineering/quickstart.mdx
@@ -123,8 +123,8 @@ To send data to Axiom, configure a tracer. For example, use a dedicated instrume
         [ATTR_SERVICE_NAME]: 'my-ai-app', // Replace with your service name
       },
       {
-        // If starting a new project it is advisable to use the latest schema version
-        // see: https://opentelemetry.io/docs/specs/semconv/
+        // Use the latest schema version
+        // Info: https://opentelemetry.io/docs/specs/semconv/
         schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
       }),
       spanProcessor: new SimpleSpanProcessor(

--- a/guides/opentelemetry-nextjs.mdx
+++ b/guides/opentelemetry-nextjs.mdx
@@ -43,8 +43,8 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
         resource: resourceFromAttributes({
           [ATTR_SERVICE_NAME]: "nextjs-otel-example",
         }, {
-          // If starting a new project it is advisable to use the latest schema version
-          // see: https://opentelemetry.io/docs/specs/semconv/
+          // Use the latest schema version
+          // Info: https://opentelemetry.io/docs/specs/semconv/
           schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
         }) as Resource,
         spanProcessor: new SimpleSpanProcessor(

--- a/guides/opentelemetry-nextjs.mdx
+++ b/guides/opentelemetry-nextjs.mdx
@@ -43,6 +43,8 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
         resource: resourceFromAttributes({
           [ATTR_SERVICE_NAME]: "nextjs-otel-example",
         }, {
+          // If starting a new project it is advisable to use the latest schema version
+          // see: https://opentelemetry.io/docs/specs/semconv/
           schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
         }) as Resource,
         spanProcessor: new SimpleSpanProcessor(

--- a/guides/opentelemetry-nextjs.mdx
+++ b/guides/opentelemetry-nextjs.mdx
@@ -42,6 +42,8 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
       const sdk = new NodeSDK({
         resource: resourceFromAttributes({
           [ATTR_SERVICE_NAME]: "nextjs-otel-example",
+        }, {
+          schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
         }) as Resource,
         spanProcessor: new SimpleSpanProcessor(
           new OTLPTraceExporter({


### PR DESCRIPTION
Version 2.1.0 of `@opentelemetry/resources` adds support for schema URL (ie user declares which schema version they want). Especially with the complexity of Gen AI schema we should suggest to use this where possible.