### PR TITLE
Add OpenAPI sanitizer for x-hide-in-docs support

### DIFF
--- a/.github/workflows/check-openapi.yml
+++ b/.github/workflows/check-openapi.yml
@@ -1,0 +1,29 @@
+name: Check OpenAPI specs
+
+on:
+  pull_request:
+    paths:
+      - 'restapi/source/**'
+      - 'restapi/versions/**'
+      - 'scripts/sanitize-openapi.js'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Regenerate sanitized specs
+        run: node scripts/sanitize-openapi.js
+
+      - name: Check for drift
+        run: |
+          if [[ -n "$(git status --porcelain -- restapi/versions/)" ]]; then
+            git status --short -- restapi/versions/
+            echo "::error::Generated OpenAPI specs are out of date. Run 'node scripts/sanitize-openapi.js' and commit the results."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Optional: install the following VS Code extensions:
 
 ## Build locally
 
-Run the following in your terminal to build the documentation locally:
+If you have changed the OpenAPI source specs in `restapi/source/`, regenerate the sanitized specs first:
+
+```
+node scripts/sanitize-openapi.js
+```
+
+Then run the following in your terminal to build the documentation locally:
 
 ```
 mint dev

--- a/restapi/source/README.md
+++ b/restapi/source/README.md
@@ -1,0 +1,31 @@
+# OpenAPI source specs
+
+These are the source-of-truth OpenAPI specification files. Edit these files, not the ones in `restapi/versions/`.
+
+After editing, run the sanitize script to regenerate the output:
+
+```
+node scripts/sanitize-openapi.js
+```
+
+The script strips fields marked with `x-hide-in-docs: true` and writes sanitized output to `restapi/versions/`.
+
+## Hiding fields from docs
+
+Add `"x-hide-in-docs": true` to any parameter, schema property, or header to exclude it from the rendered documentation.
+
+```json
+{
+  "properties": {
+    "internal_id": {
+      "type": "string",
+      "x-hide-in-docs": true
+    }
+  }
+}
+```
+
+Supported locations:
+- Schema properties (in request bodies, responses, and component schemas)
+- Parameters (query, path, header)
+- Response headers

--- a/restapi/source/v1-edge-ingest.json
+++ b/restapi/source/v1-edge-ingest.json
@@ -1,0 +1,369 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "A public and stable API for interacting with axiom services",
+    "title": "Axiom",
+    "termsOfService": "http://axiom.co/terms",
+    "contact": {
+      "name": "Axiom support team",
+      "url": "https://axiom.co",
+      "email": "hello@axiom.co"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{axiom-domain}/v1/"
+    }
+  ],
+  "paths": {
+    "/ingest/{dataset-id}": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "ingest|create"
+            ]
+          }
+        ],
+        "tags": [
+          "ingest"
+        ],
+        "operationId": "ingestToDataset",
+        "parameters": [
+          {
+            "name": "dataset-id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The name of the field to use as the timestamp. If not specified, the timestamp will be the time the event was received by Axiom.",
+            "name": "timestamp-field",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The date-time format of the timestamp field. The reference time is `Mon Jan 2 15:04:05 -0700 MST 2006`, as specified in https://pkg.go.dev/time/?tab=doc#Parse",
+            "name": "timestamp-format",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The delimiter to use when parsing CSV data. If not specified, the default delimiter is `,`.",
+            "name": "csv-delimiter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A list of optional comma separated fields to use for CSV ingestion. If not specified, the first line of the CSV will be used as the field names.",
+            "name": "X-Axiom-CSV-Fields",
+            "in": "header",
+            "style": "simple",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "An optional JSON encoded object with additional labels to add to all events in the request",
+            "name": "X-Axiom-Event-Labels",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Data you want to send to Axiom.\nSupported formats: JSON, NDJSON, CSV.\nUpload the data in a file or send it in the payload of the request.",
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/nd-json": {
+              "schema": {
+                "description": "Data you want to send to Axiom.\nSupported formats: JSON, NDJSON, CSV.\nUpload the data in a file or send it in the payload of the request.",
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "text/csv": {
+              "schema": {
+                "description": "Data you want to send to Axiom.\nSupported formats: JSON, NDJSON, CSV.\nUpload the data in a file or send it in the payload of the request.",
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/x-ndjson": {
+              "schema": {
+                "description": "Data you want to send to Axiom.\nSupported formats: JSON, NDJSON, CSV.\nUpload the data in a file or send it in the payload of the request.",
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "IngestResult",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestStatus"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-limit-requests": true,
+        "x-axiom-nocompress": true,
+        "x-axiom-not-suspended": true,
+        "x-axiom-trace-sampling": "0.01"
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100
+        }
+      },
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 0,
+          "default": 0
+        }
+      }
+    },
+    "requestBodies": {
+      "ingestDatasetOpenTelemetryLogsPayload": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Data you want to send to Axiom.\nSupported formats: JSON, Protobuf.\nUpload the data in a file or send it in the payload of the request.",
+              "type": "string",
+              "format": "binary"
+            }
+          },
+          "application/x-protobuf": {
+            "schema": {
+              "description": "Data you want to send to Axiom.\nSupported formats: JSON, Protobuf.\nUpload the data in a file or send it in the payload of the request.",
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        },
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "Auth": {
+        "description": "Authenticate using an API token or personal access token (PAT). Include the token as a Bearer token: `Authorization: Bearer <token>`. For more information, see [Tokens](/reference/tokens).",
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+            "scopes": {}
+          }
+        }
+      },
+      "Shared": {
+        "type": "apiKey",
+        "name": "tk",
+        "in": "query"
+      }
+    },
+    "schemas": {
+      "FirehoseIngestStatus": {
+        "description": "AWS Firehose HTTP endpoint response format",
+        "type": "object",
+        "required": [
+          "requestId",
+          "timestamp"
+        ],
+        "properties": {
+          "errorMessage": {
+            "description": "For failed requests, a message explaining the failure. If a request fails after exhausting all retries, the last instance of the error message is copied to error output S3 bucket if configured.",
+            "type": "string",
+            "maxLength": 8192,
+            "minLength": 0
+          },
+          "requestId": {
+            "description": "Must match the requestId in the request.",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "The timestamp (milliseconds since epoch) at which the server processed this request.",
+            "type": "integer"
+          }
+        }
+      },
+      "IngestFailure": {
+        "type": "object",
+        "required": [
+          "error",
+          "timestamp"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "IngestStatus": {
+        "type": "object",
+        "required": [
+          "ingested",
+          "failed",
+          "processedBytes",
+          "blocksCreated",
+          "walLength"
+        ],
+        "properties": {
+          "blocksCreated": {
+            "type": "integer",
+            "format": "uint32"
+          },
+          "failed": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IngestFailure"
+            }
+          },
+          "ingested": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "processedBytes": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "walLength": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        }
+      },
+      "OTELResponse": {
+        "description": "The response from the ingest API according to the OpenTelemetry specification.",
+        "type": "string",
+        "format": "binary"
+      },
+      "elasticHealth": {
+        "type": "object",
+        "properties": {
+          "cluster_name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "elasticLicenseInfo": {
+        "type": "object",
+        "properties": {
+          "expiry_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "expiry_date_in_millis": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "issue_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "issue_date_in_millis": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "issued_to": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "max_nodes": {
+            "type": "integer"
+          },
+          "start_date_in_millis": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        }
+      },
+      "elasticLicenseResponse": {
+        "type": "object",
+        "properties": {
+          "license": {
+            "$ref": "#/components/schemas/elasticLicenseInfo"
+          }
+        }
+      },
+      "elasticVersion": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "object",
+            "properties": {
+              "number": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/restapi/source/v1-edge-query.json
+++ b/restapi/source/v1-edge-query.json
@@ -1,0 +1,659 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Query execution API for regional Edge deployments",
+    "title": "Axiom Query",
+    "termsOfService": "http://axiom.co/terms",
+    "contact": {
+      "name": "Axiom support team",
+      "url": "https://axiom.co",
+      "email": "hello@axiom.co"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{axiom-domain}/v1/"
+    }
+  ],
+  "paths": {
+    "/query/batch": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "query|read"
+            ]
+          }
+        ],
+        "tags": [
+          "query"
+        ],
+        "operationId": "batchQuery",
+        "parameters": [
+          {
+            "description": "Maximum number of concurrent queries to execute",
+            "name": "maxConcurrency",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "description": "Whether to bypass cache for all queries in the batch",
+            "name": "nocache",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "description": "Contains the source of the APL query (for example console, dashboard, etc.)",
+            "name": "apl-source",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Contains the id of the source, for example dashboard_id",
+            "name": "apl-source-id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "queryId"
+                  ],
+                  "properties": {
+                    "aplRequest": {
+                      "$ref": "#/components/schemas/APLRequestWithOptions"
+                    },
+                    "queryId": {
+                      "description": "Unique identifier for this query in the batch",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream of query results",
+            "headers": {
+              "Content-Type": {
+                "schema": {
+                  "type": "string",
+                  "default": "text/event-stream"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryError"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-nocompress": true,
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/query/_apl?format=tabular": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "query|read"
+            ]
+          }
+        ],
+        "tags": [
+          "query"
+        ],
+        "operationId": "queryApl",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "legacy",
+                "tabular",
+                "tabular-rows"
+              ]
+            }
+          },
+          {
+            "name": "nocache",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "saveAsKind",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "when saveAsKind is true, this parameter indicates the id of the associated dataset",
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "streaming-duration",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "contains the source of the APL query (for example console, dashboard, etc.)",
+            "name": "apl-source",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "contains the id of the source, for example dashboard_id",
+            "name": "apl-source-id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include a totals table (only supported in MetricsDB)",
+            "name": "totals",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APLRequestWithOptions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "AplResult",
+            "headers": {
+              "X-Axiom-History-Query-Id": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-QueryLimit-Limit": {
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-QueryLimit-Remaining": {
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-QueryLimit-Reset": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AplResult"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "User or system error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryError"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-nocompress": true,
+        "x-axiom-not-suspended": true
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "Auth": {
+        "description": "Authenticate using an API token or personal access token (PAT). Include the token as a Bearer token: `Authorization: Bearer <token>`. For more information, see [Tokens](/reference/tokens).",
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+            "scopes": {}
+          }
+        }
+      },
+      "Shared": {
+        "type": "apiKey",
+        "name": "tk",
+        "in": "query"
+      }
+    },
+    "schemas": {
+      "APLRequestWithOptions": {
+        "type": "object",
+        "required": [
+          "apl"
+        ],
+        "properties": {
+          "apl": {
+            "description": "APL query string",
+            "type": "string"
+          },
+          "cursor": {
+            "description": "Pagination cursor",
+            "type": "string"
+          },
+          "defaultLimit": {
+            "description": "The default limit to use when no limit is specified in the query.\n",
+            "type": "integer"
+          },
+          "defaultOrder": {
+            "description": "The default order to use when no order is specified in the query.\n",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "desc": {
+                  "type": "boolean"
+                },
+                "field": {
+                  "type": "string"
+                }
+              },
+              "x-go-name": "APLRequestWithOptionsDefaultOrder"
+            }
+          },
+          "endTime": {
+            "description": "End time for the query range",
+            "type": "string"
+          },
+          "includeCursor": {
+            "description": "Include cursor in response",
+            "type": "boolean"
+          },
+          "includeCursorField": {
+            "description": "Defines if the _cursor field should be projected in the result",
+            "type": "boolean"
+          },
+          "libraries": {
+            "type": "array",
+            "items": {
+              "description": "library ids to include in this query",
+              "type": "string"
+            }
+          },
+          "maxBinAutoGroups": {
+            "description": "Maximum number of groups to automatically bin into",
+            "type": "integer"
+          },
+          "queryEdgeDeployment": {
+            "description": "The edge deployment the query should be run in. If not specified, the query will be run in the default edge deployment of the org. Takes precedence over queryRegion.",
+            "type": "string"
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/QueryOptions"
+          },
+          "queryRegion": {
+            "description": "The region the query should be run in. If not specified, the query will be run in the default region of the org.",
+            "type": "string"
+          },
+          "startTime": {
+            "description": "start and end time for the query, these must be specified as RFC3339 strings\nor using relative time expressions (e.g. now-1h, now-1d, now-1w, etc)",
+            "type": "string"
+          },
+          "variables": {
+            "description": "Variables is an optional set of additional variables that are inserted into the APL",
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "AplResult": {
+        "description": "APL query result (streaming binary data)",
+        "type": "object"
+      },
+      "FindMetricsRequest": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "description": "The tag value to search for matching metrics",
+            "type": "string"
+          }
+        }
+      },
+      "MetricsError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Status is the http status code associated with this error",
+            "type": "integer"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/MetricsErrorDetail"
+          },
+          "message": {
+            "description": "a formatted user-facing error message",
+            "type": "string"
+          }
+        }
+      },
+      "MetricsErrorDetail": {
+        "type": "object",
+        "properties": {
+          "column": {
+            "description": "Column is the column associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "compileErrorCode": {
+            "description": "CompileErrorCode is a special error code that is only available for Compile Errors\nIt is an integer value that can be used to identify the error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              16,
+              17,
+              32,
+              33,
+              34
+            ]
+          },
+          "errorType": {
+            "description": "Error Type is an integer value indicating the kind of error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          },
+          "line": {
+            "description": "Line is the line associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "description": "Message is the raw error message without any formatting",
+            "type": "string"
+          }
+        }
+      },
+      "MetricsQueryOptions": {
+        "type": "object",
+        "properties": {
+          "quickRange": {
+            "description": "Quick time range selection (e.g. \"last-1h\", \"last-24h\")",
+            "type": "string"
+          }
+        }
+      },
+      "MetricsRequestWithOptions": {
+        "type": "object",
+        "required": [
+          "startTime",
+          "endTime"
+        ],
+        "properties": {
+          "apl": {
+            "description": "DEPRECATED: use 'mpl' instead. Legacy alias for the query string.",
+            "type": "string"
+          },
+          "endTime": {
+            "description": "End time for the query range",
+            "type": "string"
+          },
+          "metricsQuery": {
+            "description": "Structured metrics query object",
+            "type": "object",
+            "x-go-type": {
+              "hints": {
+                "noValidation": true
+              },
+              "type": "map[string]any"
+            }
+          },
+          "mpl": {
+            "description": "MPL query string. Preferred over 'apl'.",
+            "type": "string"
+          },
+          "params": {
+            "description": "Query parameters forwarded to MetricsDB (e.g. for filterbar variable binding)",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "queryEdgeDeployment": {
+            "description": "The edge deployment the query should be run in. If not specified, the query will be run in the default edge deployment of the org. Takes precedence over queryRegion.",
+            "type": "string"
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/MetricsQueryOptions"
+          },
+          "queryRegion": {
+            "description": "The region the query should be run in. If not specified, the query will be run in the default region of the org.",
+            "type": "string"
+          },
+          "startTime": {
+            "description": "start and end time for the query, these must be specified as RFC3339 strings\nor using relative time expressions (e.g. now-1h, now-1d, now-1w, etc)",
+            "type": "string"
+          }
+        }
+      },
+      "MetricsResult": {
+        "description": "Metrics query result (streaming binary data)",
+        "type": "object"
+      },
+      "QueryError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Status is the http status code associated with this error",
+            "type": "integer"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/QueryErrorDetail"
+          },
+          "message": {
+            "description": "a formatted user-facing error message",
+            "type": "string"
+          }
+        }
+      },
+      "QueryErrorDetail": {
+        "type": "object",
+        "properties": {
+          "column": {
+            "description": "Column is the column associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "compileErrorCode": {
+            "description": "CompileErrorCode is a special error code that is only available for Compile Errors\nIt is an integer value that can be used to identify the error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              16,
+              17,
+              32,
+              33,
+              34
+            ]
+          },
+          "errorType": {
+            "description": "Error Type is an integer value indicating the kind of error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          },
+          "line": {
+            "description": "Line is the line associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "description": "Message is the raw error message without any formatting",
+            "type": "string"
+          }
+        }
+      },
+      "QueryOptions": {
+        "type": "object",
+        "properties": {
+          "against": {
+            "type": "string"
+          },
+          "againstStart": {
+            "type": "string"
+          },
+          "againstTimestamp": {
+            "type": "string"
+          },
+          "aggChartOpts": {
+            "type": "string"
+          },
+          "caseSensitive": {
+            "type": "string"
+          },
+          "containsTimeFilter": {
+            "type": "string"
+          },
+          "datasets": {
+            "type": "string"
+          },
+          "displayNull": {
+            "type": "string"
+          },
+          "editorContent": {
+            "type": "string"
+          },
+          "endColumn": {
+            "type": "string"
+          },
+          "endLineNumber": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "integrationsFilter": {
+            "type": "string"
+          },
+          "nanosecondPrecision": {
+            "type": "string"
+          },
+          "openIntervals": {
+            "type": "string"
+          },
+          "overlayCharts": {
+            "type": "string"
+          },
+          "queryObject": {
+            "type": "string"
+          },
+          "quickRange": {
+            "type": "string"
+          },
+          "resolution": {
+            "type": "string"
+          },
+          "resultsHistogram": {
+            "type": "string"
+          },
+          "selection": {
+            "type": "string"
+          },
+          "shownColumns": {
+            "type": "string"
+          },
+          "startColumn": {
+            "type": "string"
+          },
+          "startLineNumber": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "timeSeriesVariant": {
+            "type": "string"
+          },
+          "timeSeriesView": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/restapi/source/v1.json
+++ b/restapi/source/v1.json
@@ -897,264 +897,264 @@
         "example": {
           "format": "tabular",
           "status": {
-            "elapsedTime": 260650,
-            "minCursor": "0d8q6stroluyo-07c3957e7400015c-0000c875",
-            "maxCursor": "0d8q6stroluyo-07c3957e7400015c-0000c877",
-            "blocksExamined": 4,
-            "blocksCached": 0,
-            "blocksMatched": 0,
-            "rowsExamined": 197604,
-            "rowsMatched": 197604,
-            "numGroups": 0,
-            "isPartial": false,
-            "cacheStatus": 1,
-            "minBlockTime": "2025-03-26T12:03:14Z",
-            "maxBlockTime": "2025-03-26T12:12:42Z"
+              "elapsedTime": 260650,
+              "minCursor": "0d8q6stroluyo-07c3957e7400015c-0000c875",
+              "maxCursor": "0d8q6stroluyo-07c3957e7400015c-0000c877",
+              "blocksExamined": 4,
+              "blocksCached": 0,
+              "blocksMatched": 0,
+              "rowsExamined": 197604,
+              "rowsMatched": 197604,
+              "numGroups": 0,
+              "isPartial": false,
+              "cacheStatus": 1,
+              "minBlockTime": "2025-03-26T12:03:14Z",
+              "maxBlockTime": "2025-03-26T12:12:42Z"
           },
           "tables": [
-            {
-              "name": "0",
-              "sources": [
-                {
-                  "name": "dataset-name"
-                }
-              ],
-              "fields": [
-                {
-                  "name": "_sysTime",
-                  "type": "datetime"
-                },
-                {
-                  "name": "_time",
-                  "type": "datetime"
-                },
-                {
-                  "name": "content_type",
-                  "type": "string"
-                },
-                {
-                  "name": "geo.city",
-                  "type": "string"
-                },
-                {
-                  "name": "geo.country",
-                  "type": "string"
-                },
-                {
-                  "name": "id",
-                  "type": "string"
-                },
-                {
-                  "name": "is_tls",
-                  "type": "boolean"
-                },
-                {
-                  "name": "message",
-                  "type": "string"
-                },
-                {
-                  "name": "method",
-                  "type": "string"
-                },
-                {
-                  "name": "req_duration_ms",
-                  "type": "float"
-                },
-                {
-                  "name": "resp_body_size_bytes",
-                  "type": "integer"
-                },
-                {
-                  "name": "resp_header_size_bytes",
-                  "type": "integer"
-                },
-                {
-                  "name": "server_datacenter",
-                  "type": "string"
-                },
-                {
-                  "name": "status",
-                  "type": "string"
-                },
-                {
-                  "name": "uri",
-                  "type": "string"
-                },
-                {
-                  "name": "user_agent",
-                  "type": "string"
-                },
-                {
-                  "name": "is_ok_2    ",
-                  "type": "boolean"
-                },
-                {
-                  "name": "city_str_len",
-                  "type": "integer"
-                }
-              ],
-              "order": [
-                {
-                  "field": "_time",
-                  "desc": true
-                }
-              ],
-              "groups": [],
-              "range": {
-                "field": "_time",
-                "start": "1970-01-01T00:00:00Z",
-                "end": "2025-03-26T12:12:43Z"
-              },
-              "columns": [
-                [
-                  "2025-03-26T12:12:42.68112905Z",
-                  "2025-03-26T12:12:42.68112905Z",
-                  "2025-03-26T12:12:42.68112905Z"
-                ],
-                [
-                  "2025-03-26T12:12:42Z",
-                  "2025-03-26T12:12:42Z",
-                  "2025-03-26T12:12:42Z"
-                ],
-                [
-                  "text/html",
-                  "text/plain-charset=utf-8",
-                  "image/jpeg"
-                ],
-                [
-                  "Ojinaga",
-                  "Humboldt",
-                  "Nevers"
-                ],
-                [
-                  "Mexico",
-                  "United States",
-                  "France"
-                ],
-                [
-                  "8af366cf-6f25-42e6-bbb4-d860ab535a60",
-                  "032e7f68-b0ab-47c0-a24a-35af566359e5",
-                  "4d2c7baa-ff28-4b1f-9db9-8e6c0ed5a9c9"
-                ],
-                [
-                  false,
-                  false,
-                  true
-                ],
-                [
-                  "QCD permutations were not solvable in linear time, expected compressed time",
-                  "QCD permutations were not solvable in linear time, expected compressed time",
-                  "Expected a new layer of particle physics but got a Higgs Boson"
-                ],
-                [
-                  "GET",
-                  "GET",
-                  "GET"
-                ],
-                [
-                  1.396373193863436,
-                  0.16252390534308514,
-                  0.4093416175186162
-                ],
-                [
-                  3448,
-                  2533,
-                  1906
-                ],
-                [
-                  84,
-                  31,
-                  29
-                ],
-                [
-                  "DCA",
-                  "GRU",
-                  "FRA"
-                ],
-                [
-                  "201",
-                  "200",
-                  "200"
-                ],
-                [
-                  "/api/v1/buy/commit/id/go",
-                  "/api/v1/textdata/cnfigs",
-                  "/api/v1/bank/warn"
-                ],
-                [
-                  "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
-                  "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/535.24 (KHTML, like Gecko) Chrome/19.0.1055.1 Safari/535.24",
-                  "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
-                ],
-                [
-                  true,
-                  true,
-                  true
-                ],
-                [
-                  7,
-                  8,
-                  6
-                ]
-              ]
-            }
-          ],
-          "datasetNames": [
-            "dataset-name"
-          ],
-          "fieldsMetaMap": {
-            "dataset-name": [
               {
-                "name": "status",
-                "type": "",
-                "unit": "",
-                "hidden": false,
-                "description": "HTTP status code"
-              },
-              {
-                "name": "resp_header_size_bytes",
-                "type": "integer",
-                "unit": "none",
-                "hidden": false,
-                "description": ""
-              },
-              {
-                "name": "geo.city",
-                "type": "string",
-                "unit": "",
-                "hidden": false,
-                "description": "the city"
-              },
-              {
-                "name": "resp_body_size_bytes",
-                "type": "integer",
-                "unit": "decbytes",
-                "hidden": false,
-                "description": ""
-              },
-              {
-                "name": "content_type",
-                "type": "string",
-                "unit": "",
-                "hidden": false,
-                "description": ""
-              },
-              {
-                "name": "geo.country",
-                "type": "string",
-                "unit": "",
-                "hidden": false,
-                "description": ""
-              },
-              {
-                "name": "req_duration_ms",
-                "type": "float",
-                "unit": "ms",
-                "hidden": false,
-                "description": "Request duration"
+                  "name": "0",
+                  "sources": [
+                      {
+                          "name": "dataset-name"
+                      }
+                  ],
+                  "fields": [
+                      {
+                          "name": "_sysTime",
+                          "type": "datetime"
+                      },
+                      {
+                          "name": "_time",
+                          "type": "datetime"
+                      },
+                      {
+                          "name": "content_type",
+                          "type": "string"
+                      },
+                      {
+                          "name": "geo.city",
+                          "type": "string"
+                      },
+                      {
+                          "name": "geo.country",
+                          "type": "string"
+                      },
+                      {
+                          "name": "id",
+                          "type": "string"
+                      },
+                      {
+                          "name": "is_tls",
+                          "type": "boolean"
+                      },
+                      {
+                          "name": "message",
+                          "type": "string"
+                      },
+                      {
+                          "name": "method",
+                          "type": "string"
+                      },
+                      {
+                          "name": "req_duration_ms",
+                          "type": "float"
+                      },
+                      {
+                          "name": "resp_body_size_bytes",
+                          "type": "integer"
+                      },
+                      {
+                          "name": "resp_header_size_bytes",
+                          "type": "integer"
+                      },
+                      {
+                          "name": "server_datacenter",
+                          "type": "string"
+                      },
+                      {
+                          "name": "status",
+                          "type": "string"
+                      },
+                      {
+                          "name": "uri",
+                          "type": "string"
+                      },
+                      {
+                          "name": "user_agent",
+                          "type": "string"
+                      },
+                      {
+                          "name": "is_ok_2    ",
+                          "type": "boolean"
+                      },
+                      {
+                          "name": "city_str_len",
+                          "type": "integer"
+                      }
+                  ],
+                  "order": [
+                      {
+                          "field": "_time",
+                          "desc": true
+                      }
+                  ],
+                  "groups": [],
+                  "range": {
+                      "field": "_time",
+                      "start": "1970-01-01T00:00:00Z",
+                      "end": "2025-03-26T12:12:43Z"
+                  },
+                  "columns": [
+                      [
+                          "2025-03-26T12:12:42.68112905Z",
+                          "2025-03-26T12:12:42.68112905Z",
+                          "2025-03-26T12:12:42.68112905Z"
+                      ],
+                      [
+                          "2025-03-26T12:12:42Z",
+                          "2025-03-26T12:12:42Z",
+                          "2025-03-26T12:12:42Z"
+                      ],
+                      [
+                          "text/html",
+                          "text/plain-charset=utf-8",
+                          "image/jpeg"
+                      ],
+                      [
+                          "Ojinaga",
+                          "Humboldt",
+                          "Nevers"
+                      ],
+                      [
+                          "Mexico",
+                          "United States",
+                          "France"
+                      ],
+                      [
+                          "8af366cf-6f25-42e6-bbb4-d860ab535a60",
+                          "032e7f68-b0ab-47c0-a24a-35af566359e5",
+                          "4d2c7baa-ff28-4b1f-9db9-8e6c0ed5a9c9"
+                      ],
+                      [
+                          false,
+                          false,
+                          true
+                      ],
+                      [
+                          "QCD permutations were not solvable in linear time, expected compressed time",
+                          "QCD permutations were not solvable in linear time, expected compressed time",
+                          "Expected a new layer of particle physics but got a Higgs Boson"
+                      ],
+                      [
+                          "GET",
+                          "GET",
+                          "GET"
+                      ],
+                      [
+                          1.396373193863436,
+                          0.16252390534308514,
+                          0.4093416175186162
+                      ],
+                      [
+                          3448,
+                          2533,
+                          1906
+                      ],
+                      [
+                          84,
+                          31,
+                          29
+                      ],
+                      [
+                          "DCA",
+                          "GRU",
+                          "FRA"
+                      ],
+                      [
+                          "201",
+                          "200",
+                          "200"
+                      ],
+                      [
+                          "/api/v1/buy/commit/id/go",
+                          "/api/v1/textdata/cnfigs",
+                          "/api/v1/bank/warn"
+                      ],
+                      [
+                          "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
+                          "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/535.24 (KHTML, like Gecko) Chrome/19.0.1055.1 Safari/535.24",
+                          "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
+                      ],
+                      [
+                          true,
+                          true,
+                          true
+                      ],
+                      [
+                          7,
+                          8,
+                          6
+                      ]
+                  ]
               }
-            ]
-          }
+            ],
+            "datasetNames": [
+                "dataset-name"
+            ],
+            "fieldsMetaMap": {
+                "dataset-name": [
+                    {
+                        "name": "status",
+                        "type": "",
+                        "unit": "",
+                        "hidden": false,
+                        "description": "HTTP status code"
+                    },
+                    {
+                        "name": "resp_header_size_bytes",
+                        "type": "integer",
+                        "unit": "none",
+                        "hidden": false,
+                        "description": ""
+                    },
+                    {
+                        "name": "geo.city",
+                        "type": "string",
+                        "unit": "",
+                        "hidden": false,
+                        "description": "the city"
+                    },
+                    {
+                        "name": "resp_body_size_bytes",
+                        "type": "integer",
+                        "unit": "decbytes",
+                        "hidden": false,
+                        "description": ""
+                    },
+                    {
+                        "name": "content_type",
+                        "type": "string",
+                        "unit": "",
+                        "hidden": false,
+                        "description": ""
+                    },
+                    {
+                        "name": "geo.country",
+                        "type": "string",
+                        "unit": "",
+                        "hidden": false,
+                        "description": ""
+                    },
+                    {
+                        "name": "req_duration_ms",
+                        "type": "float",
+                        "unit": "ms",
+                        "hidden": false,
+                        "description": "Request duration"
+                    }
+                ]
+            }
         },
         "x-go-type": {
           "hints": {

--- a/restapi/source/v2.json
+++ b/restapi/source/v2.json
@@ -1,0 +1,8713 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "A public and stable API for interacting with axiom services",
+    "title": "Axiom",
+    "termsOfService": "http://axiom.co/terms",
+    "contact": {
+      "name": "Axiom support team",
+      "url": "https://axiom.co",
+      "email": "hello@axiom.co"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "2.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.axiom.co/v2/"
+    }
+  ],
+  "paths": {
+    "/annotations": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "annotations|read"
+            ]
+          }
+        ],
+        "description": "Get annotations",
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "getAnnotations",
+        "parameters": [
+          {
+            "description": "Optional: Filter for dataset names.",
+            "name": "datasets",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Optional: Filter for events after this date. Use RFC3339 time format.",
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional: Filter for events before this date. Use RFC3339 time format.",
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Annotation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Annotation"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "annotations|create"
+            ]
+          }
+        ],
+        "description": "Create annotation",
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "createAnnotation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAnnotation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Annotation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotations/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "annotations|read"
+            ]
+          }
+        ],
+        "description": "Get annotation by ID",
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "getAnnotation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Annotation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "annotations|update"
+            ]
+          }
+        ],
+        "description": "Update annotation",
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "updateAnnotation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatedAnnotation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Annotation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "annotations|delete"
+            ]
+          }
+        ],
+        "description": "Delete annotation",
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "deleteAnnotation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/datasets": {
+      "get": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "description": "Get list of datasets",
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Get list of datasets",
+        "operationId": "getDatasets",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Dataset"
+                  },
+                  "example": [
+                    {
+                      "created": "2020-01-01T00:00:00Z",
+                      "description": "This is an example dataset",
+                      "id": "example-dataset",
+                      "name": "example-dataset",
+                      "who": "John Doe"
+                    },
+                    {
+                      "created": "2020-02-01T00:00:00Z",
+                      "description": "This is an example dataset",
+                      "id": "example-dataset-2",
+                      "name": "example-dataset-2",
+                      "who": "Foo Bar"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|create"
+            ]
+          }
+        ],
+        "description": "Create dataset",
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Create dataset",
+        "operationId": "createDataset",
+        "parameters": [
+          {
+            "description": "Referrer slug",
+            "name": "referrer",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDataset"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dataset"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/datasets/{dataset_id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "description": "Get dataset by ID",
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Get dataset by ID",
+        "operationId": "getDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dataset"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|update"
+            ]
+          }
+        ],
+        "description": "Update dataset",
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Update dataset",
+        "operationId": "updateDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDataset"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Dataset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dataset"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|delete"
+            ]
+          }
+        ],
+        "description": "Delete dataset",
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Delete dataset",
+        "operationId": "deleteDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/datasets/{dataset_id}/trim": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "trim|update"
+            ]
+          }
+        ],
+        "description": "Trim dataset",
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Trim dataset by duration",
+        "operationId": "trimDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrimOptions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "TrimResult"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/datasets/{dataset_id}/vacuum": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "vacuum|update"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "vacuumDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VacuumResult"
+          },
+          "429": {
+            "description": "TooManyVacuumRequests",
+            "headers": {
+              "Retry-After": {
+                "description": "The GMT date/time at which the current rate limit window resets.\n",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/fields": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|read"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "getFieldsForDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of fields in the dataset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DatasetField"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/fields/{field_id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|read"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "getFieldForDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "field_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "DatasetField",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetField"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|update"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "updateFieldForDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "field_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetField"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "DatasetField",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetField"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets/{dataset_id}/mapfields": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|read"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "getMapFields",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MapFields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapFields"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-not-suspended": true
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|update"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "updateMapFields",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MapFields"
+              }
+            }
+          },
+          "description": "A list of MapField-names",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A list of map field names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapFields"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-not-suspended": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|update"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "createMapField",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MapField"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A mapfield, described by a name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MapField"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/datasets/{dataset_id}/mapfields/{map_field_name}": {
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "datasets|update"
+            ]
+          }
+        ],
+        "tags": [
+          "datasets"
+        ],
+        "operationId": "deleteMapField",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "map_field_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        },
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/monitors": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|read"
+            ]
+          }
+        ],
+        "description": "Lists all configured monitors. Returns an array of monitor configurations including their IDs and current status.",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "getMonitors",
+        "responses": {
+          "200": {
+            "description": "Monitor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MonitorWithId"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|create"
+            ]
+          }
+        ],
+        "description": "Create monitor",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "createMonitor",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Monitor"
+        },
+        "responses": {
+          "200": {
+            "description": "Monitor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MonitorWithId"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/monitors/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|read"
+            ]
+          }
+        ],
+        "description": "Retrieves detailed configuration for a specific monitor by its unique identifier",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "getMonitor",
+        "parameters": [
+          {
+            "description": "Unique identifier of the monitor (format: mon_*)",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Monitor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MonitorWithId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|update"
+            ]
+          }
+        ],
+        "description": "Update monitor",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "updateMonitor",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Monitor"
+        },
+        "responses": {
+          "200": {
+            "description": "Monitor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MonitorWithId"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|delete"
+            ]
+          }
+        ],
+        "description": "Delete monitor",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "deleteMonitor",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/monitors/{id}/history": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "monitors|read"
+            ]
+          }
+        ],
+        "description": "Get monitor history",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "getMonitorHistory",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start time (ISO 8601 format) for filtering alert history.",
+            "name": "startTime",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "description": "End time (ISO 8601 format) for filtering alert history.",
+            "name": "endTime",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AlertHistory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlertHistory"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/notifiers": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "notifiers|read"
+            ]
+          }
+        ],
+        "description": "Lists all configured notifiers. Returns an array of notification configurations including their IDs and current status.",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "getNotifiers",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved list of notifiers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotifierWithId"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "notifiers|create"
+            ]
+          }
+        ],
+        "description": "Creates a new notifier configuration for sending alerts through various channels (Slack, Email, etc)",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "createNotifier",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Notifier"
+              }
+            }
+          },
+          "description": "Notifier configuration details",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Notifier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotifierWithId"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/notifiers/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "notifiers|read"
+            ]
+          }
+        ],
+        "description": "Retrieves detailed configuration for a specific notifier by its unique identifier",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "getNotifier",
+        "parameters": [
+          {
+            "description": "Unique identifier of the notifier (format: notify_*)",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notifier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotifierWithId"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "notifiers|update"
+            ]
+          }
+        ],
+        "description": "Update notifier",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "updateNotifier",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Notifier"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Notifier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotifierWithId"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "notifiers|delete"
+            ]
+          }
+        ],
+        "description": "Delete notifier",
+        "tags": [
+          "Monitors"
+        ],
+        "operationId": "deleteNotifier",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/orgs": {
+      "get": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "tags": [
+          "orgs"
+        ],
+        "operationId": "getOrgs",
+        "responses": {
+          "200": {
+            "description": "Org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Org"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-no-org-required": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "tags": [
+          "orgs"
+        ],
+        "operationId": "createOrg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostOrg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Org"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-no-org-required": true
+      }
+    },
+    "/orgs/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "tags": [
+          "orgs"
+        ],
+        "operationId": "getOrg",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Org"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "tags": [
+          "orgs"
+        ],
+        "operationId": "updateOrg",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOrg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Org"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rbac/roles": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|read"
+            ]
+          }
+        ],
+        "description": "Retrieves all roles in the organization with their associated permissions and members.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "List all roles",
+        "operationId": "listRoles",
+        "responses": {
+          "200": {
+            "description": "A list of roles was successfully retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RoleWithID"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Creates a new role in the organization with the specified permissions and member assignments.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Create role",
+        "operationId": "createRole",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Role"
+              }
+            }
+          },
+          "description": "The role configuration containing name, description, members, and capability settings",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The role was successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithID"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rbac/roles/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|read"
+            ]
+          }
+        ],
+        "description": "Retrieves detailed information about a specific role by its unique identifier.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Get role by ID",
+        "operationId": "getRoleById",
+        "parameters": [
+          {
+            "description": "Unique identifier of the role to retrieve",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The role was successfully retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithID"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Updates an existing role's configuration including its permissions and member assignments.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Update role",
+        "operationId": "updateRole",
+        "parameters": [
+          {
+            "description": "Unique identifier of the role to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Role"
+              }
+            }
+          },
+          "description": "The updated role configuration",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The role was successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleWithID"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Permanently removes a role from the organization.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Delete role",
+        "operationId": "deleteRole",
+        "parameters": [
+          {
+            "description": "Unique identifier of the role to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The role was successfully deleted"
+          }
+        }
+      }
+    },
+    "/rbac/groups": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|read"
+            ]
+          }
+        ],
+        "description": "Retrieves all groups in the organization.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "List all groups",
+        "operationId": "listGroups",
+        "responses": {
+          "200": {
+            "description": "A list of groups was successfully retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupWithID"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Creates a new group in the organization.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Create group",
+        "operationId": "createGroup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Group"
+              }
+            }
+          },
+          "description": "The group configuration",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The group was successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupWithID"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rbac/groups/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|read"
+            ]
+          }
+        ],
+        "description": "Retrieves detailed information about a specific group by its unique identifier.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Get group by ID",
+        "operationId": "getGroupById",
+        "parameters": [
+          {
+            "description": "Unique identifier of the group to retrieve",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The group was successfully retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupWithID"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Updates an existing group's configuration.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Update group",
+        "operationId": "updateGroup",
+        "parameters": [
+          {
+            "description": "Unique identifier of the group to update",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Group"
+              }
+            }
+          },
+          "description": "The updated group configuration",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The group was successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupWithID"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "rbac|create"
+            ]
+          }
+        ],
+        "description": "Permanently removes a group from the organization.",
+        "tags": [
+          "rbac"
+        ],
+        "summary": "Delete group",
+        "operationId": "deleteGroup",
+        "parameters": [
+          {
+            "description": "Unique identifier of the group to delete",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The group was successfully deleted"
+          }
+        }
+      }
+    },
+    "/apl-starred-queries": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "starredQueries|read"
+            ]
+          }
+        ],
+        "tags": [
+          "starred"
+        ],
+        "operationId": "getStarredQueries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "name": "dataset",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "- If the value of `who` is undefined, the request returns queries starred by the authenticated user.\n- If the value of `who` is a user ID, the request returns queries starred by the user with this ID (this request requires elevated privileges). For example, `&who='abc123'`.\n- If the value of `who` is `team`, the request returns queries starred by the team apart from the authenticated user.For example, `&who=team`.\n- If the value of `who` is `all`, the request returns queries starred by all users in the team, including the authenticated user. For example, `&who=all`.",
+            "name": "who",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "qs",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "StarredQueryWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StarredQueryWithId"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "starredQueries|create"
+            ]
+          }
+        ],
+        "tags": [
+          "starred"
+        ],
+        "operationId": "createStarred",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StarredQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "StarredQueryWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StarredQueryWithId"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apl-starred-queries/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "starredQueries|read"
+            ]
+          }
+        ],
+        "tags": [
+          "starred"
+        ],
+        "operationId": "getStarred",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "StarredQueryWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StarredQueryWithId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "starredQueries|update"
+            ]
+          }
+        ],
+        "tags": [
+          "starred"
+        ],
+        "operationId": "updateStarred",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/StarredQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "StarredQueryWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StarredQueryWithId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "starredQueries|delete"
+            ]
+          }
+        ],
+        "tags": [
+          "starred"
+        ],
+        "operationId": "deleteStarred",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        }
+      }
+    },
+    "/tokens": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "apiTokens|read"
+            ]
+          }
+        ],
+        "description": "Get API tokens",
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "getAPITokens",
+        "responses": {
+          "200": {
+            "description": "Token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/APIToken"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "apiTokens|create"
+            ]
+          }
+        ],
+        "description": "Create API token",
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "createAPIToken",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAPIToken"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "CreateApiTokenResponse",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAPITokenResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/tokens/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "apiTokens|read"
+            ]
+          }
+        ],
+        "description": "Get API token by ID",
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "getAPIToken",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIToken"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "apiTokens|delete"
+            ]
+          }
+        ],
+        "description": "Delete API token",
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "deleteAPIToken",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        }
+      }
+    },
+    "/tokens/{id}/regenerate": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "apiTokens|update"
+            ]
+          }
+        ],
+        "description": "Regenerate API token",
+        "tags": [
+          "tokens"
+        ],
+        "operationId": "regenerateAPIToken",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegenerateAPIToken"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "CreateAPITokenResponse",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAPITokenResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/user": {
+      "get": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "description": "Get current user",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-no-org-required": true,
+        "x-axiom-preview": true
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": []
+          }
+        ],
+        "description": "Update current user",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "updateCurrentUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCurrentUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-no-org-required": true,
+        "x-axiom-preview": true
+      }
+    },
+    "/users": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "users|read"
+            ]
+          }
+        ],
+        "description": "Get users",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "getUsers",
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "users|create"
+            ]
+          }
+        ],
+        "description": "Create user",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-no-org-required": true,
+        "x-axiom-not-suspended": true,
+        "x-axiom-preview": true
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "users|read"
+            ]
+          }
+        ],
+        "description": "Get user by ID",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "getUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "users|delete"
+            ]
+          }
+        ],
+        "description": "Remove user from org",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "removeUserFromOrg",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/users/{id}/role": {
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "users|update"
+            ]
+          }
+        ],
+        "description": "Update user role",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "updateUserRole",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
+    "/vfields": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "virtualFields|read"
+            ]
+          }
+        ],
+        "tags": [
+          "vfields"
+        ],
+        "operationId": "getVirtualFields",
+        "parameters": [
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VirtualFieldWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirtualFieldWithId"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "virtualFields|create"
+            ]
+          }
+        ],
+        "tags": [
+          "vfields"
+        ],
+        "operationId": "createVirtualField",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/VirtualField"
+        },
+        "responses": {
+          "200": {
+            "description": "VirtualFieldWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualFieldWithId"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vfields/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "virtualFields|read"
+            ]
+          }
+        ],
+        "tags": [
+          "vfields"
+        ],
+        "operationId": "getVirtualField",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "VirtualFieldWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualFieldWithId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "virtualFields|update"
+            ]
+          }
+        ],
+        "tags": [
+          "vfields"
+        ],
+        "operationId": "updateVirtualField",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/VirtualField"
+        },
+        "responses": {
+          "200": {
+            "description": "VirtualFieldWithId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VirtualFieldWithId"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "virtualFields|delete"
+            ]
+          }
+        ],
+        "tags": [
+          "vfields"
+        ],
+        "operationId": "deleteVirtualField",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        }
+      }
+    },
+    "/views": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "views|read"
+            ]
+          }
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "getViews",
+        "responses": {
+          "200": {
+            "description": "View",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/View"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "views|create"
+            ]
+          }
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "createView",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/View"
+        },
+        "responses": {
+          "200": {
+            "description": "View",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/View"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/views/{id}": {
+      "get": {
+        "security": [
+          {
+            "Auth": [
+              "views|read"
+            ]
+          }
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "getView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "View",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/View"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Auth": [
+              "views|update"
+            ]
+          }
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "updateView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/View"
+        },
+        "responses": {
+          "200": {
+            "description": "View",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/View"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "views|delete"
+            ]
+          }
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "deleteView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "(empty)"
+          }
+        }
+      }
+    },
+    "/dashboards": {
+      "get": {
+        "tags": [
+          "dashboards"
+        ],
+        "summary": "List dashboards",
+        "description": "List dashboards visible to the caller.",
+        "operationId": "listDashboards",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of dashboards",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "dashboards"
+        ],
+        "summary": "Create dashboard",
+        "description": "Create a dashboard from a dashboard document payload.",
+        "operationId": "createDashboard",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardUpsertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated dashboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardWriteResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created dashboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardWriteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid dashboard payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Dashboard already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/uid/{uid}": {
+      "get": {
+        "tags": [
+          "dashboards"
+        ],
+        "summary": "Get dashboard",
+        "description": "Get a dashboard by UID.",
+        "operationId": "getDashboard",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dashboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResource"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dashboard not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "dashboards"
+        ],
+        "summary": "Update dashboard",
+        "description": "Update a dashboard by UID.",
+        "operationId": "updateDashboard",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardUpsertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated dashboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardWriteResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created dashboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardWriteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid dashboard payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Dashboard already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Version conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "dashboards"
+        ],
+        "summary": "Delete dashboard",
+        "description": "Delete a dashboard by UID.",
+        "operationId": "deleteDashboard",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "uid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Dashboard deleted"
+          },
+          "404": {
+            "description": "Dashboard not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100
+        }
+      },
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "id": {
+        "description": "Unique ID of the annotation",
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^ann_"
+        }
+      }
+    },
+    "responses": {
+      "ForbiddenError": {
+        "description": "Forbidden",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "example": {
+                "code": 403,
+                "message": "Forbidden"
+              }
+            }
+          }
+        }
+      },
+      "NotFoundError": {
+        "description": "Not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "example": {
+                "code": 404,
+                "message": "Not found"
+              }
+            }
+          }
+        }
+      }
+    },
+    "requestBodies": {
+      "FlowDestination": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FlowDestination"
+            }
+          }
+        },
+        "required": true
+      },
+      "Repo": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Repo"
+            }
+          }
+        },
+        "required": true
+      },
+      "View": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/View"
+            }
+          }
+        },
+        "required": true
+      },
+      "DashboardUpsertRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DashboardUpsertRequest"
+            }
+          }
+        },
+        "required": true
+      },
+      "StarredQuery": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/StarredQuery"
+            }
+          }
+        },
+        "required": true
+      },
+      "Monitor": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Monitor"
+            }
+          }
+        },
+        "required": true
+      },
+      "VirtualField": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/VirtualField"
+            }
+          }
+        },
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "Auth": {
+        "description": "Authenticate using an API token or personal access token (PAT). Include the token as a Bearer token: `Authorization: Bearer <token>`. For more information, see [Tokens](/reference/tokens).",
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+            "scopes": {}
+          }
+        }
+      },
+      "Shared": {
+        "type": "apiKey",
+        "name": "tk",
+        "in": "query"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Authenticate using an API token or personal access token (PAT). Include the token as a Bearer token: `Authorization: Bearer <token>`. For more information, see [Tokens](/reference/tokens)."
+      }
+    },
+    "schemas": {
+      "APIToken": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "datasetCapabilities",
+          "orgCapabilities"
+        ],
+        "properties": {
+          "datasetCapabilities": {
+            "$ref": "#/components/schemas/datasetCapabilities"
+          },
+          "description": {
+            "description": "Description of the token",
+            "type": "string"
+          },
+          "expiresAt": {
+            "description": "Expiration date of the token (ISO 8601 format)",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true,
+            "nullable": true
+          },
+          "id": {
+            "description": "ID of the token",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the token",
+            "type": "string"
+          },
+          "orgCapabilities": {
+            "$ref": "#/components/schemas/orgCapabilities"
+          },
+          "samlAuthenticated": {
+            "type": "boolean"
+          },
+          "viewCapabilities": {
+            "$ref": "#/components/schemas/viewCapabilities"
+          }
+        }
+      },
+      "APLRequestWithOptions": {
+        "type": "object",
+        "required": [
+          "apl"
+        ],
+        "properties": {
+          "apl": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "defaultLimit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "defaultOrder": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/APLRequestWithOptionsDefaultOrder"
+            }
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "includeCursor": {
+            "type": "boolean"
+          },
+          "includeCursorField": {
+            "type": "boolean"
+          },
+          "libraries": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/QueryOptions"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "object"
+          }
+        }
+      },
+      "APLRequestWithOptionsDefaultOrder": {
+        "type": "object",
+        "properties": {
+          "desc": {
+            "type": "boolean"
+          },
+          "field": {
+            "type": "string"
+          }
+        }
+      },
+      "AggInfo": {
+        "description": "AggInfo captures information about an aggregation",
+        "type": "object",
+        "properties": {
+          "args": {
+            "description": "Args specifies any non-field arguments for the aggregation. Fx. [10] for topk(players, 10).",
+            "type": "array",
+            "items": {}
+          },
+          "fields": {
+            "description": "Fields specifies the names of the fields this aggregation is computed on.\nFx [\"players\"] for topk(players, 10)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "Name is the system name of the aggregation, which is the string form of aggregation.Type.\nIf the aggregation is aliased, the alias is stored in the parent FieldInfo",
+            "type": "string"
+          }
+        }
+      },
+      "AlertHistory": {
+        "description": "Historical record of an alert's state changes.\nTracks when alerts are opened and closed, allowing for incident timeline analysis.\n",
+        "type": "object",
+        "required": [
+          "name",
+          "checkId",
+          "timestamp",
+          "state"
+        ],
+        "properties": {
+          "checkId": {
+            "description": "Unique identifier of the check that triggered the alert",
+            "type": "string",
+            "example": "chk_abc123"
+          },
+          "name": {
+            "description": "The name of the alert",
+            "type": "string",
+            "example": "High CPU Usage Alert"
+          },
+          "state": {
+            "description": "Current state of the alert",
+            "type": "string",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "example": "open"
+          },
+          "timestamp": {
+            "description": "ISO 8601 timestamp when the alert state changed",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-03-20T15:30:00Z"
+          }
+        }
+      },
+      "Annotation": {
+        "type": "object",
+        "required": [
+          "id",
+          "time",
+          "datasets",
+          "type"
+        ],
+        "properties": {
+          "datasets": {
+            "description": "array<string> of dataset names for which the annotation appears on charts",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "description": {
+            "description": "Explanation of the event the annotation marks on the charts",
+            "type": "string",
+            "maxLength": 512
+          },
+          "endTime": {
+            "description": "End time of the annotation",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "$ref": "#/components/schemas/AnnotationID"
+          },
+          "time": {
+            "description": "Time the annotation marks on the charts. If you don't include this field, Axiom assigns the time of the API request to the annotation.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "description": "Summary of the annotation that appears on the charts",
+            "type": "string",
+            "maxLength": 256
+          },
+          "type": {
+            "description": "Type of the event marked by the annotation. Use only alphanumeric characters or hyphens. For example, \"production-deployment\".",
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "url": {
+            "description": "URL relevant for the event marked by the annotation. For example, link to GitHub pull request.",
+            "type": "string",
+            "maxLength": 512
+          }
+        },
+        "example": {
+          "datasets": [
+            "my-dataset"
+          ],
+          "description": "Deploy new feature to the sales form",
+          "endTime": "2024-02-06T11:39:28.382Z",
+          "id": "ann_123",
+          "time": "2024-02-06T10:39:28.382Z",
+          "title": "Production deployment",
+          "type": "deploy",
+          "url": "https://example.com"
+        }
+      },
+      "AnnotationID": {
+        "type": "string",
+        "x-go-type": {
+          "import": {
+            "package": "github.com/axiomhq/axiom/pkg/core/ids"
+          },
+          "type": "AnnotationID"
+        }
+      },
+      "AplDeletionRequest": {
+        "type": "object",
+        "required": [
+          "apl",
+          "commit"
+        ],
+        "properties": {
+          "Modules": {
+            "description": "Key-value pairs of module names and module sources. Axiom will make modules available for this query later.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "apl": {
+            "type": "string"
+          },
+          "commit": {
+            "type": "boolean"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "startTime": {
+            "description": "start and end time for the query, these must be specified as RFC3339 strings\nor using relative time expressions (e.g. now-1h, now-1d, now-1w, etc)",
+            "type": "string"
+          },
+          "variables": {
+            "description": "Variables is an optional set of additional variables that are inserted into the APL",
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "AplDeletionResponse": {
+        "type": "object",
+        "required": [
+          "rowsMatched",
+          "rowsDeleted"
+        ],
+        "properties": {
+          "blocksMatched": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "dryRun": {
+            "type": "boolean"
+          },
+          "firstMatchedEvent": {
+            "description": "these are timestamps",
+            "type": "string"
+          },
+          "lastMatchedEvent": {
+            "type": "string"
+          },
+          "rowsDeleted": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "rowsMatched": {
+            "type": "integer",
+            "format": "uint64"
+          }
+        }
+      },
+      "AplModuleDefinition": {
+        "type": "object",
+        "properties": {
+          "constant": {
+            "$ref": "#/components/schemas/Constant"
+          },
+          "description": {
+            "description": "The description of the apl module definition.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier for the object.",
+            "type": "string"
+          },
+          "lookup": {
+            "$ref": "#/components/schemas/Lookup"
+          },
+          "name": {
+            "description": "The name of the apl module definition.",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "The namespace of the APL module definition.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the object.",
+            "type": "string",
+            "enum": [
+              "REGEX",
+              "CONSTANT",
+              "LOOKUP"
+            ]
+          }
+        }
+      },
+      "AplQueryError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Status is the http status code associated with this error",
+            "type": "integer"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/AplQueryErrorDetail"
+          },
+          "message": {
+            "description": "a formatted user-facing error message",
+            "type": "string"
+          }
+        }
+      },
+      "AplQueryErrorDetail": {
+        "type": "object",
+        "properties": {
+          "column": {
+            "description": "Column is the column associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "compileErrorCode": {
+            "description": "CompileErrorCode is a special error code that is only available for Compile Errors\nIt is an integer value that can be used to identify the error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              16,
+              17,
+              32,
+              33,
+              34
+            ]
+          },
+          "errorType": {
+            "description": "Error Type is an integer value indicating the kind of error",
+            "type": "integer",
+            "format": "int64",
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
+          },
+          "line": {
+            "description": "Line is the line associated with this compile type error",
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "description": "Message is the raw error message without any formatting",
+            "type": "string"
+          }
+        }
+      },
+      "AplRequest": {
+        "type": "object",
+        "required": [
+          "apl"
+        ],
+        "properties": {
+          "apl": {
+            "type": "string"
+          },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "AplResult": {
+        "type": "object",
+        "required": [
+          "status",
+          "tables"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "tables": {
+            "description": "Tables hold the result data for a query",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Table"
+            }
+          }
+        }
+      },
+      "Block": {
+        "type": "object",
+        "properties": {
+          "locatorURL": {
+            "description": "URL to locate the block in storage",
+            "type": "string",
+            "example": "block://unstable_v0/zgAQynPEQLEMsQwAAwAACAwYqTcAFGcAAAAAAAAACjgVchcAG7bpGFuQrFTOk54YW5Fr9V76LmidjehN6GOLBD7YhQAAAACS2SJheGlvbWVyc2Z0ODNheGlvbXRyYWNlc2RldnlreDdjeXJ12SxzMzovL2F4aW9tLWNsb3VkLWRldmVsb3BtZW50LWRhdGFiYXNlLTY1amJtLw=="
+          },
+          "memoryEstimate": {
+            "description": "Estimated memory usage in bytes",
+            "type": "integer",
+            "format": "int64",
+            "example": 100000
+          },
+          "recordCount": {
+            "description": "Number of records in the block",
+            "type": "integer",
+            "format": "int32",
+            "example": 10000
+          }
+        }
+      },
+      "BlockFailure": {
+        "type": "object",
+        "properties": {
+          "block": {
+            "$ref": "#/components/schemas/Block"
+          },
+          "error": {
+            "description": "Error message describing the failure",
+            "type": "string",
+            "example": "Failed to parse block data"
+          },
+          "errorCode": {
+            "description": "Error code for categorizing the failure",
+            "type": "string",
+            "example": "PARSE_ERROR"
+          }
+        }
+      },
+      "BlockSuccess": {
+        "type": "object",
+        "properties": {
+          "block": {
+            "$ref": "#/components/schemas/Block"
+          },
+          "events": {
+            "description": "Number of events processed",
+            "type": "integer",
+            "format": "int64",
+            "example": 5000
+          }
+        }
+      },
+      "BlocksRequest": {
+        "type": "object",
+        "required": [
+          "apl",
+          "startTime",
+          "endTime"
+        ],
+        "properties": {
+          "apl": {
+            "description": "The APL query to execute for finding matching blocks",
+            "type": "string",
+            "example": "['my-dataset'] | where status_code >= 400"
+          },
+          "endTime": {
+            "description": "The end time for the query time range",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-01-02T00:00:00Z"
+          },
+          "startTime": {
+            "description": "The start time for the query time range",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-01-01T00:00:00Z"
+          }
+        }
+      },
+      "BlocksResponse": {
+        "type": "object",
+        "properties": {
+          "blocks": {
+            "description": "List of blocks matching the query",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Block"
+            }
+          }
+        }
+      },
+      "BucketInfo": {
+        "description": "The standard mode of operation for Kirby is to create buckets on the _time column,",
+        "type": "object",
+        "title": "BucketInfo captures information about how a grouped query is sorted into buckets.",
+        "properties": {
+          "field": {
+            "description": "Field specifies the field used to create buckets on. Normally this would be _time.",
+            "type": "string"
+          },
+          "size": {
+            "description": "An integer or float representing the fixed bucket size.\nWhen the bucket field is _time this value is in nanoseconds."
+          }
+        }
+      },
+      "Constant": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "description": "Constant value of any type"
+          }
+        }
+      },
+      "CreateAPIToken": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "datasetCapabilities": {
+            "$ref": "#/components/schemas/datasetCapabilities"
+          },
+          "description": {
+            "description": "Description of the token",
+            "type": "string"
+          },
+          "expiresAt": {
+            "description": "Expiration date of the token (ISO 8601 format)",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "name": {
+            "description": "Name of the token",
+            "type": "string"
+          },
+          "orgCapabilities": {
+            "$ref": "#/components/schemas/orgCapabilities"
+          },
+          "viewCapabilities": {
+            "$ref": "#/components/schemas/viewCapabilities"
+          }
+        }
+      },
+      "CreateAPITokenResponse": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/APIToken"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "token": {
+                "type": "string",
+                "x-go-name": "Value"
+              }
+            }
+          }
+        ]
+      },
+      "CreateDataset": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "description": {
+            "description": "Dataset description",
+            "type": "string",
+            "default": ""
+          },
+          "edgeDeployment": {
+            "description": "Edge deployment of the dataset",
+            "type": "string",
+            "x-omitempty": true
+          },
+          "kind": {
+            "description": "The kind of the dataset",
+            "type": "string",
+            "default": "axiom:events:v1",
+            "enum": [
+              "otel:metrics:v1",
+              "otel:traces:v1",
+              "otel:logs:v1",
+              "axiom:events:v1"
+            ],
+            "example": "axiom:events:v1"
+          },
+          "name": {
+            "description": "Dataset unique name",
+            "type": "string"
+          },
+          "region": {
+            "description": "Deprecated. Use `edgeDeployment` instead.",
+            "type": "string",
+            "x-omitempty": true
+          },
+          "retentionDays": {
+            "description": "Number of days to retain data in the dataset",
+            "type": "integer",
+            "x-omitempty": false
+          },
+          "useRetentionPeriod": {
+            "description": "Whether to use the retention period",
+            "type": "boolean",
+            "x-omitempty": false
+          }
+        },
+        "example": {
+          "description": "string",
+          "kind": "axiom:events:v1",
+          "name": "string",
+          "retentionDays": 30
+        }
+      },
+      "CreateFlowExport": {
+        "type": "object",
+        "required": [
+          "destinationId",
+          "name",
+          "apl",
+          "start",
+          "end"
+        ],
+        "properties": {
+          "apl": {
+            "description": "The APL query to execute for the export",
+            "type": "string"
+          },
+          "destinationId": {
+            "description": "The destination to export to",
+            "type": "string"
+          },
+          "end": {
+            "description": "The RFC3339-formatted time of the end of the export range",
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "description": "The name of the export",
+            "type": "string"
+          },
+          "start": {
+            "description": "The RFC3339-formatted time of the start of the export range",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateUserRequest": {
+        "description": "Object representing a new user creation request",
+        "type": "object",
+        "required": [
+          "name",
+          "email",
+          "role"
+        ],
+        "properties": {
+          "email": {
+            "description": "Email address of the new user",
+            "type": "string",
+            "example": "jane.doe@example.com"
+          },
+          "name": {
+            "description": "Full name of the new user",
+            "type": "string",
+            "example": "Jane Doe"
+          },
+          "role": {
+            "description": "Role to assign to the new user",
+            "type": "string",
+            "example": "member"
+          }
+        }
+      },
+      "CustomNotifierConfig": {
+        "description": "Configuration for custom webhook notifications with flexible headers and body template.\nSupports variable substitution in the body template using {{.Variable}} syntax.\n",
+        "type": "object",
+        "required": [
+          "url",
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "description": "Template for the webhook body, supports variable substitution",
+            "type": "string",
+            "example": "{\"alert\": \"{{.AlertName}}\", \"severity\": \"{{.Severity}}\", \"message\": \"{{.Message}}\"}"
+          },
+          "headers": {
+            "description": "HTTP headers to include in the request",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {
+              "Content-Type": "application/json",
+              "X-API-Version": "1.0"
+            }
+          },
+          "secretHeaders": {
+            "description": "Sensitive HTTP headers (tokens, keys) that should be masked in logs",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {
+              "Authorization": "Bearer {{token}}"
+            }
+          },
+          "url": {
+            "description": "Custom webhook endpoint URL",
+            "type": "string",
+            "example": "https://api.custom-service.com/alerts"
+          }
+        }
+      },
+      "DashboardDocument": {
+        "type": "object",
+        "additionalProperties": true,
+        "$ref": "#/components/schemas/Dashboard"
+      },
+      "DashboardError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "currentVersion": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        }
+      },
+      "DashboardID": {
+        "type": "string",
+        "x-go-type": {
+          "import": {
+            "package": "github.com/axiomhq/axiom/pkg/core/ids"
+          },
+          "type": "DashboardID"
+        }
+      },
+      "DashboardResource": {
+        "type": "object",
+        "required": [
+          "uid",
+          "id",
+          "version",
+          "dashboard",
+          "createdAt",
+          "updatedAt",
+          "createdBy",
+          "updatedBy"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dashboard": {
+            "$ref": "#/components/schemas/DashboardDocument"
+          },
+          "id": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "DashboardUpsertRequest": {
+        "type": "object",
+        "required": [
+          "dashboard"
+        ],
+        "properties": {
+          "dashboard": {
+            "$ref": "#/components/schemas/DashboardDocument"
+          },
+          "message": {
+            "type": "string"
+          },
+          "overwrite": {
+            "type": "boolean",
+            "default": false
+          },
+          "uid": {
+            "description": "Stable external dashboard identifier (org-scoped unique).",
+            "type": "string"
+          },
+          "version": {
+            "description": "Required for updates when overwrite is false.",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "DashboardVariable": {
+        "description": "A variable defines an APL variable that is available to a dashboard",
+        "type": "object",
+        "required": [
+          "name",
+          "kind"
+        ],
+        "properties": {
+          "default": {
+            "description": "If set, should be the default value for this variable in the dashboard",
+            "type": "object"
+          },
+          "kind": {
+            "description": "A kind allows for different kinds of variables to be treated differently depending on what they are used for. A refless kind indicates that it's just a plain variable and we can not derive possible values from it A datadog kind indicates that we will use the ref value as a lookup against a datadog tag\n",
+            "type": "string",
+            "enum": [
+              "refless",
+              "datadog"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "ref": {
+            "description": "The ref value indicates where this variable can derive its values from",
+            "type": "string"
+          },
+          "values": {
+            "description": "Values is an indication of possible values for this variable, it may not be all the possible values just known quantities",
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "x-omitempty": true
+          }
+        }
+      },
+      "DashboardWriteResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "dashboard"
+        ],
+        "properties": {
+          "dashboard": {
+            "$ref": "#/components/schemas/DashboardResource"
+          },
+          "overwritten": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated"
+            ]
+          }
+        }
+      },
+      "Dataset": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created",
+          "who",
+          "kind"
+        ],
+        "properties": {
+          "canWrite": {
+            "description": "Whether this dataset has write access",
+            "type": "boolean"
+          },
+          "created": {
+            "description": "The RFC3339-formatted time when the dataset was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "description": "Dataset description",
+            "type": "string"
+          },
+          "edgeDeployment": {
+            "description": "Edge deployment of the dataset",
+            "type": "string",
+            "x-omitempty": true
+          },
+          "id": {
+            "description": "Dataset ID",
+            "type": "string"
+          },
+          "kind": {
+            "description": "The kind of the dataset",
+            "type": "string",
+            "default": "axiom:events:v1",
+            "enum": [
+              "otel:metrics:v1",
+              "otel:traces:v1",
+              "otel:logs:v1",
+              "axiom:events:v1"
+            ],
+            "example": "axiom:events:v1"
+          },
+          "mapFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "Unique dataset name",
+            "type": "string"
+          },
+          "region": {
+            "description": "Deprecated. Use `edgeDeployment` instead.",
+            "type": "string",
+            "x-omitempty": true
+          },
+          "retentionDays": {
+            "description": "Number of days to retain data in the dataset",
+            "type": "integer",
+            "x-omitempty": false
+          },
+          "sharedByOrg": {
+            "description": "ID of the org that shared this resource, if it's shared",
+            "type": "string"
+          },
+          "useRetentionPeriod": {
+            "description": "Whether to use the retention period",
+            "type": "boolean",
+            "x-omitempty": false
+          },
+          "who": {
+            "description": "Name of the dataset creator",
+            "type": "string"
+          }
+        },
+        "example": {
+          "created": "2022-07-20T02:35:14.137Z",
+          "description": "string",
+          "id": "string",
+          "kind": "axiom:events:v1",
+          "name": "string",
+          "who": "string"
+        }
+      },
+      "DatasetField": {
+        "type": "object",
+        "required": [
+          "name",
+          "type"
+        ],
+        "properties": {
+          "description": {
+            "description": "Description of the field",
+            "type": "string"
+          },
+          "hidden": {
+            "description": "Whether the field is hidden",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name of the field",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of the field",
+            "type": "string"
+          },
+          "unit": {
+            "description": "Unit of the field",
+            "type": "string"
+          }
+        }
+      },
+      "DiscordConfig": {
+        "description": "Configuration for Discord notifications using bot token",
+        "properties": {
+          "discordChannel": {
+            "description": "Discord channel ID to send notifications",
+            "type": "string",
+            "example": "123456789012345678"
+          },
+          "discordToken": {
+            "description": "Discord bot token for authentication",
+            "type": "string",
+            "example": "Bot 123456789012345678"
+          }
+        }
+      },
+      "DiscordWebhookConfig": {
+        "description": "Configuration for Discord notifications using webhooks",
+        "properties": {
+          "discordWebhookUrl": {
+            "description": "Discord webhook URL",
+            "type": "string",
+            "example": "https://discord.com/api/webhooks/123456789012345678/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+          }
+        }
+      },
+      "EdgeDeployment": {
+        "type": "object",
+        "required": [
+          "id",
+          "instanceName",
+          "deploymentType",
+          "cloud",
+          "domain",
+          "description"
+        ],
+        "properties": {
+          "cloud": {
+            "description": "Edge deployment cloud",
+            "type": "string"
+          },
+          "deploymentType": {
+            "description": "Edge deployment type",
+            "type": "string"
+          },
+          "description": {
+            "description": "Edge deployment description",
+            "type": "string"
+          },
+          "domain": {
+            "description": "Edge deployment domain",
+            "type": "string"
+          },
+          "environmentDefault": {
+            "description": "Whether the edge deployment is the default for the environment",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Unique edge deployment identifier",
+            "type": "string"
+          },
+          "instanceName": {
+            "description": "Human-readable edge deployment name",
+            "type": "string"
+          }
+        }
+      },
+      "EdgeDeployments": {
+        "type": "object",
+        "required": [
+          "axiom"
+        ],
+        "properties": {
+          "axiom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EdgeDeployment"
+            }
+          }
+        }
+      },
+      "EmailConfig": {
+        "description": "Configuration for email notifications",
+        "properties": {
+          "emails": {
+            "description": "List of email addresses to receive notifications",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "oncall@example.com",
+              "alerts@example.com"
+            ]
+          }
+        }
+      },
+      "FieldInfo": {
+        "type": "object",
+        "title": "FieldInfo captures information about a field used in the tabular result format. See Table.",
+        "properties": {
+          "agg": {
+            "$ref": "#/components/schemas/AggInfo"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "FlowDestination": {
+        "description": "Flow destination configuration schema.",
+        "type": "object",
+        "required": [
+          "kind",
+          "name",
+          "failureMode",
+          "properties"
+        ],
+        "properties": {
+          "failureMode": {
+            "type": "string",
+            "enum": [
+              "waitAndRetry",
+              "abort",
+              "continue"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "axiom",
+              "azureBlobStorageClientSecret",
+              "gcs",
+              "http",
+              "httpAuthorization",
+              "httpBasic",
+              "s3Compat"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "description": "Flow properties for the specific flow type.",
+            "type": "object",
+            "properties": {
+              "axiom": {
+                "$ref": "#/components/schemas/axiomProperties"
+              },
+              "azureBlobStorageClientSecret": {
+                "$ref": "#/components/schemas/azureBlobStorageClientSecretProperties"
+              },
+              "gcs": {
+                "$ref": "#/components/schemas/gcsProperties"
+              },
+              "http": {
+                "$ref": "#/components/schemas/httpProperties"
+              },
+              "httpAuthorization": {
+                "$ref": "#/components/schemas/httpAuthorizationProperties"
+              },
+              "httpBasic": {
+                "$ref": "#/components/schemas/httpBasicProperties"
+              },
+              "s3Compat": {
+                "$ref": "#/components/schemas/s3CompatProperties"
+              }
+            }
+          }
+        }
+      },
+      "FlowExport": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "description": "The APL of the export",
+            "type": "string",
+            "readOnly": true
+          },
+          "createdAt": {
+            "description": "The RFC3339-formatted time the export was created at",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "createdBy": {
+            "type": "string",
+            "readOnly": true
+          },
+          "destinationId": {
+            "description": "The destination ID",
+            "type": "string",
+            "readOnly": true
+          },
+          "end": {
+            "description": "The RFC3339-formatted time of the end of the export range",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "errorMessages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "errorRate": {
+            "description": "Error Rate",
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "eventsIn": {
+            "description": "Number of events received",
+            "type": "integer",
+            "readOnly": true
+          },
+          "eventsOut": {
+            "description": "Number of events delivered",
+            "type": "integer",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "lastActivity": {
+            "description": "The RFC3339-formatted time of the last activity",
+            "type": "string",
+            "format": "date-time",
+            "x-isnullable": true,
+            "readOnly": true
+          },
+          "name": {
+            "description": "The name of the export",
+            "type": "string",
+            "readOnly": true
+          },
+          "progress": {
+            "description": "Progress",
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "start": {
+            "description": "The RFC3339-formatted time of the start of the export range",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "state": {
+            "description": "State",
+            "type": "string",
+            "enum": [
+              "requested",
+              "running",
+              "stopped",
+              "aborted",
+              "finished",
+              "expired"
+            ],
+            "readOnly": true
+          },
+          "stoppedAt": {
+            "description": "The RFC3339-formatted time the export was stopped at",
+            "type": "string",
+            "format": "date-time",
+            "x-isnullable": true,
+            "readOnly": true
+          },
+          "stoppedBy": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
+      },
+      "Group": {
+        "description": "Defines a group of users for organizational purposes",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "description": {
+            "description": "Detailed description of the group's purpose and scope",
+            "type": "string"
+          },
+          "isManaged": {
+            "description": "Whether the group is managed by Axiom",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "members": {
+            "description": "List of user IDs that are assigned to this group",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "Unique name identifier for the group",
+            "type": "string"
+          },
+          "roles": {
+            "description": "List of role IDs that are assigned to this group",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GroupInfo": {
+        "type": "object",
+        "title": "GroupInfo captures information about a grouping clause in the tabular result format. See Table.",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupWithID": {
+        "description": "Extends the base Group type to include a unique identifier",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Group"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the group",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "IdentifyAPITokenRequest": {
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "properties": {
+          "token": {
+            "description": "The raw token value to identify",
+            "type": "string"
+          }
+        }
+      },
+      "IdentifyAPITokenResponse": {
+        "type": "object",
+        "required": [
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "createdAt": {
+            "description": "When the token was created (ISO 8601 format)",
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "description": "User ID or token ID of the creator",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the token",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the token",
+            "type": "string"
+          }
+        }
+      },
+      "License": {
+        "type": "object",
+        "required": [
+          "id",
+          "tier",
+          "issuer",
+          "issuedTo",
+          "issuedAt",
+          "validFrom",
+          "monthlyIngestGb",
+          "monthlyQueryGbHours",
+          "apiRateLimitPerSecond",
+          "maxUsers",
+          "maxDatasets",
+          "maxMonitors",
+          "maxFields",
+          "maxEndpoints",
+          "maxQueryWindowSeconds",
+          "maxAuditWindowSeconds",
+          "withAuths",
+          "features",
+          "billingPeriodStart",
+          "billingPeriodEnd",
+          "defaultRegion",
+          "defaultEdgeDeployment",
+          "regions",
+          "edgeDeployments"
+        ],
+        "properties": {
+          "apiRateLimitPerSecond": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "billingPeriodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "billingPeriodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "defaultEdgeDeployment": {
+            "type": "string",
+            "x-omitempty": true
+          },
+          "defaultRegion": {
+            "type": "string",
+            "x-omitempty": true
+          },
+          "edgeDeployments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-omitempty": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "features": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "issuedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "issuedTo": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "maxAuditWindowSeconds": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxDatasets": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxEndpoints": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxFields": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxMonitors": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxQueryWindowSeconds": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "maxUsers": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "monthlyIngestGb": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "monthlyQueryGbHours": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "regions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-omitempty": true
+          },
+          "storageAllowanceGB": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "personal",
+              "basicDirect",
+              "teamMonthlyDirect",
+              "teamMonthlyAws",
+              "axiomCloud",
+              "teamPlus",
+              "enterprise",
+              "comped"
+            ]
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "withAuths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Lookup": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "MapField": {
+        "description": "A map field, described by a name",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "name": "fieldname"
+        }
+      },
+      "MapFields": {
+        "description": "A list of map field names",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "example": [
+          "field1",
+          "field2"
+        ]
+      },
+      "Message": {
+        "type": "object",
+        "required": [
+          "priority",
+          "count",
+          "message",
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "message": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "trace",
+              "debug",
+              "info",
+              "warn",
+              "error",
+              "fatal"
+            ]
+          }
+        }
+      },
+      "MicrosoftTeamsConfig": {
+        "description": "Configuration for Microsoft Teams notifications",
+        "properties": {
+          "microsoftTeamsUrl": {
+            "description": "Microsoft Teams webhook URL",
+            "type": "string",
+            "example": "https://outlook.office.com/webhook/123456789/IncomingWebhook/..."
+          }
+        }
+      },
+      "Monitor": {
+        "description": "Configuration for a monitoring rule. Monitors can be configured to:\n- Check threshold values (e.g., CPU usage > 90%)\n- Match specific events in logs\n- Detect anomalies based on historical patterns\nEach monitor runs on a specified interval and can trigger notifications through configured notifiers.\n",
+        "type": "object",
+        "required": [
+          "name",
+          "type"
+        ],
+        "properties": {
+          "alertOnNoData": {
+            "description": "Whether to alert when no data is received",
+            "type": "boolean",
+            "example": true
+          },
+          "aplQuery": {
+            "description": "APL (Axiom Processing Language) query string used for monitoring.\nThis query defines what data to analyze and how to process it.\nAt least one of aplQuery or mplQuery must be provided.\n",
+            "type": "string",
+            "example": "| where severity = 'error' | count() > 100"
+          },
+          "columnName": {
+            "description": "Name of the column to monitor",
+            "type": "string",
+            "example": "cpu_usage"
+          },
+          "compareDays": {
+            "description": "Number of days to compare for anomaly detection",
+            "type": "number",
+            "format": "int64",
+            "maximum": 7,
+            "example": 7
+          },
+          "createdAt": {
+            "description": "Timestamp when the monitor was created",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-03-20T10:00:00Z"
+          },
+          "createdBy": {
+            "description": "ID of the user who created the monitor",
+            "type": "string",
+            "example": "usr_789xyz"
+          },
+          "description": {
+            "description": "Detailed description of the monitor's purpose",
+            "type": "string",
+            "example": "Monitors CPU usage and alerts when it exceeds 90%"
+          },
+          "disabled": {
+            "description": "Whether the monitor is currently disabled",
+            "type": "boolean",
+            "example": false
+          },
+          "disabledUntil": {
+            "description": "Timestamp until when the monitor should remain disabled",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-04-01T00:00:00Z",
+            "nullable": true
+          },
+          "intervalMinutes": {
+            "description": "How frequently the monitor should run, in minutes.\nMinimum value is 1 minute.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1,
+            "example": 5
+          },
+          "mplQuery": {
+            "description": "MPL (Metrics Processing Language) query string for metrics-based monitoring.\nUse this as an alternative to aplQuery for metrics datasets.\nAt least one of aplQuery or mplQuery must be provided.\n",
+            "type": "string",
+            "example": "test-metrics:http_request_duration_seconds"
+          },
+          "name": {
+            "description": "Name of the monitor",
+            "type": "string",
+            "example": "Production CPU Monitor"
+          },
+          "notifierIds": {
+            "description": "List of notifier IDs that will receive alerts.\nNotifiers can be email, Slack, webhook endpoints, etc.\n",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "notify_slack_prod",
+              "notify_email_oncall"
+            ]
+          },
+          "notifyByGroup": {
+            "description": "Whether to group notifications",
+            "type": "boolean",
+            "example": false
+          },
+          "notifyEveryRun": {
+            "description": "Whether to send notifications on every check",
+            "type": "boolean",
+            "example": false
+          },
+          "operator": {
+            "description": "Comparison operator for threshold checks:\n- Below: Trigger when value < threshold\n- BelowOrEqual: Trigger when value <= threshold\n- Above: Trigger when value > threshold\n- AboveOrEqual: Trigger when value >= threshold\n- AboveOrBelow: Trigger when value is outside a range\n",
+            "type": "string",
+            "enum": [
+              "Below",
+              "BelowOrEqual",
+              "Above",
+              "AboveOrEqual",
+              "AboveOrBelow"
+            ],
+            "example": "Above"
+          },
+          "rangeMinutes": {
+            "description": "Time window to evaluate in each check, in minutes.\nFor example, \"last 5 minutes of data\"\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 1,
+            "example": 5
+          },
+          "resolvable": {
+            "description": "Whether the alert can be manually resolved",
+            "type": "boolean",
+            "example": true
+          },
+          "secondDelay": {
+            "description": "Delay in seconds before triggering the alert",
+            "type": "number",
+            "format": "int64",
+            "maximum": 86400,
+            "example": 300
+          },
+          "skipResolved": {
+            "description": "Whether to skip resolved alerts",
+            "type": "boolean",
+            "example": false
+          },
+          "threshold": {
+            "description": "Threshold value for triggering the alert",
+            "type": "number",
+            "format": "double",
+            "x-omitempty": false,
+            "example": 90
+          },
+          "tolerance": {
+            "description": "Tolerance percentage for anomaly detection",
+            "type": "number",
+            "maximum": 100,
+            "example": 10
+          },
+          "triggerAfterNPositiveResults": {
+            "description": "Number of positive results needed before triggering",
+            "type": "number",
+            "format": "int64",
+            "example": 2
+          },
+          "triggerFromNRuns": {
+            "description": "Number of consecutive check runs that must fail before triggering an alert.\nUse this to avoid alerting on temporary spikes.\n",
+            "type": "number",
+            "format": "int64",
+            "example": 3
+          },
+          "type": {
+            "description": "Type of monitoring check to perform:\n- Threshold: Compares a numeric value against a threshold\n- MatchEvent: Looks for specific events or patterns\n- AnomalyDetection: Identifies unusual patterns based on historical data\n",
+            "type": "string",
+            "enum": [
+              "Threshold",
+              "MatchEvent",
+              "AnomalyDetection"
+            ],
+            "example": "Threshold"
+          }
+        }
+      },
+      "MonitorWithId": {
+        "description": "Monitor configuration with its unique identifier",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Monitor"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the monitor",
+                "type": "string",
+                "example": "mon_xyz789"
+              }
+            }
+          }
+        ]
+      },
+      "NewAnnotation": {
+        "type": "object",
+        "required": [
+          "datasets",
+          "type"
+        ],
+        "properties": {
+          "datasets": {
+            "description": "array<string> of dataset names for which the annotation appears on charts",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "description": "Explanation of the event the annotation marks on the charts",
+            "type": "string",
+            "maxLength": 512
+          },
+          "endTime": {
+            "description": "End time of the annotation",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time": {
+            "description": "Time the annotation marks on the charts. If you don't include this field, Axiom assigns the time of the API request to the annotation.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "description": "Summary of the annotation that appears on the charts",
+            "type": "string",
+            "maxLength": 256
+          },
+          "type": {
+            "description": "Type of the event marked by the annotation. Use only alphanumeric characters or hyphens. For example, \"production-deployment\".",
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "url": {
+            "description": "URL relevant for the event marked by the annotation. For example, link to GitHub pull request.",
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      },
+      "Notifier": {
+        "description": "Configuration for a notification channel. Notifiers can be configured for various services like:\n- Slack\n- Email\n- PagerDuty\n- OpsGenie\n- Discord\n- Microsoft Teams\n- Custom Webhooks\n",
+        "type": "object",
+        "required": [
+          "name",
+          "properties"
+        ],
+        "properties": {
+          "createdAt": {
+            "description": "Timestamp when the notifier was created",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true,
+            "example": "2024-01-15T10:30:00Z"
+          },
+          "createdBy": {
+            "description": "Email or ID of the user who created the notifier",
+            "type": "string",
+            "readOnly": true,
+            "example": "alice@example.com"
+          },
+          "disabledUntil": {
+            "description": "ISO timestamp until which the notifier is disabled (null if enabled)",
+            "type": "string",
+            "example": "2024-03-20T15:00:00Z"
+          },
+          "name": {
+            "description": "Human-readable name for the notifier",
+            "type": "string",
+            "example": "Production Slack Alerts"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/NotifierProperties"
+          }
+        }
+      },
+      "NotifierProperties": {
+        "description": "Configuration options for different notification channels. Only one channel should be configured per notifier.",
+        "properties": {
+          "customWebhook": {
+            "$ref": "#/components/schemas/CustomNotifierConfig"
+          },
+          "discord": {
+            "$ref": "#/components/schemas/DiscordConfig"
+          },
+          "discordWebhook": {
+            "$ref": "#/components/schemas/DiscordWebhookConfig"
+          },
+          "email": {
+            "$ref": "#/components/schemas/EmailConfig"
+          },
+          "microsoftTeams": {
+            "$ref": "#/components/schemas/MicrosoftTeamsConfig"
+          },
+          "opsgenie": {
+            "$ref": "#/components/schemas/OpsGenieConfig"
+          },
+          "pagerduty": {
+            "$ref": "#/components/schemas/PagerDutyConfig"
+          },
+          "slack": {
+            "$ref": "#/components/schemas/SlackConfig"
+          },
+          "webhook": {
+            "$ref": "#/components/schemas/WebhookConfig"
+          }
+        }
+      },
+      "NotifierWithId": {
+        "description": "Notifier configuration with its unique identifier",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Notifier"
+          },
+          {
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the notifier",
+                "type": "string",
+                "example": "notify_slack_prod"
+              }
+            }
+          }
+        ]
+      },
+      "OTELResponse": {
+        "type": "string",
+        "format": "binary"
+      },
+      "OpsGenieConfig": {
+        "description": "Configuration for OpsGenie integration",
+        "properties": {
+          "apiKey": {
+            "description": "OpsGenie API key for authentication",
+            "type": "string",
+            "example": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          },
+          "isEU": {
+            "description": "Whether to use EU region endpoints",
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "Order": {
+        "type": "object",
+        "required": [
+          "desc",
+          "field"
+        ],
+        "properties": {
+          "desc": {
+            "type": "boolean"
+          },
+          "field": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Org": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "plan",
+          "planCreated",
+          "lastUsageSync",
+          "paymentStatus",
+          "license",
+          "primaryEmail"
+        ],
+        "properties": {
+          "defaultEdgeDeployment": {
+            "type": "string"
+          },
+          "defaultRegion": {
+            "type": "string"
+          },
+          "firstFailedPayment": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUsageSync": {
+            "type": "string"
+          },
+          "license": {
+            "$ref": "#/components/schemas/License"
+          },
+          "metaCreated": {
+            "type": "string"
+          },
+          "metaModified": {
+            "type": "string"
+          },
+          "metaVersion": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "paymentStatus": {
+            "type": "string",
+            "enum": [
+              "na",
+              "failed",
+              "success",
+              "blocked"
+            ]
+          },
+          "plan": {
+            "type": "string",
+            "enum": [
+              "personal",
+              "basicDirect",
+              "teamMonthlyDirect",
+              "teamMonthlyAws",
+              "axiomCloud",
+              "teamPlus",
+              "enterprise",
+              "comped"
+            ]
+          },
+          "planCreated": {
+            "type": "string"
+          },
+          "primaryEmail": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          }
+        }
+      },
+      "PagerDutyConfig": {
+        "description": "Configuration for PagerDuty integration",
+        "properties": {
+          "routingKey": {
+            "description": "PagerDuty integration key for routing alerts",
+            "type": "string",
+            "example": "1234567890abcdef1234567890abcdef"
+          },
+          "token": {
+            "description": "PagerDuty API token for additional functionality",
+            "type": "string",
+            "example": "u+1234567890abcdef1234567890abcdef"
+          }
+        }
+      },
+      "PostOrg": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "edgeDeployment": {
+            "description": "The default edge deployment of the organization.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "region": {
+            "description": "Deprecated. Use `edgeDeployment` instead.",
+            "type": "string"
+          }
+        }
+      },
+      "QueryOptions": {
+        "type": "object",
+        "properties": {
+          "disableCache": {
+            "type": "boolean"
+          },
+          "disableStats": {
+            "type": "boolean"
+          },
+          "disableTrace": {
+            "type": "boolean"
+          },
+          "maxDataPoints": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "maxSeries": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "noAggregation": {
+            "type": "boolean"
+          },
+          "noFill": {
+            "type": "boolean"
+          },
+          "noInterpolation": {
+            "type": "boolean"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "resolution": {
+            "type": "string"
+          },
+          "displayNull": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "null",
+              "span",
+              "zero",
+              ""
+            ],
+            "description": "Controls how empty intervals are rendered in time series charts. `auto` infers from the query, `null` leaves gaps, `span` connects adjacent points, `zero` fills with zero."
+          },
+          "overlayCharts": {
+            "$ref": "#/components/schemas/BooleanString",
+            "description": "When enabled, charts are overlaid on a single chart instead of stacked separately."
+          },
+          "shownColumns": {
+            "type": "string",
+            "maxLength": 10000
+          },
+          "timeSeriesVariant": {
+            "type": "string",
+            "enum": [
+              "area",
+              "bars",
+              "line",
+              "lines",
+              ""
+            ]
+          },
+          "timeSeriesView": {
+            "type": "string",
+            "enum": [
+              "charts",
+              "resultsTable",
+              "charts|resultsTable",
+              ""
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "RangeInfo": {
+        "type": "object",
+        "title": "RangeInfo specifies the window a query was restricted to.",
+        "properties": {
+          "end": {
+            "description": "End is the ending time the query is limited by.\nQueries are restricted to the interval (start,end).",
+            "type": "string",
+            "format": "date-time"
+          },
+          "field": {
+            "description": "Field specifies the field name on which the query range was restricted. Normally _time",
+            "type": "string"
+          },
+          "start": {
+            "description": "Start is the starting time the query is limited by.\nQueries are restricted to the interval (start,end).",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RegenerateAPIToken": {
+        "type": "object",
+        "required": [
+          "existingTokenExpiresAt"
+        ],
+        "properties": {
+          "existingTokenExpiresAt": {
+            "description": "Expiration date of the existing token (ISO 8601 format)",
+            "type": "string",
+            "format": "date-time"
+          },
+          "newToken": {
+            "$ref": "#/components/schemas/CreateAPIToken"
+          },
+          "newTokenExpiresAt": {
+            "description": "Expiration date of the new token (ISO 8601 format)",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "Region": {
+        "type": "object",
+        "required": [
+          "id",
+          "instanceName",
+          "regionType",
+          "regionCloud",
+          "domain",
+          "description"
+        ],
+        "properties": {
+          "description": {
+            "description": "Region description",
+            "type": "string"
+          },
+          "domain": {
+            "description": "Region domain",
+            "type": "string"
+          },
+          "environmentDefault": {
+            "description": "Whether the region is the default region for the environment",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Unique region identifier",
+            "type": "string"
+          },
+          "instanceName": {
+            "description": "Human-readable region name",
+            "type": "string"
+          },
+          "regionCloud": {
+            "description": "Region cloud",
+            "type": "string"
+          },
+          "regionType": {
+            "description": "Region type",
+            "type": "string"
+          }
+        }
+      },
+      "Regions": {
+        "type": "object",
+        "required": [
+          "axiom"
+        ],
+        "properties": {
+          "axiom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Region"
+            }
+          }
+        }
+      },
+      "Repo": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "description": "UUID of the user or system that created the object.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "data": {
+            "description": "Data specific to the type of repo object.",
+            "type": "string"
+          },
+          "global": {
+            "description": "Indicates whether the object is global.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The unique identifier for the object.",
+            "type": "string"
+          },
+          "resourceId": {
+            "description": "The unique identifier for the associated resource object.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the object.",
+            "type": "string",
+            "enum": [
+              "PACKAGE",
+              "DATASET",
+              "MONITOR",
+              "DASHBOARD",
+              "VIRTUAL_FIELD",
+              "APL_MODULE_DEFINITION",
+              "VIEW"
+            ]
+          }
+        }
+      },
+      "Role": {
+        "description": "Defines a role and its associated permissions within the system",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "datasetCapabilities": {
+            "$ref": "#/components/schemas/roleDatasetCapabilities"
+          },
+          "description": {
+            "description": "Detailed description of the role's purpose and scope",
+            "type": "string"
+          },
+          "members": {
+            "description": "List of user IDs that are assigned to this role",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "description": "Unique name identifier for the role",
+            "type": "string"
+          },
+          "orgCapabilities": {
+            "$ref": "#/components/schemas/roleOrgCapabilities"
+          },
+          "viewCapabilities": {
+            "$ref": "#/components/schemas/roleViewCapabilities"
+          }
+        }
+      },
+      "RoleWithID": {
+        "description": "Extends the base Role type to include a unique identifier",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Role"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the role",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ShareRequest": {
+        "type": "object",
+        "properties": {
+          "canWrite": {
+            "type": "boolean"
+          },
+          "expiryDate": {
+            "description": "Optional time which the link will expire",
+            "type": "string",
+            "format": "date-time"
+          },
+          "organizationIds": {
+            "description": "Optional list of organization IDs to restrict access to the shared link.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "description": "The type of the object.",
+            "type": "string",
+            "enum": [
+              "PACKAGE",
+              "DATASET",
+              "MONITOR",
+              "DASHBOARD",
+              "VIRTUAL_FIELD",
+              "REGEX",
+              "QUERY",
+              "CONSTANT",
+              "MAPPING",
+              "VIEW"
+            ]
+          }
+        }
+      },
+      "ShareResponse": {
+        "type": "object",
+        "properties": {
+          "canWrite": {
+            "type": "boolean"
+          },
+          "expiryDate": {
+            "description": "Optional time which the link will expire",
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "description": "The unique identifier for the object.",
+            "type": "string"
+          },
+          "organizationIds": {
+            "description": "Optional list of organization IDs with access to the shared link.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organizationNames": {
+            "description": "Optional list of organization names associated with the ids.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shareableLink": {
+            "description": "The URL that can be used to access the shared repo.",
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the object.",
+            "type": "string",
+            "enum": [
+              "PACKAGE",
+              "DATASET",
+              "MONITOR",
+              "DASHBOARD",
+              "VIRTUAL_FIELD",
+              "REGEX",
+              "QUERY",
+              "VIEW"
+            ]
+          }
+        }
+      },
+      "SlackConfig": {
+        "description": "Configuration for Slack notifications using incoming webhooks",
+        "properties": {
+          "slackUrl": {
+            "description": "Slack incoming webhook URL",
+            "type": "string",
+            "example": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+          }
+        }
+      },
+      "SlackEvent": {
+        "type": "object",
+        "required": [
+          "token",
+          "team_id",
+          "api_app_id",
+          "event",
+          "type",
+          "event_id",
+          "event_time"
+        ],
+        "properties": {
+          "api_app_id": {
+            "description": "ID of the Slack app that the event is for",
+            "type": "string"
+          },
+          "event": {
+            "type": "object",
+            "required": [
+              "type",
+              "user",
+              "ts",
+              "channel"
+            ],
+            "properties": {
+              "channel": {
+                "description": "Channel ID where the event occurred",
+                "type": "string"
+              },
+              "text": {
+                "description": "Text content of the event",
+                "type": "string"
+              },
+              "ts": {
+                "description": "Timestamp of when the event occurred",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of the event",
+                "type": "string"
+              },
+              "user": {
+                "description": "ID of the user who triggered the event",
+                "type": "string"
+              }
+            }
+          },
+          "event_id": {
+            "description": "Unique identifier for the event",
+            "type": "string"
+          },
+          "event_time": {
+            "description": "Timestamp of when the event was dispatched",
+            "type": "integer",
+            "format": "int64"
+          },
+          "team_id": {
+            "description": "ID of the team where the event originated",
+            "type": "string"
+          },
+          "token": {
+            "description": "Verification token to validate the event is from Slack",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of the event callback",
+            "type": "string"
+          }
+        }
+      },
+      "SourceInfo": {
+        "description": "Result sources will typically be the names of a datasets that were searched,\nbut may be expanded to other things in the future.",
+        "type": "object",
+        "title": "SourceInfo specifies the provenance of a results Table.",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "StarredQuery": {
+        "type": "object",
+        "required": [
+          "kind",
+          "name",
+          "who",
+          "query",
+          "metadata"
+        ],
+        "properties": {
+          "dataset": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "apl"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "query": {
+            "$ref": "#/components/schemas/APLRequestWithOptions"
+          },
+          "who": {
+            "type": "string"
+          }
+        }
+      },
+      "StarredQueryWithId": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/StarredQuery"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Status": {
+        "type": "object",
+        "required": [
+          "elapsedTimeNs",
+          "isCached",
+          "isEstimated",
+          "rowsExamined",
+          "rowsMatched"
+        ],
+        "properties": {
+          "elapsedTimeNs": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isCached": {
+            "type": "boolean"
+          },
+          "isEstimated": {
+            "type": "boolean"
+          },
+          "maxCursor": {
+            "description": "Row id of the newest row, as seen server side.\nMay be higher than what the results include if the server scanned more data than included in the results.\nCan be used to efficiently resume time-sorted non-aggregating queries (ie filtering only).",
+            "type": "string"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          },
+          "minCursor": {
+            "description": "Row id of the oldest row, as seen server side.\nMay be lower than what the results include if the server scanned more data than included in the results.\nCan be used to efficiently resume time-sorted non-aggregating queries (ie filtering only).",
+            "type": "string"
+          },
+          "rowsExamined": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "rowsMatched": {
+            "type": "integer",
+            "format": "uint64"
+          }
+        }
+      },
+      "Table": {
+        "type": "object",
+        "title": "Table defines the schema for query results.",
+        "properties": {
+          "buckets": {
+            "$ref": "#/components/schemas/BucketInfo"
+          },
+          "columns": {
+            "description": "Columns contain a series of arrays with the raw result data.\nThe columns here line up with the fields in the Fields array.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "fields": {
+            "description": "Fields contain information about the fields included in these results.\nThe order of the fields match up with the order of the data in Columns.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FieldInfo"
+            }
+          },
+          "groups": {
+            "description": "Groups specifies which grouping operations has been performed on the results.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupInfo"
+            }
+          },
+          "name": {
+            "description": "Name is the name assigned to this table. Defaults to \"0\". The name \"_totals\" is reserved for system use.",
+            "type": "string"
+          },
+          "order": {
+            "description": "Order echoes the ordering clauses that was used to sort the results.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            }
+          },
+          "range": {
+            "$ref": "#/components/schemas/RangeInfo"
+          },
+          "sources": {
+            "description": "Sources contain the names of the datasets that contributed data to these results.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceInfo"
+            }
+          }
+        }
+      },
+      "TokenInfo": {
+        "type": "object",
+        "properties": {
+          "expiryDate": {
+            "description": "Optional time which the link will expire",
+            "type": "string",
+            "format": "date-time"
+          },
+          "ownerEmail": {
+            "description": "Email of the owner.",
+            "type": "string"
+          },
+          "resourceId": {
+            "description": "The unique identifier for the associated resource object.",
+            "type": "string"
+          },
+          "resourceType": {
+            "description": "The type of the resource.",
+            "type": "string"
+          }
+        }
+      },
+      "TransformRequest": {
+        "type": "object",
+        "required": [
+          "blocks",
+          "apl",
+          "startTime",
+          "endTime",
+          "resultURLs"
+        ],
+        "properties": {
+          "apl": {
+            "description": "The APL query to apply for transformation",
+            "type": "string",
+            "example": "['my-dataset'] | where status_code >= 400 | project timestamp, service, error_message"
+          },
+          "blocks": {
+            "description": "List of block locator URLs to transform",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "block://unstable_v0/zgAQynPEQLEMsQwAAwAACAwYqTcAFGcAAAAAAAAACjgVchcAG7bpGFuQrFTOk54YW5Fr9V76LmidjehN6GOLBD7YhQAAAACS2SJheGlvbWVyc2Z0ODNheGlvbXRyYWNlc2RldnlreDdjeXJ12SxzMzovL2F4aW9tLWNsb3VkLWRldmVsb3BtZW50LWRhdGFiYXNlLTY1amJtLw=="
+            ]
+          },
+          "endTime": {
+            "description": "The end time for the transformation",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-01-02T00:00:00Z"
+          },
+          "resultURLs": {
+            "description": "List of URLs where transformation results should be uploaded",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "https://output-bucket.s3.amazonaws.com/transformed/result1.jsonl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=...",
+              "https://output-bucket.s3.amazonaws.com/transformed/result2.jsonl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=..."
+            ]
+          },
+          "startTime": {
+            "description": "The start time for the transformation",
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-01-01T00:00:00Z"
+          }
+        }
+      },
+      "TrimOptions": {
+        "type": "object",
+        "required": [
+          "maxDuration"
+        ],
+        "properties": {
+          "maxDuration": {
+            "type": "string",
+            "example": "1h"
+          }
+        },
+        "example": {
+          "maxDuration": "1h"
+        }
+      },
+      "UpdateCurrentUserRequest": {
+        "description": "Object representing a user update request",
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "description": "New name for the user",
+            "type": "string",
+            "example": "John Smith"
+          }
+        }
+      },
+      "UpdateDataset": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "retentionDays": {
+            "description": "Number of days to retain data in the dataset",
+            "type": "integer",
+            "x-omitempty": false
+          },
+          "useRetentionPeriod": {
+            "description": "Whether to use the retention period",
+            "type": "boolean",
+            "x-omitempty": false
+          }
+        },
+        "example": {
+          "description": "string",
+          "retentionDays": 30
+        }
+      },
+      "UpdateOrg": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateUserRoleRequest": {
+        "description": "Object representing a user's role update request",
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "description": "Role identifier to assign to the user",
+            "type": "string",
+            "example": "admin"
+          }
+        }
+      },
+      "UpdatedAnnotation": {
+        "type": "object",
+        "properties": {
+          "datasets": {
+            "description": "array<string> of dataset names for which the annotation appears on charts",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "description": {
+            "description": "Explanation of the event the annotation marks on the charts",
+            "type": "string",
+            "maxLength": 512
+          },
+          "endTime": {
+            "description": "End time of the annotation",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time": {
+            "description": "Time the annotation marks on the charts. If you don't include this field, Axiom assigns the time of the API request to the annotation.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "description": "Summary of the annotation that appears on the charts",
+            "type": "string",
+            "maxLength": 256
+          },
+          "type": {
+            "description": "Type of the event marked by the annotation. Use only alphanumeric characters or hyphens. For example, \"production-deployment\".",
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "url": {
+            "description": "URL relevant for the event marked by the annotation. For example, link to GitHub pull request.",
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      },
+      "User": {
+        "description": "Represents a user in the system",
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role"
+        ],
+        "properties": {
+          "email": {
+            "description": "User's email address",
+            "type": "string",
+            "example": "john.doe@example.com"
+          },
+          "id": {
+            "description": "Unique identifier for the user",
+            "type": "string",
+            "example": "usr_123456789"
+          },
+          "name": {
+            "description": "User's full name",
+            "type": "string",
+            "example": "John Doe"
+          },
+          "role": {
+            "$ref": "#/components/schemas/UserDetailsRole"
+          }
+        }
+      },
+      "UserDetailsRole": {
+        "description": "Detailed information about a user's role",
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the role",
+            "type": "string",
+            "example": "role_123456789"
+          },
+          "name": {
+            "description": "Human-readable name of the role",
+            "type": "string",
+            "example": "Organization Admin"
+          }
+        }
+      },
+      "View": {
+        "type": "object",
+        "required": [
+          "name",
+          "aplQuery"
+        ],
+        "properties": {
+          "aplQuery": {
+            "type": "string"
+          },
+          "datasets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sharedByOrg": {
+            "description": "ID of the org that shared this resource, if it's shared",
+            "type": "string"
+          },
+          "sharedByOrgName": {
+            "description": "The name of the org that shared this resource, if it's shared",
+            "type": "string"
+          }
+        }
+      },
+      "VirtualField": {
+        "type": "object",
+        "required": [
+          "dataset",
+          "name",
+          "expression"
+        ],
+        "properties": {
+          "dataset": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "expression": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      },
+      "VirtualFieldWithId": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VirtualField"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "WebhookConfig": {
+        "description": "Configuration for simple webhook notifications",
+        "properties": {
+          "url": {
+            "description": "Webhook endpoint URL",
+            "type": "string",
+            "example": "https://api.example.com/webhooks/alerts"
+          }
+        }
+      },
+      "axiomProperties": {
+        "type": "object",
+        "required": [
+          "dataset",
+          "token"
+        ],
+        "properties": {
+          "dataset": {
+            "description": "Name of the destination dataset",
+            "type": "string"
+          },
+          "token": {
+            "description": "Axiom ingest API token",
+            "type": "string"
+          },
+          "url": {
+            "description": "Axiom ingest API endpoint",
+            "type": "string"
+          }
+        }
+      },
+      "azureBlobStorageClientSecretProperties": {
+        "type": "object",
+        "required": [
+          "clientId",
+          "clientSecret",
+          "tenantID",
+          "url"
+        ],
+        "properties": {
+          "clientId": {
+            "description": "Client ID of the service principal",
+            "type": "string"
+          },
+          "clientSecret": {
+            "description": "Client secret of the service principal",
+            "type": "string"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson"
+            ]
+          },
+          "maximumEvents": {
+            "description": "Maximum number of events to send in a single file",
+            "type": "integer"
+          },
+          "tenantID": {
+            "description": "AD Tenant ID",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the container",
+            "type": "string"
+          }
+        }
+      },
+      "datasetCapabilities": {
+        "type": "object",
+        "additionalProperties": {
+          "properties": {
+            "data": {
+              "description": "Data Management capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "ingest": {
+              "description": "Ingest capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "query": {
+              "description": "Query capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "share": {
+              "description": "Sharing dataset capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "starredQueries": {
+              "description": "Starred queries capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "update",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "trim": {
+              "description": "Data Trimming capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "vacuum": {
+              "description": "Field Vacuuming capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "virtualFields": {
+              "description": "Virtual fields capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "update",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            }
+          }
+        }
+      },
+      "gcsProperties": {
+        "type": "object",
+        "required": [
+          "credentialsJson",
+          "bucket"
+        ],
+        "properties": {
+          "bucket": {
+            "description": "Name of the destination bucket",
+            "type": "string"
+          },
+          "credentialsJson": {
+            "description": "Service account or refresh token JSON credentials",
+            "type": "string"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson"
+            ]
+          }
+        }
+      },
+      "httpAuthorizationProperties": {
+        "type": "object",
+        "required": [
+          "authorization",
+          "url"
+        ],
+        "properties": {
+          "authorization": {
+            "description": "Authorization header value",
+            "type": "string"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson",
+              "textTemplate"
+            ]
+          },
+          "headers": {
+            "description": "HTTP headers to send with each request",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "maximumConnections": {
+            "description": "Maximum number of connections to the target server",
+            "type": "integer"
+          },
+          "maximumEvents": {
+            "description": "Maximum number of events to send in a single request",
+            "type": "integer"
+          },
+          "textTemplateEncoderBody": {
+            "description": "Text Encoder Template, only available if format is textTemplate",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the destination endpoint",
+            "type": "string"
+          }
+        }
+      },
+      "httpBasicProperties": {
+        "type": "object",
+        "required": [
+          "username",
+          "url"
+        ],
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson",
+              "textTemplate"
+            ]
+          },
+          "headers": {
+            "description": "HTTP headers to send with each request",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "maximumConnections": {
+            "description": "Maximum number of connections to the target server",
+            "type": "integer"
+          },
+          "maximumEvents": {
+            "description": "Maximum number of events to send in a single request",
+            "type": "integer"
+          },
+          "password": {
+            "description": "Password of the destination endpoint",
+            "type": "string"
+          },
+          "textTemplateEncoderBody": {
+            "description": "Text Encoder Template, only available if format is textTemplate",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the destination endpoint",
+            "type": "string"
+          },
+          "username": {
+            "description": "Username of the destination endpoint",
+            "type": "string"
+          }
+        }
+      },
+      "httpProperties": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson",
+              "textTemplate"
+            ]
+          },
+          "headers": {
+            "description": "HTTP headers to send with each request",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "maximumConnections": {
+            "description": "Maximum number of connections to the target server",
+            "type": "integer"
+          },
+          "maximumEvents": {
+            "description": "Maximum number of events to send in a single request",
+            "type": "integer"
+          },
+          "textTemplateEncoderBody": {
+            "description": "Text Encoder Template, only available if format is textTemplate",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the destination endpoint",
+            "type": "string"
+          }
+        }
+      },
+      "orgCapabilities": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Annotations capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "apiTokens": {
+            "description": "API tokens capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "auditLog": {
+            "description": "Audit Log capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "billing": {
+            "description": "Billing capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "dashboards": {
+            "description": "Dashboards capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "datasets": {
+            "description": "Datasets capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "endpoints": {
+            "description": "Endpoints capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "flows": {
+            "description": "Flows capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "integrations": {
+            "description": "Integrations capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "monitors": {
+            "description": "Monitors capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "notifiers": {
+            "description": "Notifiers capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "rbac": {
+            "description": "Access control capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "sharedAccessKeys": {
+            "description": "Shared access keys capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "users": {
+            "description": "Users capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "views": {
+            "description": "Views capability",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          }
+        }
+      },
+      "roleDatasetCapabilities": {
+        "description": "Defines the available permissions for dataset operations",
+        "type": "object",
+        "additionalProperties": {
+          "properties": {
+            "data": {
+              "description": "Controls data management operations like deletion",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "ingest": {
+              "description": "Controls the ability to ingest data into datasets",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "query": {
+              "description": "Controls the ability to query and read data from datasets",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "share": {
+              "description": "Controls the ability to share datasets with other users",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "starredQueries": {
+              "description": "Controls the management of starred/saved queries",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "update",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "trim": {
+              "description": "Controls data trimming operations for storage optimization",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "vacuum": {
+              "description": "Controls field vacuuming operations for storage optimization",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "virtualFields": {
+              "description": "Controls the management of virtual fields in datasets",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "update",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            }
+          }
+        }
+      },
+      "roleOrgCapabilities": {
+        "description": "Defines organization-wide permissions and capabilities",
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Controls the management of annotations across the organization",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "apiTokens": {
+            "description": "Controls the management of API tokens for authentication",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "auditLog": {
+            "description": "Controls access to organization audit logs",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "billing": {
+            "description": "Controls access to billing information and settings",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "dashboards": {
+            "description": "Controls the management of organization dashboards",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "datasets": {
+            "description": "Controls the management of organization datasets",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "endpoints": {
+            "description": "Controls the management of API endpoints",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "flows": {
+            "description": "Controls the management of data flows and pipelines",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "integrations": {
+            "description": "Controls the management of third-party integrations",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "monitors": {
+            "description": "Controls the management of monitoring",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "notifiers": {
+            "description": "Controls the management of notification settings",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "rbac": {
+            "description": "Controls access to role-based access control settings",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "sharedAccessKeys": {
+            "description": "Controls the management of shared access keys",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "read",
+                "update"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "users": {
+            "description": "Controls user management within the organization",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          },
+          "views": {
+            "description": "Controls the management of data views",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            },
+            "x-omitempty": true
+          }
+        }
+      },
+      "roleViewCapabilities": {
+        "description": "Defines the available permissions for view operations",
+        "type": "object",
+        "additionalProperties": {
+          "properties": {
+            "query": {
+              "description": "Controls the ability to query and read data from views",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "share": {
+              "description": "Controls the ability to share views with other users",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            }
+          }
+        }
+      },
+      "s3CompatProperties": {
+        "type": "object",
+        "required": [
+          "accessKeyId",
+          "secretAccessKey",
+          "hostname",
+          "bucket"
+        ],
+        "properties": {
+          "accessKeyId": {
+            "description": "AWS access key identifier",
+            "type": "string"
+          },
+          "bucket": {
+            "description": "Name of the destination bucket",
+            "type": "string"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "ndjson",
+              "headerlessCsv",
+              "csv",
+              "parquetFlat",
+              "sparseNdjson"
+            ]
+          },
+          "hostname": {
+            "description": "Hostname of the S3 compatible storage",
+            "type": "string"
+          },
+          "maximumEvents": {
+            "description": "Maximum number of events to send in a single file",
+            "type": "integer"
+          },
+          "region": {
+            "description": "Region of the destination bucket",
+            "type": "string"
+          },
+          "secretAccessKey": {
+            "description": "AWS secret access key",
+            "type": "string"
+          }
+        }
+      },
+      "viewCapabilities": {
+        "type": "object",
+        "additionalProperties": {
+          "properties": {
+            "query": {
+              "description": "Query capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "read"
+                ]
+              },
+              "x-omitempty": true
+            },
+            "share": {
+              "description": "Sharing view capability",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "read",
+                  "delete"
+                ]
+              },
+              "x-omitempty": true
+            }
+          }
+        }
+      },
+      "Dashboard": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "charts": {
+            "maxItems": 200,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Chart"
+            }
+          },
+          "layout": {
+            "maxItems": 200,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LayoutItem"
+            }
+          },
+          "refreshTime": {
+            "type": "integer",
+            "enum": [
+              15,
+              60,
+              300
+            ]
+          },
+          "schemaVersion": {
+            "$ref": "#/components/schemas/SchemaVersion"
+          },
+          "against": {
+            "type": "string",
+            "enum": [
+              "-1h",
+              "-3h",
+              "-6h",
+              "-12h",
+              "-1d",
+              "-3d",
+              "-7d",
+              "-1w",
+              "-2w",
+              "-3w",
+              "-30d",
+              "-60d",
+              "-90d"
+            ],
+            "description": "Relative time comparison offset. Compares the current time window against a previous period offset by this duration. Mutually exclusive with `againstTimestamp` \u2014 setting one clears the other. Use an empty string or omit to disable comparison."
+          },
+          "againstTimestamp": {
+            "$ref": "#/components/schemas/DatetimeString",
+            "description": "Absolute or relative timestamp to compare against. Mutually exclusive with `against` \u2014 setting one clears the other. Accepts ISO 8601, `now-{duration}` (e.g. `now-1h`), or epoch milliseconds as a string."
+          },
+          "timeWindowStart": {
+            "$ref": "#/components/schemas/TimeWindowStart"
+          },
+          "timeWindowEnd": {
+            "$ref": "#/components/schemas/TimeWindowEnd"
+          },
+          "uid": {
+            "$ref": "#/components/schemas/DashboardUID"
+          }
+        },
+        "required": [
+          "name",
+          "owner",
+          "charts",
+          "layout",
+          "refreshTime",
+          "schemaVersion",
+          "timeWindowStart",
+          "timeWindowEnd"
+        ],
+        "additionalProperties": false
+      },
+      "Owner": {
+        "type": "string",
+        "description": "User ID of the dashboard owner. Use `X-AXIOM-EVERYONE` to make the dashboard accessible to all users in the organization."
+      },
+      "Chart": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TimeSeriesChart"
+          },
+          {
+            "$ref": "#/components/schemas/HeatmapChart"
+          },
+          {
+            "$ref": "#/components/schemas/LogStreamChart"
+          },
+          {
+            "$ref": "#/components/schemas/PieChart"
+          },
+          {
+            "$ref": "#/components/schemas/ScatterChart"
+          },
+          {
+            "$ref": "#/components/schemas/TableChart"
+          },
+          {
+            "$ref": "#/components/schemas/TopKChart"
+          },
+          {
+            "$ref": "#/components/schemas/StatisticChart"
+          },
+          {
+            "$ref": "#/components/schemas/NoteChart"
+          },
+          {
+            "$ref": "#/components/schemas/MonitorListChart"
+          },
+          {
+            "$ref": "#/components/schemas/SmartFilterChart"
+          },
+          {
+            "$ref": "#/components/schemas/SpacerChart"
+          }
+        ]
+      },
+      "TimeSeriesChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "TimeSeries"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/TimeSeriesNonMetricsAplQuery"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Timeseries"
+      },
+      "ChartId": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      },
+      "ChartModified": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 9007199254740991
+      },
+      "ChartNumSeries": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 9007199254740991
+      },
+      "ChartHideHeader": {
+        "type": "boolean"
+      },
+      "OverrideDashboardTimeRange": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "OverrideDashboardCompareAgainst": {
+        "type": "boolean"
+      },
+      "AplString": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500000
+      },
+      "DatetimeString": {
+        "type": "string",
+        "maxLength": 100,
+        "description": "A datetime value. Accepts ISO 8601 (e.g. `2024-01-02T00:00:00.000Z`), relative time using `now-{duration}` where duration is a number followed by `s` (seconds), `m` (minutes), `h` (hours), `d` (days), or `w` (weeks) (e.g. `now-1h`, `now-7d`), a Unix epoch millisecond timestamp as a string (e.g. `1704067200000`), or an empty string to clear the value."
+      },
+      "TimeSeriesQueryOptions": {
+        "type": "object",
+        "properties": {
+          "displayNull": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "null",
+              "span",
+              "zero",
+              ""
+            ],
+            "description": "Controls how empty intervals are rendered in time series charts. `auto` infers from the query, `null` leaves gaps, `span` connects adjacent points, `zero` fills with zero."
+          },
+          "overlayCharts": {
+            "$ref": "#/components/schemas/BooleanString",
+            "description": "When enabled, charts are overlaid on a single chart instead of stacked separately."
+          },
+          "shownColumns": {
+            "type": "string",
+            "maxLength": 10000
+          },
+          "timeSeriesVariant": {
+            "type": "string",
+            "enum": [
+              "area",
+              "bars",
+              "line",
+              "lines",
+              ""
+            ]
+          },
+          "timeSeriesView": {
+            "type": "string",
+            "enum": [
+              "charts",
+              "resultsTable",
+              "charts|resultsTable",
+              ""
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "BooleanString": {
+        "type": "string",
+        "enum": [
+          "true",
+          "false",
+          ""
+        ]
+      },
+      "QueryVariables": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "string",
+              "maxLength": 10000
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "nullable": true,
+              "enum": [
+                null
+              ]
+            }
+          ]
+        }
+      },
+      "QueryLibraries": {
+        "nullable": true,
+        "maxItems": 50,
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "pattern": "^[a-zA-Z0-9._/@-]+$"
+        }
+      },
+      "DefaultLimit": {
+        "type": "integer",
+        "exclusiveMinimum": true,
+        "maximum": 1000000
+      },
+      "DefaultOrder": {
+        "nullable": true,
+        "maxItems": 50,
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/DefaultOrderItem"
+        }
+      },
+      "DefaultOrderItem": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "desc": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MaxBinAutoGroups": {
+        "type": "integer",
+        "exclusiveMinimum": true,
+        "maximum": 10000
+      },
+      "QueryRegion": {
+        "type": "string",
+        "maxLength": 100,
+        "pattern": "^cloud\\.[a-z0-9-]+\\.[a-z0-9-]+$"
+      },
+      "Resolution": {
+        "type": "string",
+        "maxLength": 50
+      },
+      "IncludeCursorField": {
+        "type": "boolean"
+      },
+      "TimeSeriesNonMetricsAplQuery": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "$ref": "#/components/schemas/AplString"
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/TimeSeriesQueryOptions"
+          }
+        },
+        "required": [
+          "apl"
+        ],
+        "additionalProperties": false,
+        "title": "APL"
+      },
+      "Aggregation": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "argument": {},
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "field",
+          "op"
+        ],
+        "additionalProperties": false
+      },
+      "Filter": {
+        "type": "object",
+        "properties": {
+          "caseSensitive": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "children": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Filter"
+            }
+          },
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "type": "string",
+            "enum": [
+              "and",
+              "or",
+              "==",
+              "not",
+              "!=",
+              "exists",
+              "not-exists",
+              ">",
+              ">=",
+              "<",
+              "<=",
+              "starts-with",
+              "not-starts-with",
+              "ends-with",
+              "not-ends-with",
+              "contains",
+              "not-contains",
+              "has",
+              "not-has",
+              "regexp",
+              "not-regexp"
+            ]
+          },
+          "value": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "field",
+          "op"
+        ],
+        "additionalProperties": false
+      },
+      "Projection": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "additionalProperties": false
+      },
+      "AggChartOptsString": {
+        "type": "string",
+        "maxLength": 100000
+      },
+      "VirtualColumn": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "expr": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "alias",
+          "expr"
+        ],
+        "additionalProperties": false
+      },
+      "ChartMetadata": {
+        "type": "object",
+        "properties": {
+          "requires": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dataset": {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                "fields": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                }
+              },
+              "required": [
+                "dataset",
+                "fields"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "noData": {
+            "type": "object",
+            "properties": {
+              "coverName": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "iconName": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "iconColor": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "message": {
+                "type": "string",
+                "maxLength": 1000
+              },
+              "buttonLabel": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "buttonLink": {
+                "type": "string",
+                "maxLength": 2000
+              }
+            },
+            "additionalProperties": false
+          },
+          "zeroData": {
+            "type": "object",
+            "properties": {
+              "coverName": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "iconName": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "iconColor": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "message": {
+                "type": "string",
+                "maxLength": 1000
+              },
+              "buttonLabel": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "buttonLink": {
+                "type": "string",
+                "maxLength": 2000
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "HeatmapChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Heatmap"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/HeatmapNonMetricsAplQuery"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Heatmap"
+      },
+      "HeatmapQueryOptions": {
+        "type": "object",
+        "properties": {
+          "timeSeriesView": {
+            "type": "string",
+            "enum": [
+              "charts",
+              "resultsTable",
+              "charts|resultsTable",
+              ""
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "HeatmapNonMetricsAplQuery": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "$ref": "#/components/schemas/AplString"
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/HeatmapQueryOptions"
+          }
+        },
+        "required": [
+          "apl"
+        ],
+        "additionalProperties": false,
+        "title": "APL"
+      },
+      "LogStreamChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "LogStream"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          },
+          "tableSettings": {
+            "$ref": "#/components/schemas/TableSettings"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Log stream"
+      },
+      "SimpleNonMetricsAplQuery": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "$ref": "#/components/schemas/AplString"
+          }
+        },
+        "required": [
+          "apl"
+        ],
+        "additionalProperties": false,
+        "title": "APL"
+      },
+      "TableSettings": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "maxItems": 500,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnSetting"
+            }
+          },
+          "settings": {
+            "$ref": "#/components/schemas/DatasetStreamSettings"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ColumnSetting": {
+        "oneOf": [
+          {
+            "type": "string",
+            "maxLength": 500
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedColumnSetting"
+          }
+        ]
+      },
+      "AdvancedColumnSetting": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "width": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "DatasetStreamSettings": {
+        "type": "object",
+        "properties": {
+          "fontSize": {
+            "type": "string",
+            "maxLength": 20,
+            "pattern": "^\\d+px$"
+          },
+          "highlightSeverity": {
+            "type": "boolean"
+          },
+          "showRaw": {
+            "type": "boolean"
+          },
+          "showEvent": {
+            "type": "boolean"
+          },
+          "showTimestamp": {
+            "type": "boolean"
+          },
+          "wrapLines": {
+            "type": "boolean"
+          },
+          "hideNulls": {
+            "type": "boolean"
+          },
+          "fitColumns": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PieChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Pie"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Pie"
+      },
+      "ScatterChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Scatter"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Scatter"
+      },
+      "TableChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Table"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          },
+          "tableSettings": {
+            "$ref": "#/components/schemas/TableSettings"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Table"
+      },
+      "TopKChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "TopK"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Top list"
+      },
+      "StatisticChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Statistic"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "query": {
+            "$ref": "#/components/schemas/SimpleNonMetricsAplQuery"
+          },
+          "colorScheme": {
+            "type": "string",
+            "enum": [
+              "Blue",
+              "Orange",
+              "Red",
+              "Purple",
+              "Teal",
+              "Yellow",
+              "Green",
+              "Pink",
+              "Grey",
+              "Brown"
+            ]
+          },
+          "customUnits": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "showChart": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "hideValue": {
+            "type": "boolean"
+          },
+          "chartHeight": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "errorThreshold": {
+            "type": "string",
+            "enum": [
+              "Above",
+              "AboveOrEqual",
+              "Below",
+              "BelowOrEqual",
+              "AboveOrBelow"
+            ]
+          },
+          "errorThresholdValue": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "warningThreshold": {
+            "type": "string",
+            "enum": [
+              "Above",
+              "AboveOrEqual",
+              "Below",
+              "BelowOrEqual",
+              "AboveOrBelow"
+            ]
+          },
+          "warningThresholdValue": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "invertTheme": {
+            "type": "boolean"
+          },
+          "background": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "textColor": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "labelColor": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "chartFillColor": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "okColorProps": {
+            "$ref": "#/components/schemas/StatisticChartColorProps"
+          },
+          "warningColorProps": {
+            "$ref": "#/components/schemas/StatisticChartColorProps"
+          },
+          "errorColorProps": {
+            "$ref": "#/components/schemas/StatisticChartColorProps"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "query"
+        ],
+        "additionalProperties": false,
+        "title": "Statistic"
+      },
+      "CssColor": {
+        "type": "string",
+        "maxLength": 200
+      },
+      "StatisticChartColorProps": {
+        "type": "object",
+        "properties": {
+          "background": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "chartFillColor": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "labelColor": {
+            "$ref": "#/components/schemas/CssColor"
+          },
+          "textColor": {
+            "$ref": "#/components/schemas/CssColor"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NoteChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Note"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100000
+          },
+          "variant": {
+            "type": "string",
+            "enum": [
+              "default"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "text"
+        ],
+        "additionalProperties": false,
+        "title": "Note"
+      },
+      "MonitorListChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "MonitorList"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "selectedMonitors": {
+            "minItems": 1,
+            "maxItems": 200,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          "columns": {
+            "$ref": "#/components/schemas/MonitorListColumns"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "selectedMonitors",
+          "columns"
+        ],
+        "additionalProperties": false,
+        "title": "Monitor list"
+      },
+      "MonitorListColumns": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "boolean"
+          },
+          "history": {
+            "type": "boolean"
+          },
+          "dataset": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "boolean"
+          },
+          "notifiers": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "status",
+          "history",
+          "dataset",
+          "type",
+          "notifiers"
+        ],
+        "additionalProperties": false
+      },
+      "SmartFilterChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SmartFilter"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "filters": {
+            "minItems": 1,
+            "maxItems": 50,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SmartFilterConfig"
+            }
+          },
+          "logo": {
+            "$ref": "#/components/schemas/LogoUrl"
+          },
+          "logoDark": {
+            "$ref": "#/components/schemas/LogoUrl"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "filters"
+        ],
+        "additionalProperties": false,
+        "title": "Filter bar"
+      },
+      "SmartFilterConfig": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SmartFilterSearch"
+          },
+          {
+            "$ref": "#/components/schemas/SmartFilterSelect"
+          }
+        ]
+      },
+      "SmartFilterSearch": {
+        "type": "object",
+        "properties": {
+          "__isPlaceholderData": {
+            "$ref": "#/components/schemas/SmartFilterIsPlaceholderData"
+          },
+          "id": {
+            "$ref": "#/components/schemas/SmartFilterId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/SmartFilterName"
+          },
+          "active": {
+            "$ref": "#/components/schemas/SmartFilterActive"
+          },
+          "options": {
+            "$ref": "#/components/schemas/SmartFilterOptions"
+          },
+          "datasetId": {
+            "$ref": "#/components/schemas/SmartFilterDatasetId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "search"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "additionalProperties": false,
+        "title": "SmartFilterSearch"
+      },
+      "SmartFilterIsPlaceholderData": {
+        "type": "boolean"
+      },
+      "SmartFilterId": {
+        "type": "string",
+        "maxLength": 200
+      },
+      "SmartFilterName": {
+        "type": "string",
+        "maxLength": 200
+      },
+      "SmartFilterActive": {
+        "type": "boolean"
+      },
+      "SmartFilterOptions": {
+        "anyOf": [
+          {
+            "maxItems": 200,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SmartFilterOption"
+            }
+          },
+          {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              null
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              ""
+            ]
+          }
+        ]
+      },
+      "SmartFilterOption": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "key": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "value": {
+            "type": "string",
+            "maxLength": 10000
+          },
+          "default": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "additionalProperties": false
+      },
+      "SmartFilterDatasetId": {
+        "type": "string",
+        "maxLength": 200
+      },
+      "SmartFilterSelect": {
+        "type": "object",
+        "properties": {
+          "__isPlaceholderData": {
+            "$ref": "#/components/schemas/SmartFilterIsPlaceholderData"
+          },
+          "id": {
+            "$ref": "#/components/schemas/SmartFilterId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/SmartFilterName"
+          },
+          "active": {
+            "$ref": "#/components/schemas/SmartFilterActive"
+          },
+          "options": {
+            "$ref": "#/components/schemas/SmartFilterOptions"
+          },
+          "datasetId": {
+            "$ref": "#/components/schemas/SmartFilterDatasetId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "select"
+            ]
+          },
+          "selectType": {
+            "$ref": "#/components/schemas/SmartFilterSelectType"
+          },
+          "apl": {
+            "$ref": "#/components/schemas/SmartFilterApl"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "additionalProperties": false,
+        "title": "SmartFilterSelect"
+      },
+      "SmartFilterSelectType": {
+        "nullable": true,
+        "type": "string",
+        "enum": [
+          "list",
+          "apl",
+          ""
+        ]
+      },
+      "SmartFilterApl": {
+        "title": "SmartFilterApl",
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AplQuery"
+              },
+              {
+                "$ref": "#/components/schemas/EmptyAplObject"
+              }
+            ]
+          }
+        ]
+      },
+      "NonMetricsAplQuery": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "$ref": "#/components/schemas/AplString"
+          },
+          "queryOptions": {
+            "$ref": "#/components/schemas/QueryOptions"
+          }
+        },
+        "required": [
+          "apl"
+        ],
+        "additionalProperties": false,
+        "title": "APL"
+      },
+      "EmptyAplObject": {
+        "type": "object",
+        "properties": {
+          "apl": {
+            "type": "string",
+            "enum": [
+              ""
+            ]
+          }
+        },
+        "required": [
+          "apl"
+        ],
+        "additionalProperties": {},
+        "title": "EmptyAplObject"
+      },
+      "LogoUrl": {
+        "type": "string",
+        "maxLength": 2000
+      },
+      "SpacerChart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Spacer"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "additionalProperties": false,
+        "title": "Spacer"
+      },
+      "LayoutItem": {
+        "type": "object",
+        "properties": {
+          "i": {
+            "$ref": "#/components/schemas/ChartId"
+          },
+          "x": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 11
+          },
+          "y": {
+            "nullable": true,
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "w": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 12
+          },
+          "h": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "minW": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 12
+          },
+          "minH": {
+            "type": "number",
+            "minimum": 0.5,
+            "maximum": 100
+          },
+          "maxW": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 12
+          },
+          "maxH": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "static": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "i",
+          "x",
+          "y",
+          "w",
+          "h"
+        ],
+        "additionalProperties": false
+      },
+      "SchemaVersion": {
+        "type": "integer",
+        "enum": [
+          2
+        ]
+      },
+      "TimeWindowStart": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 100,
+        "description": "Start of the dashboard time range. Use `qr-now-{duration}` for a quick range relative to now, where duration is a number followed by `s` (seconds), `m` (minutes), `h` (hours), `d` (days), or `w` (weeks). Examples: `qr-now-5m`, `qr-now-1h`, `qr-now-7d`. Alternatively, use a Unix epoch millisecond timestamp as a string (e.g. `1704067200000`)."
+      },
+      "TimeWindowEnd": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 100,
+        "description": "End of the dashboard time range. Use `qr-now` for a rolling window that tracks the current time (pair with a `qr-now-{duration}` start), or a Unix epoch millisecond timestamp as a string (e.g. `1704153600000`)."
+      },
+      "Overrides": {
+        "type": "object",
+        "properties": {
+          "rowHeight": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          }
+        },
+        "additionalProperties": false
+      },
+      "DashboardUID": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_-]{1,128}$",
+        "description": "Optional dashboard UID. Must contain only letters, numbers, underscores, or hyphens, with length 1-128 when provided."
+      },
+      "DashboardOutput": {
+        "$ref": "#/components/schemas/DashboardResource"
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ]
+}

--- a/scripts/sanitize-openapi.js
+++ b/scripts/sanitize-openapi.js
@@ -1,0 +1,176 @@
+// Sanitize OpenAPI specs by removing fields marked with x-hide-in-docs: true.
+//
+// Reads from restapi/source/*.json, writes to restapi/versions/*.json.
+// Handles parameters, schema properties, and headers.
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const SOURCE_DIR = path.join(ROOT, "restapi", "source");
+const OUTPUT_DIR = path.join(ROOT, "restapi", "versions");
+
+const MARKER = "x-hide-in-docs";
+const REMOVE = Symbol("remove");
+
+function validateNoHiddenReusableComponents(spec, file) {
+  const components = spec.components || {};
+
+  for (const section of ["parameters", "headers"]) {
+    const items = components[section];
+    if (!items || typeof items !== "object") continue;
+
+    for (const [name, value] of Object.entries(items)) {
+      if (value && value[MARKER] === true) {
+        throw new Error(
+          `${file}: ${MARKER} is not supported on reusable components.${section}.${name}. ` +
+            `Inline the parameter/header in the operation instead.`
+        );
+      }
+    }
+  }
+}
+
+function sanitize(node, ctx = {}) {
+  if (Array.isArray(node)) {
+    return node
+      .map((item) => sanitize(item, ctx))
+      .filter((item) => item !== REMOVE);
+  }
+
+  if (!node || typeof node !== "object") return node;
+
+  // Only remove nodes in relevant contexts
+  if (node[MARKER] === true) {
+    if (ctx.removable) {
+      return REMOVE;
+    }
+    console.warn(
+      `Warning: ${MARKER} found in unsupported location (not a property, parameter, or header). ` +
+        `The field will not be hidden.`
+    );
+  }
+
+  // First pass: process properties to know which were removed
+  const removedProperties = new Set();
+  let processedProperties = undefined;
+
+  if (
+    node.properties &&
+    typeof node.properties === "object" &&
+    !Array.isArray(node.properties)
+  ) {
+    processedProperties = {};
+    for (const [propName, propSchema] of Object.entries(node.properties)) {
+      const result = sanitize(propSchema, { removable: true });
+      if (result === REMOVE) {
+        removedProperties.add(propName);
+      } else {
+        processedProperties[propName] = result;
+      }
+    }
+  }
+
+  // Second pass: build output preserving original key order
+  const out = {};
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === MARKER) continue;
+
+    if (key === "properties" && processedProperties !== undefined) {
+      out[key] = processedProperties;
+      continue;
+    }
+
+    if (key === "required" && Array.isArray(value)) {
+      const filtered = value.filter(
+        (name) => !removedProperties.has(name)
+      );
+      if (filtered.length > 0) {
+        out[key] = filtered;
+      }
+      continue;
+    }
+
+    if (key === "parameters") {
+      if (Array.isArray(value)) {
+        out[key] = value
+          .map((item) => sanitize(item, { removable: true }))
+          .filter((item) => item !== REMOVE);
+      } else if (value && typeof value === "object") {
+        const params = {};
+        for (const [name, param] of Object.entries(value)) {
+          const result = sanitize(param, { removable: true });
+          if (result !== REMOVE) params[name] = result;
+        }
+        out[key] = params;
+      }
+      continue;
+    }
+
+    if (
+      key === "headers" &&
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      const headers = {};
+      for (const [headerName, header] of Object.entries(value)) {
+        const result = sanitize(header, { removable: true });
+        if (result !== REMOVE) headers[headerName] = result;
+      }
+      out[key] = headers;
+      continue;
+    }
+
+    out[key] = sanitize(value);
+  }
+
+  return out;
+}
+
+function main() {
+  if (!fs.existsSync(SOURCE_DIR)) {
+    console.error(`Source directory not found: ${SOURCE_DIR}`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const files = fs
+    .readdirSync(SOURCE_DIR)
+    .filter((f) => f.endsWith(".json"));
+
+  if (files.length === 0) {
+    console.error("No JSON files found in source directory.");
+    process.exit(1);
+  }
+
+  for (const file of files) {
+    const sourcePath = path.join(SOURCE_DIR, file);
+    const outputPath = path.join(OUTPUT_DIR, file);
+
+    const raw = fs.readFileSync(sourcePath, "utf-8");
+    const spec = JSON.parse(raw);
+
+    validateNoHiddenReusableComponents(spec, file);
+
+    const sanitized = sanitize(spec);
+
+    fs.writeFileSync(outputPath, JSON.stringify(sanitized, null, 2) + "\n");
+    console.log(`Sanitized: ${file}`);
+  }
+
+  // Remove stale files in output that no longer exist in source
+  const outputFiles = fs
+    .readdirSync(OUTPUT_DIR)
+    .filter((f) => f.endsWith(".json"));
+  for (const file of outputFiles) {
+    if (!files.includes(file)) {
+      fs.unlinkSync(path.join(OUTPUT_DIR, file));
+      console.log(`Removed stale: ${file}`);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## What changed

Add a preprocessing pipeline that allows hiding specific fields from the rendered API documentation by marking them with `x-hide-in-docs: true` in the OpenAPI source specs.

### Architecture

```
restapi/source/*.json  →  scripts/sanitize-openapi.js  →  restapi/versions/*.json
   (source of truth)         (strips hidden fields)         (Mintlify input)
```

- **Source specs** moved to `restapi/source/` — this is where editors add `x-hide-in-docs: true`
- **Generated specs** written to `restapi/versions/` — same filenames, so no MDX changes needed
- **Zero changes** to endpoint MDX files or `docs.json`

### Usage

Add `"x-hide-in-docs": true` to any parameter, schema property, or header:

```json
{
  "properties": {
    "internal_id": {
      "type": "string",
      "x-hide-in-docs": true
    }
  }
}
```

Then regenerate:

```
node scripts/sanitize-openapi.js
```

### Safety

- Fail-fast if `x-hide-in-docs` is used on reusable `components.parameters` or `components.headers` (would cause dangling $refs)
- Warns if the marker appears in unsupported locations
- Cleans up `required` arrays when properties are removed
- CI workflow checks for drift between source and generated specs (catches untracked files too)

## Why

Mintlify has no native per-field hide attribute. This preprocessing approach gives us a simple boolean marker without requiring Mintlify auth/personalization or any MDX changes.

Amp thread: https://ampcode.com/threads/T-019d1a5a-a19a-77aa-9ca4-4b53369b8a38