### PR TITLE
fix: use consistent nested flag paths in CLI examples

### DIFF
--- a/ai-engineering/iterate.mdx
+++ b/ai-engineering/iterate.mdx
@@ -91,13 +91,13 @@ Use [flags](/ai-engineering/evaluate/flags-experiments) to test different approa
 
 ```bash
 # Test with a more capable model
-axiom eval ticket-classification --flag.model=gpt-4o
+axiom eval ticket-classification --flag.ticketClassification.model=gpt-4o
 
-# Try a different temperature
-axiom eval ticket-classification --flag.temperature=0.3
+# Try a lower temperature
+axiom eval ticket-classification --flag.ticketClassification.temperature=0.3
 
 # Experiment with prompt variations
-axiom eval ticket-classification --flag.promptStrategy=detailed
+axiom eval ticket-classification --flag.ticketClassification.promptStrategy=detailed
 ```
 
 Run multiple experiments to understand the tradeoffs between accuracy, cost, and latency.


### PR DESCRIPTION
Update flag override examples in `iterate.mdx` and `analyze-results.mdx` to use nested flag paths (e.g., `--flag.ticketClassification.model`) consistent with the flag schema structure documented in `flags-experiments.mdx`.

The CLI requires flags to match the nested schema structure defined in the app scope. Examples using flat paths like `--flag.model` would fail validation when the flag schema uses nested objects like `ticketClassification.model`.

Fixes AXM-10752