### PR TITLE
MCP docs keywords

### DIFF
--- a/console/intelligence/mcp-server.mdx
+++ b/console/intelligence/mcp-server.mdx
@@ -2,6 +2,7 @@
 title: Axiom MCP Server
 description: "This page explains how to get deeper insights with Axiom MCP Server."
 sidebarTitle: MCP Server
+keywords: ["MCP", "Model Context Protocol", "MCP server", "Axiom MCP Server", "AI agents", "AI assistant", "Claude", "Cursor", "APL", "Axiom Processing Language", "query data", "observability", "remote MCP", "MCP tools", "MCP prompts", "LLM", "large language models", "MCP integration", "OAuth", "AI coding assistant"]
 ---
 
 import Prerequisites from "/snippets/minimal-prerequisites.mdx"

--- a/console/intelligence/mcp-server.mdx
+++ b/console/intelligence/mcp-server.mdx
@@ -2,7 +2,7 @@
 title: Axiom MCP Server
 description: "This page explains how to get deeper insights with Axiom MCP Server."
 sidebarTitle: MCP Server
-keywords: ["MCP", "Model Context Protocol", "MCP server", "Axiom MCP Server", "AI agents", "AI assistant", "Claude", "Cursor", "APL", "Axiom Processing Language", "query data", "observability", "remote MCP", "MCP tools", "MCP prompts", "LLM", "large language models", "MCP integration", "OAuth", "AI coding assistant"]
+keywords: ["MCP", "Model Context Protocol", "MCP server", "Axiom MCP", "Claude MCP", "Cursor MCP", "AI agent"]
 ---
 
 import Prerequisites from "/snippets/minimal-prerequisites.mdx"


### PR DESCRIPTION
Add keywords to `mcp-server.mdx` to improve its search engine discoverability.

---
Linear Issue: [AXM-11511](https://linear.app/axiom/issue/AXM-11511/mcp-docs-should-have-keywords-so-search-finds-the-material)

<p><a href="https://cursor.com/agents/bc-f72c63e9-405d-435e-9608-e9a5cbca2ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f72c63e9-405d-435e-9608-e9a5cbca2ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

