### PR TITLE
Fix: Update Axiom CLI Homebrew Instructions

### DIFF
--- a/reference/cli.mdx
+++ b/reference/cli.mdx
@@ -27,8 +27,7 @@ go install github.com/axiomhq/cli/cmd/axiom@latest
 You can also install the CLI using [Homebrew](https://brew.sh/)
 
 ```bash
-brew tap axiomhq/tap
-brew install axiom
+brew install --cask axiom
 ```
 
 This installs Axiom command globally so you can run `axiom` commands from any directory.
@@ -36,7 +35,7 @@ This installs Axiom command globally so you can run `axiom` commands from any di
 To update:
 
 ```bash
-brew upgrade axiom
+brew upgrade --cask axiom
 ```
 
 ### Install from source


### PR DESCRIPTION
Updated Homebrew installation instructions for Axiom CLI to use --cask option which is the correct option