### PR TITLE
fix(docs): cli legacy page missing redirection

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1042,6 +1042,10 @@
     {
       "source": "/process-data/*",
       "destination": "/introduction"
+    },
+    {
+      "source": "/cli",
+      "destination": "/reference/cli"
     }
   ]
 }


### PR DESCRIPTION
**description**
when clicking through the website mega menu cli install [link](https://axiom.co/docs/cli), we are facing a 404 page.

**solution**
this pr adds a redirection from the cli legacy page to the new one, as it seems to be used within the website mega menu:

| preview |
|------|
| <img width="1470" height="780" alt="image" src="https://github.com/user-attachments/assets/096619a1-0a9f-4e78-91da-41f3a8691dc0" /> |
| the link being used within the menu is pointing to `docs/cli` which is throwing 404 | 

another take could be to update the link within the website also, but redirection might do the trick to ensure availability if used elsewhere.