### PR TITLE
docs(grafana): clarify API token permissions requirement

### DIFF
--- a/apps/grafana.mdx
+++ b/apps/grafana.mdx
@@ -19,9 +19,9 @@ A Grafana data source plugin extends the functionality of Grafana by allowing it
 
 ## Prerequisites
 
-- [Create an Axiom account](https://app.axiom.co/).
-- [Create a dataset in Axiom](/reference/datasets) where you send your data.
-- [Create an Advanced API token in Axiom](/reference/tokens#create-advanced-api-token) with **Query** permissions enabled for the datasets you want to visualize. Basic API tokens only allow data ingestion and won't work with Grafana.
+- [Create an Axiom account](https://app.axiom.co/register).
+- [Create a dataset in Axiom](/reference/datasets#create-dataset) where you send your data.
+- [Create an advanced API token in Axiom](/reference/tokens#create-advanced-api-token) with permissions to query data from the dataset you have created. Basic API tokens only allow data ingestion and won't work with Grafana.
 
 ## Install the Axiom Grafana data source plugin on Grafana Cloud
 

--- a/apps/grafana.mdx
+++ b/apps/grafana.mdx
@@ -21,7 +21,7 @@ A Grafana data source plugin extends the functionality of Grafana by allowing it
 
 - [Create an Axiom account](https://app.axiom.co/).
 - [Create a dataset in Axiom](/reference/datasets) where you send your data.
-- [Create an API token in Axiom](/reference/tokens) with permissions to create, read, update, and delete datasets.
+- [Create an Advanced API token in Axiom](/reference/tokens#create-advanced-api-token) with **Query** permissions enabled for the datasets you want to visualize. Basic API tokens only allow data ingestion and won't work with Grafana.
 
 ## Install the Axiom Grafana data source plugin on Grafana Cloud
 


### PR DESCRIPTION

This addresses user confusion where the default Basic token permissions don't include the query access that Grafana needs to function.