### PR TITLE
Update popular pages based on do11y

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -43,6 +43,11 @@ Intuitive web app built for exploration, visualization, and monitoring of your d
 - **Flexible insights:** Real-time query capabilities and an increasingly intelligent UI help pinpoint issues and opportunities without sampling.
 - **AI engineering:** Axiom provides specialized features designed explicitly for AI engineering workflows, allowing teams to confidently build, deploy, and optimize AI capabilities.
 
+Learn more about the popular use cases for Axiom:
+- [AI engineering](/ai-engineering/overview)
+- [Observability](/getting-started-guide/observability)
+- [Product analytics](/getting-started-guide/product-analytics)
+
 ## What do you want to do?
 
 <CardGroup cols={2}>
@@ -61,9 +66,11 @@ Intuitive web app built for exploration, visualization, and monitoring of your d
   <Card title="AI engineering" icon="robot" href="/ai-engineering/overview">
     Build, deploy, and optimize AI capabilities with Axiom's AI features.
   </Card>
-  <Card title="Get started guide" icon="rocket" href="/getting-started-guide/observability">
+  {/*
+  <Card title="Get started guide" icon="rocket" href="/getting-started-guide/getting-started">
     Follow a step-by-step guide to set up observability or product analytics.
   </Card>
+  */}
 </CardGroup>
 
 New to Axiom? [Explore the interactive demo playground](https://play.axiom.co/) or [create a free account](https://app.axiom.co/register).

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -27,7 +27,7 @@ Dedicated metrics datastore engineered specifically for high-cardinality time-se
 - **Optimized storage:** Purpose-built storage format designed for time-series workloads delivers efficient compression and fast aggregations across millions of unique tag combinations.
 - **Thoughtful constraints:** Design choices prioritize the most common metrics use cases while maintaining exceptional performance.
 
-For more information, see [Axiom’s architecture](/platform-overview/architecture).
+For more information, see [Axiom's architecture](/platform-overview/architecture).
 
 ### Console
 
@@ -43,8 +43,27 @@ Intuitive web app built for exploration, visualization, and monitoring of your d
 - **Flexible insights:** Real-time query capabilities and an increasingly intelligent UI help pinpoint issues and opportunities without sampling.
 - **AI engineering:** Axiom provides specialized features designed explicitly for AI engineering workflows, allowing teams to confidently build, deploy, and optimize AI capabilities.
 
-## Getting started
+## What do you want to do?
 
-- [Learn more about Axiom’s features](/platform-overview/features).
-- [Explore the interactive demo playground](https://play.axiom.co/).
-- [Create your own organization](https://app.axiom.co/register).
+<CardGroup cols={2}>
+  <Card title="Send data" icon="upload" href="/send-data/methods">
+    Ingest events and logs from your apps, infrastructure, and services.
+  </Card>
+  <Card title="Query data" icon="magnifying-glass" href="/query-data/explore">
+    Explore and visualize your data with APL and the Axiom Console.
+  </Card>
+  <Card title="Set up monitoring" icon="bell" href="/monitor-data/monitors">
+    Create threshold-based and anomaly-driven alerts.
+  </Card>
+  <Card title="Use the API" icon="code" href="/restapi/introduction">
+    Send data and manage resources programmatically with the REST API.
+  </Card>
+  <Card title="AI engineering" icon="robot" href="/ai-engineering/overview">
+    Build, deploy, and optimize AI capabilities with Axiom's AI features.
+  </Card>
+  <Card title="Get started guide" icon="rocket" href="/getting-started-guide/observability">
+    Follow a step-by-step guide to set up observability or product analytics.
+  </Card>
+</CardGroup>
+
+New to Axiom? [Explore the interactive demo playground](https://play.axiom.co/) or [create a free account](https://app.axiom.co/register).

--- a/restapi/introduction.mdx
+++ b/restapi/introduction.mdx
@@ -17,7 +17,26 @@ import BaseDomains from "/snippets/base-domains.mdx"
 
 You can use the Axiom API (Application Programming Interface) to send data to Axiom, query data, and manage resources programmatically. This page covers the basics for interacting with the Axiom API.
 
+<CardGroup cols={2}>
+  <Card title="Ingest data" icon="upload" href="/restapi/ingest">
+    Send events and logs to Axiom datasets via the API.
+  </Card>
+  <Card title="Query data" icon="magnifying-glass" href="/restapi/query">
+    Run APL queries against your datasets programmatically.
+  </Card>
+  <Card title="Manage datasets" icon="database" href="/restapi/endpoints/getDatasets">
+    List, create, and configure your Axiom datasets.
+  </Card>
+  <Card title="Manage tokens" icon="key" href="/reference/tokens">
+    Create and manage API tokens and personal access tokens.
+  </Card>
+</CardGroup>
+
 <Prerequisites />
+
+<Info>
+Before making API requests, you need an API token. See [Authentication](#authentication) to learn how to create and use tokens.
+</Info>
 
 ## API basics
 
@@ -99,3 +118,5 @@ Below is a list of the types of data used within the Axiom API:
 
 - [Ingest data via API](/restapi/ingest)
 - [Query data via API](/restapi/query)
+- [List datasets](/restapi/endpoints/getDatasets)
+- [Create and manage tokens](/reference/tokens)

--- a/send-data/methods.mdx
+++ b/send-data/methods.mdx
@@ -28,8 +28,10 @@ To send events continuously, Axiom supports a wide range of standard tools, libr
 
 | Method | Description |
 |:--------|:-------------|
-| [Rest API](/restapi/introduction) | Direct HTTP API for sending logs and events |
 | [OpenTelemetry](/send-data/opentelemetry) | Industry-standard observability framework |
+| [Next.js](/send-data/nextjs) | Full-stack React framework logging |
+| [Vercel](/apps/vercel) | Stream logs from Vercel deployments |
+| [Rest API](/restapi/introduction) | Direct HTTP API for sending logs and events |
 | [Vector](/send-data/vector) | High-performance observability data pipeline |
 | [Cribl](/send-data/cribl) | Route and transform data with Cribl Stream |
 | [Fluent Bit](/send-data/fluent-bit) | Fast and lightweight log processor |
@@ -57,7 +59,6 @@ To send events continuously, Axiom supports a wide range of standard tools, libr
 | [Logstash](/send-data/logstash) | Server-side data processing pipeline |
 | [Loki](/endpoints/loki) | Compatible endpoint for Grafana Loki clients |
 | [Loki Multiplexer](/send-data/loki-multiplexer) | Forward Loki data to multiple destinations |
-| [Next.js](/send-data/nextjs) | Full-stack React framework logging |
 | [Pino](/guides/pino) | Fast Node.js logger integration |
 | [Python](/guides/python) | Python logging with standard library |
 | [React](/send-data/react) | Client-side React app logging |


### PR DESCRIPTION
Improve navigation and discoverability based on docs analytics

**introduction.mdx:** Replace the Getting started section (which currently has three marketing links) with an intent-based card grid segmented by user goal: send data, query data, monitoring, API, AI engineering, and getting started guides. Users arriving at the highest-traffic page (3,250 entry sessions) currently trigger search at 8.5%. This is the highest rate on the site and the reason can be that the page doesn't direct them to their task.

**restapi/introduction.mdx:** Add a quick-nav card grid at the top of the page linking directly to ingest, query, datasets, and tokens. Add an authentication callout above the API basics section. The page has 2,520 entry sessions and a 23.2% scroll depth, indicating that most users leave before reaching the content they need.

**send-data/methods.mdx:** Move Next.js from "Other methods" to "Popular methods" and reorder rows by actual traffic. Next.js is the 5th highest entry point on the site (594 sessions) but is buried below less-visited integrations.