### PR TITLE
Add Privatelink Prod EU Documentation

### DIFF
--- a/apps/aws-privatelink.mdx
+++ b/apps/aws-privatelink.mdx
@@ -28,7 +28,6 @@ Select an edge deployment above to see supported cross-region endpoints.
 
 <div data-show-if="AXIOM_DOMAIN=us-east-1.aws.edge.axiom.co">
 
-- `us-east-1`
 - `us-east-2`
 - `us-west-1`
 - `us-west-2`
@@ -41,7 +40,6 @@ Select an edge deployment above to see supported cross-region endpoints.
 
 <div data-show-if="AXIOM_DOMAIN=eu-central-1.aws.edge.axiom.co">
 
-- `eu-central-1`
 - `eu-north-1`
 
 </div>

--- a/apps/aws-privatelink.mdx
+++ b/apps/aws-privatelink.mdx
@@ -6,28 +6,53 @@ sidebarTitle: AWS PrivateLink
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) is a networking service provided by Amazon Web Services (AWS) that allows you to securely access services hosted on the AWS cloud over a private network connection. With AWS PrivateLink, you can access Axiom directly from your AWS without an internet gateway or NAT device, simplifying your network setup.
 
+## PrivateLink service details
+
+Use the service details for your edge deployment to set up the VPC endpoint.
+
+```
+DNS name:       AXIOM_DOMAIN
+Service name:   PRIVATELINK_SERVICE_NAME
+Service region: PRIVATELINK_SERVICE_REGION
+```
+
 ## Cross-region support
 
-The Axiom service is hosted in the `us-east-1` region. Axiom supports native cross-region PrivateLink for the following regions:
+Axiom supports native cross-region PrivateLink for the following regions:
 
-US regions:
+<div data-show-if="AXIOM_DOMAIN=">
+
+Select an edge deployment above to see supported cross-region endpoints.
+
+</div>
+
+<div data-show-if="AXIOM_DOMAIN=us-east-1.aws.edge.axiom.co">
+
+- `us-east-1`
 - `us-east-2`
 - `us-west-1`
 - `us-west-2`
-
-EU regions:
 - `eu-west-1`
 - `eu-west-2`
 - `eu-west-3`
 - `eu-central-1`
 
-To connect to a region that isn’t listed above, [contact Axiom](https://axiom.co/contact).
+</div>
+
+<div data-show-if="AXIOM_DOMAIN=eu-central-1.aws.edge.axiom.co">
+
+- `eu-central-1`
+- `eu-north-1`
+
+</div>
+
+To connect to a region that isn't listed above, [contact Axiom](https://axiom.co/contact).
 
 ## Setup
 
 1. In your VPC Console, go to **PrivateLink and Lattice > Endpoints**, and then click **Create endpoint**.
-1. Select **PrivateLink ready partner services**, and then enter `com.amazonaws.vpce.us-east-1.vpce-svc-05a64735cdf68866b` as the service name.
-1. Under **Service Region**, turn on **Cross-region endpoint**, and then select the `us-east-1` region. This is the region where the Axiom service is hosted, and it’s independent of your VPC’s region.
+1. Select **PrivateLink ready partner services**, and then enter the service name for your edge deployment.
+1. Under **Service Region**, turn on **Cross-region endpoint**, and then select the service region for your edge deployment. This is the region where the Axiom service is hosted, and it's independent of your VPC's region.
 1. Click **Verify service**.
-1. Select the VPC and subnets that you want to connect to the Axiom VPC service endpoint. Ensure that **Enable DNS name** is turned on and the security group accepts inbound traffic on TCP port `443`.
+1. Select the VPC and subnets that you want to connect to the Axiom VPC service endpoint. Ensure that **Enable DNS name** is turned on and the security group accepts inbound traffic on TCP port `443`.
 1. Finish the setup and wait for the VPC endpoint to become available. This usually takes 10 minutes.

--- a/scripts/placeholder-configurator.js
+++ b/scripts/placeholder-configurator.js
@@ -29,7 +29,17 @@
                 { value: "", label: "Select edge deployment" },
                 { value: "us-east-1.aws.edge.axiom.co", label: "US East 1 (AWS)" },
                 { value: "eu-central-1.aws.edge.axiom.co", label: "EU Central 1 (AWS)" }
-            ]
+            ],
+            linkedValues: {
+                "us-east-1.aws.edge.axiom.co": {
+                    "PRIVATELINK_SERVICE_NAME": "com.amazonaws.vpce.us-east-1.vpce-svc-05a64735cdf68866b",
+                    "PRIVATELINK_SERVICE_REGION": "us-east-1"
+                },
+                "eu-central-1.aws.edge.axiom.co": {
+                    "PRIVATELINK_SERVICE_NAME": "com.amazonaws.vpce.eu-central-1.vpce-svc-00e8d47e8c60784f7",
+                    "PRIVATELINK_SERVICE_REGION": "eu-central-1"
+                }
+            }
         },
         "API_TOKEN": { 
             label: "API token", 
@@ -47,7 +57,22 @@
             help: 'The ID of your Axiom organization. For more information, see <a class="link" href="https://axiom.co/docs/reference/tokens#determine-organization-id">Determine organization ID</a>.'
         }
     };
