### PR TITLE
Fix instrumentation.ts code in OTel Next.js

### DIFF
--- a/guides/opentelemetry-nextjs.mdx
+++ b/guides/opentelemetry-nextjs.mdx
@@ -46,7 +46,7 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
           // Info: https://opentelemetry.io/docs/specs/semconv/
           schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
         }),
-        spanProcessor: new SimpleSpanProcessor(
+        spanProcessor: [new SimpleSpanProcessor(
           new OTLPTraceExporter({
             url: `https://${process.env.AXIOM_DOMAIN}/v1/traces`,
             headers: {
@@ -54,7 +54,7 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
               "X-Axiom-Dataset": `${process.env.DATASET_NAME}`,
             },
           })
-        ),
+        )],
       });
 
       provider.register();

--- a/guides/opentelemetry-nextjs.mdx
+++ b/guides/opentelemetry-nextjs.mdx
@@ -46,7 +46,7 @@ OpenTelemetry provides a standardized way to collect and export telemetry data f
           // Info: https://opentelemetry.io/docs/specs/semconv/
           schemaUrl: 'https://opentelemetry.io/schemas/1.37.0',
         }),
-        spanProcessor: [new SimpleSpanProcessor(
+        spanProcessors: [new SimpleSpanProcessor(
           new OTLPTraceExporter({
             url: `https://${process.env.AXIOM_DOMAIN}/v1/traces`,
             headers: {


### PR DESCRIPTION
“There’s a typing error in the Next.js documentation example: it shows new SimpleSpanProcessor(), but spanProcessors actually expects an array of this element.”


<img width="559" height="313" alt="Screenshot 2025-10-04 at 12 50 50 PM" src="https://github.com/user-attachments/assets/0a5d3799-e763-481c-a23e-5207220841d6" />

