### PR TITLE
Fix link for extracting top-level fields in performance.mdx

### DIFF
--- a/reference/performance.mdx
+++ b/reference/performance.mdx
@@ -310,7 +310,7 @@ Some ingestion pipelines place large JSON payloads into a string field, deferrin
 ### How to fix it
 
 - **Ingest as map fields:** Axiom’s new [map field type](/apl/data-types/map-fields#map-fields) can store object fields column by column, preserving structure and optimizing for nested queries. This allows indexing of specific nested keys.
-- **Extract top-level fields where possible:** If a certain nested field is frequently used for filtering or grouping, consider promoting it to its own top-level field (for faster scanning and filtering). For more information, see [Extract top-level fields from log body](/send-data/kubernetes.mdx#extract-top-level-fields-from-log-body).
+- **Extract top-level fields where possible:** If a certain nested field is frequently used for filtering or grouping, consider promoting it to its own top-level field (for faster scanning and filtering). For more information, see [Extract top-level fields from log body](/send-data/kubernetes#extract-top-level-fields-from-log-body).
 - **Avoid `parse_json()` in query:** If your JSON can’t be flattened entirely, ingest it into a map field. Then query subfields directly:
     
     ```kusto


### PR DESCRIPTION
Updated link reference for extracting top-level fields in performance documentation.