### PR TITLE
Clarify behavior of zeroes in extend-valid and add link to isfinite

### DIFF
--- a/apl/scalar-functions/mathematical-functions.mdx
+++ b/apl/scalar-functions/mathematical-functions.mdx
@@ -21,6 +21,7 @@ The table summarizes the mathematical functions available in APL.
 | [exp10](#exp10)       | The base-10 exponential function of x, which is 10 raised to the power x: 10^x.                                |
 | [exp2](#exp2)        | The base-2 exponential function of x, which is 2 raised to the power x: 2^x.                                   |
 | [gamma](#gamma)       | Computes gamma function.                                                                                       |
+| [isfinite](#isfinite)       | Returns whether input is a finite value (neither infinite nor NaN).                                             |
 | [isinf](#isinf)       | Returns whether input is an infinite (positive or negative) value.                                             |
 | [isint](#isint)       |  Returns whether input is an integer (positive or negative) value                                              |
 | [isnan](#isnan)       | Returns whether input is a Not a Number (NaN) value.                                                             |

--- a/apl/tabular-operators/extend-valid-operator.mdx
+++ b/apl/tabular-operators/extend-valid-operator.mdx
@@ -9,8 +9,8 @@ This is a shorthand operator to create a field while also doing basic checking o
 
 - **Dictionary:** Check if the dictionary isn’t null and has at least one entry.
 - **Array:** Check if the array isn’t null and has at least one value.
-- **String:** Check is the string isn’t empty and has at least one character.
-- **Number:** Check that the number is non-zero and not infinity or NaN.
+- **String:** Check if the string isn’t empty and has at least one character.
+- **Number:** Check if the value isn’t one of the following: zero, infinity, or NaN.
 - **Other types:** The same logic as `tobool` and a check for true.
 
 You can use `extend-valid` to perform conditional transformations on large datasets, especially in scenarios where data quality varies or when dealing with complex log or telemetry data.
@@ -154,4 +154,4 @@ In this query, the `extract` function retrieves the first letter of the city nam
 - [extend](/apl/tabular-operators/extend-operator): Use `extend` to add calculated fields unconditionally, without validating data.
 - [project](/apl/tabular-operators/project-operator): Use `project` to select and rename fields, without performing conditional extensions.
 - [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` for aggregation, often used before extending fields with further calculations.
-- [isfinite](/apl/scalar-functions/mathematical-functions#isfinite): Use `where isfinite(field)` to select numbers that are not infinity or NaN.
+- [isfinite](/apl/scalar-functions/mathematical-functions#isfinite): Determines whether the input is a finite value (neither infinite nor NaN).

--- a/apl/tabular-operators/extend-valid-operator.mdx
+++ b/apl/tabular-operators/extend-valid-operator.mdx
@@ -8,8 +8,9 @@ The `extend-valid` operator in Axiom Processing Language (APL) allows you to ext
 This is a shorthand operator to create a field while also doing basic checking on the validity of the field. In many cases, additional checks are required and it’s recommended in those cases a combination of an [extend](/apl/tabular-operators/extend-operator) and a [where](/apl/tabular-operators/where-operator) operator are used. The basic checks that Axiom preform depend on the type of the expression:
 
 - **Dictionary:** Check if the dictionary isn’t null and has at least one entry.
-- **Array:** Check if the arrat isn’t null and has at least one value.
+- **Array:** Check if the array isn’t null and has at least one value.
 - **String:** Check is the string isn’t empty and has at least one character.
+- **Number:** Check that the number is non-zero and not infinity or NaN.
 - **Other types:** The same logic as `tobool` and a check for true.
 
 You can use `extend-valid` to perform conditional transformations on large datasets, especially in scenarios where data quality varies or when dealing with complex log or telemetry data.
@@ -148,8 +149,9 @@ In this query, the `extract` function retrieves the first letter of the city nam
 </Tab>
 </Tabs>
 
-## List of related operators
+## List of related operators and functions
 
 - [extend](/apl/tabular-operators/extend-operator): Use `extend` to add calculated fields unconditionally, without validating data.
 - [project](/apl/tabular-operators/project-operator): Use `project` to select and rename fields, without performing conditional extensions.
 - [summarize](/apl/tabular-operators/summarize-operator): Use `summarize` for aggregation, often used before extending fields with further calculations.
+- [isfinite](/apl/scalar-functions/mathematical-functions#isfinite): Use `where isfinite(field)` to select numbers that are not infinity or NaN.


### PR DESCRIPTION
Based on some internal discussion it came to my awareness that extend-valid did not explicitly state that zeroes are filtered out as well. This PR makes that explicit (it was implied already about the note on `tobool`, but was not too obvious).

Also added a link to isfinite() for people that want to keep the zeroes in there

cc @Licenser 