### PR TITLE
Update otelhttp examples to use zstd compression

### DIFF
--- a/send-data/aws-lambda-dot.mdx
+++ b/send-data/aws-lambda-dot.mdx
@@ -79,7 +79,7 @@ receivers:
 
 exporters:
   otlphttp:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN

--- a/send-data/kubernetes.mdx
+++ b/send-data/kubernetes.mdx
@@ -243,7 +243,7 @@ data:
         type: axiom
         inputs:
           - kubernetes_logs
-        compression: gzip
+        compression: zstd
         dataset: ${AXIOM_DATASET_NAME}
         token: ${AXIOM_API_TOKEN}
         healthcheck:

--- a/send-data/opentelemetry.mdx
+++ b/send-data/opentelemetry.mdx
@@ -42,7 +42,7 @@ Configuring the OpenTelemetry collector is as simple as creating an HTTP exporte
 ```yaml
 exporters:
   otlphttp:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN
@@ -64,7 +64,7 @@ service:
 ```yaml
 exporters:
   otlphttp:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN
@@ -86,7 +86,7 @@ service:
 ```yaml
 exporters:
   otlphttp:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN

--- a/send-data/reference-architectures.mdx
+++ b/send-data/reference-architectures.mdx
@@ -103,7 +103,7 @@ Axiom natively supports the OpenTelemetry Line Protocol (OTLP). Configuring the 
 exporters:
   # Exporter for logs and traces
   otlphttp:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN
@@ -111,7 +111,7 @@ exporters:
   
   # Exporter for metrics
   otlphttp/metrics:
-    compression: gzip
+    compression: zstd
     endpoint: https://AXIOM_DOMAIN
     headers:
       authorization: Bearer API_TOKEN


### PR DESCRIPTION
Update OpenTelemetry Collector examples to use zstd compression instead of gzip.

zstd offers better compression ratios and performance compared to gzip, making it a superior choice for sending telemetry data.

---
<a href="https://cursor.com/background-agent?bcId=bc-f778ea57-56a5-4fb2-9ccc-2fcf32743be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f778ea57-56a5-4fb2-9ccc-2fcf32743be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