-    var PLACEHOLDER_PATTERNS = Object.keys(PLACEHOLDERS);
+    // Collect all linked value keys (e.g. SERVICE_NAME, SERVICE_REGION) so they
+    // are detected in code blocks and replaced when their parent placeholder is set.
+    var LINKED_VALUE_KEYS = [];
+    Object.keys(PLACEHOLDERS).forEach(function(key) {
+        var config = PLACEHOLDERS[key];
+        if (config.linkedValues) {
+            Object.keys(config.linkedValues).forEach(function(domainVal) {
+                Object.keys(config.linkedValues[domainVal]).forEach(function(linkedKey) {
+                    if (LINKED_VALUE_KEYS.indexOf(linkedKey) === -1) {
+                        LINKED_VALUE_KEYS.push(linkedKey);
+                    }
+                });
+            });
+        }
+    });
+    var PLACEHOLDER_PATTERNS = Object.keys(PLACEHOLDERS).concat(LINKED_VALUE_KEYS);
     
     var originalCodeContent = new WeakMap();
     var originalCodeHTML = new WeakMap();
@@ -311,6 +336,22 @@
         }
     }
     
+    // Toggle visibility of elements with data-show-if="KEY=value" attributes
+    // based on the current placeholder values. When KEY has no stored value,
+    // only the empty-condition section (data-show-if="KEY=") is shown.
+    function updateConditionalSections(values) {
+        var sections = document.querySelectorAll("[data-show-if]");
+        sections.forEach(function(section) {
+            var condition = section.getAttribute("data-show-if");
+            var eqIndex = condition.indexOf("=");
+            if (eqIndex === -1) return;
+            var key = condition.substring(0, eqIndex);
+            var expected = condition.substring(eqIndex + 1);
+            var current = values[key] || "";
+            section.style.display = current === expected ? "" : "none";
+        });
+    }
+    
     function createConfigBar(preElement, codeElement, placeholdersInCode) {
         var values = loadStoredValues();
         
@@ -320,6 +361,9 @@
         
         placeholdersInCode.forEach(function(key) {
             var config = PLACEHOLDERS[key];
+            // Skip linked-only placeholders (e.g. SERVICE_NAME) — they have no
+            // config of their own and are driven by a parent placeholder's dropdown.
+            if (!config) return;
             var inputId = generateUniqueId(key);
             
             // Outer wrapper for the entire field including help text
@@ -374,10 +418,27 @@
                     } else {
                         delete vals[key];
                     }
+                    // Write linked values when a parent placeholder changes
+                    if (config.linkedValues) {
+                        // Clear all linked keys first
+                        Object.keys(config.linkedValues).forEach(function(domainVal) {
+                            Object.keys(config.linkedValues[domainVal]).forEach(function(linkedKey) {
+                                delete vals[linkedKey];
+                            });
+                        });
+                        // Set linked values for the selected option
+                        if (inputElement.value && config.linkedValues[inputElement.value]) {
+                            var linked = config.linkedValues[inputElement.value];
+                            Object.keys(linked).forEach(function(linkedKey) {
+                                vals[linkedKey] = linked[linkedKey];
+                            });
+                        }
+                    }
                     saveValues(vals);
                     updateSelectColor(inputElement, inputElement.value);
                     updateAllCodeBlocks();
                     updateAllBars();
+                    updateConditionalSections(vals);
                 });
             } else {
                 // Create text input for regular fields
@@ -552,6 +613,9 @@
         });
         
         updateAllBars();
+        
+        // Apply conditional section visibility from stored values
+        updateConditionalSections(values);
         
         // Return status for retry logic
         return { processed: processedCount, hasStoredValues: hasStoredValues };


### PR DESCRIPTION
## Add AWS PrivateLink support for EU Central 1 edge deployment

### Summary

- Add PrivateLink service details for `EU Central 1 (AWS)` edge deployment (`com.amazonaws.vpce.eu-central-1.vpce-svc-00e8d47e8c60784f7`)
- Introduce interactive code block with `AXIOM_DOMAIN`, `PRIVATELINK_SERVICE_NAME`, and `PRIVATELINK_SERVICE_REGION` placeholders that auto-populate based on the edge deployment dropdown selection
- Add `linkedValues` support to the placeholder configurator so a single "Edge domain" dropdown drives all three code block values
- Add `data-show-if` conditional visibility to toggle cross-region support lists based on the selected edge deployment
- EU Central 1 cross-region support: `eu-central-1`, `eu-north-1`
- US East 1 cross-region support: `us-east-2`, `us-west-1`, `us-west-2`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `eu-central-1`

### Changes

| File | Description |
|:-----|:------------|
| `apps/aws-privatelink.mdx` | Restructured page with interactive code block, conditional cross-region sections, and generic setup instructions |
| `scripts/placeholder-configurator.js` | Added `linkedValues` config, `LINKED_VALUE_KEYS` detection, linked value propagation in change handler, `updateConditionalSections()` for `data-show-if` attribute toggling |
