### PR TITLE
fix: add X-Axiom-Org-ID header parameter to all API reference endpoints

### DIFF
--- a/restapi/versions/v1-edge-ingest.json
+++ b/restapi/versions/v1-edge-ingest.json
@@ -36,6 +36,9 @@
         "operationId": "ingestToDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset-id",
             "in": "path",
             "required": true,
@@ -161,6 +164,14 @@
           "format": "int64",
           "minimum": 0,
           "default": 0
+        }
+      },
+      "X-Axiom-Org-ID": {
+        "name": "X-Axiom-Org-ID",
+        "in": "header",
+        "description": "Organization ID. Required when using a personal access token (PAT) for authentication. Not required when using an API token. For more information, see [Determine org ID](/reference/tokens#determine-org-id).",
+        "schema": {
+          "type": "string"
         }
       }
     },

--- a/restapi/versions/v1-edge-query.json
+++ b/restapi/versions/v1-edge-query.json
@@ -36,6 +36,9 @@
         "operationId": "batchQuery",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "Maximum number of concurrent queries to execute",
             "name": "maxConcurrency",
             "in": "query",
@@ -139,6 +142,9 @@
         "operationId": "queryMetrics",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "Response format. If omitted, the Accept header is used for content negotiation. Defaults to metrics-v2 when neither is specified.",
             "name": "format",
             "in": "query",
@@ -236,6 +242,9 @@
         ],
         "operationId": "getDatasetMetrics",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "The dataset to retrieve metrics from",
             "name": "dataset",
@@ -376,6 +385,9 @@
         "operationId": "findMetrics",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "The dataset to search for metrics in",
             "name": "dataset",
             "in": "path",
@@ -485,6 +497,9 @@
         "operationId": "getDatasetMetricTags",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "The dataset to retrieve metric tags from",
             "name": "dataset",
             "in": "path",
@@ -592,6 +607,9 @@
         ],
         "operationId": "getDatasetMetricTagValues",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "The dataset to retrieve metric tag values from",
             "name": "dataset",
@@ -710,6 +728,9 @@
         "operationId": "getDatasetTags",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "The dataset to retrieve tags from",
             "name": "dataset",
             "in": "path",
@@ -808,6 +829,9 @@
         ],
         "operationId": "getDatasetTagValues",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "The dataset to retrieve tag values from",
             "name": "dataset",
@@ -916,6 +940,9 @@
         ],
         "operationId": "queryApl",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "format",
             "in": "query",
@@ -1351,6 +1378,16 @@
           "timeSeriesView": {
             "type": "string"
           }
+        }
+      }
+    },
+    "parameters": {
+      "X-Axiom-Org-ID": {
+        "name": "X-Axiom-Org-ID",
+        "in": "header",
+        "description": "Organization ID. Required when using a personal access token (PAT) for authentication. Not required when using an API token. For more information, see [Determine org ID](/reference/tokens#determine-org-id).",
+        "schema": {
+          "type": "string"
         }
       }
     }

--- a/restapi/versions/v1.json
+++ b/restapi/versions/v1.json
@@ -74,7 +74,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "tags": [
@@ -121,7 +126,12 @@
             ]
           }
         ],
-        "x-codegen-request-body-name": "payload"
+        "x-codegen-request-body-name": "payload",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/datasets/_apl?format=tabular": {
@@ -132,6 +142,9 @@
         "description": "Query",
         "operationId": "queryApl",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "format",
             "in": "query",
@@ -241,6 +254,9 @@
         "operationId": "getDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_name",
             "in": "path",
             "description": "Unique name of the dataset.",
@@ -290,6 +306,9 @@
         "description": "Update dataset",
         "operationId": "updateDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "{dataset_name}",
             "in": "path",
@@ -349,6 +368,9 @@
         "operationId": "deleteDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_name",
             "in": "path",
             "description": "Unique name of the dataset.",
@@ -391,6 +413,9 @@
         "description": "Ingest",
         "operationId": "ingestIntoDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_name",
             "in": "path",
@@ -513,6 +538,9 @@
         "operationId": "queryDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "saveAsKind",
             "in": "query",
             "schema": {
@@ -615,6 +643,9 @@
         "description": "Trim dataset",
         "operationId": "trimDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_name",
             "in": "path",
@@ -897,264 +928,264 @@
         "example": {
           "format": "tabular",
           "status": {
-              "elapsedTime": 260650,
-              "minCursor": "0d8q6stroluyo-07c3957e7400015c-0000c875",
-              "maxCursor": "0d8q6stroluyo-07c3957e7400015c-0000c877",
-              "blocksExamined": 4,
-              "blocksCached": 0,
-              "blocksMatched": 0,
-              "rowsExamined": 197604,
-              "rowsMatched": 197604,
-              "numGroups": 0,
-              "isPartial": false,
-              "cacheStatus": 1,
-              "minBlockTime": "2025-03-26T12:03:14Z",
-              "maxBlockTime": "2025-03-26T12:12:42Z"
+            "elapsedTime": 260650,
+            "minCursor": "0d8q6stroluyo-07c3957e7400015c-0000c875",
+            "maxCursor": "0d8q6stroluyo-07c3957e7400015c-0000c877",
+            "blocksExamined": 4,
+            "blocksCached": 0,
+            "blocksMatched": 0,
+            "rowsExamined": 197604,
+            "rowsMatched": 197604,
+            "numGroups": 0,
+            "isPartial": false,
+            "cacheStatus": 1,
+            "minBlockTime": "2025-03-26T12:03:14Z",
+            "maxBlockTime": "2025-03-26T12:12:42Z"
           },
           "tables": [
-              {
-                  "name": "0",
-                  "sources": [
-                      {
-                          "name": "dataset-name"
-                      }
-                  ],
-                  "fields": [
-                      {
-                          "name": "_sysTime",
-                          "type": "datetime"
-                      },
-                      {
-                          "name": "_time",
-                          "type": "datetime"
-                      },
-                      {
-                          "name": "content_type",
-                          "type": "string"
-                      },
-                      {
-                          "name": "geo.city",
-                          "type": "string"
-                      },
-                      {
-                          "name": "geo.country",
-                          "type": "string"
-                      },
-                      {
-                          "name": "id",
-                          "type": "string"
-                      },
-                      {
-                          "name": "is_tls",
-                          "type": "boolean"
-                      },
-                      {
-                          "name": "message",
-                          "type": "string"
-                      },
-                      {
-                          "name": "method",
-                          "type": "string"
-                      },
-                      {
-                          "name": "req_duration_ms",
-                          "type": "float"
-                      },
-                      {
-                          "name": "resp_body_size_bytes",
-                          "type": "integer"
-                      },
-                      {
-                          "name": "resp_header_size_bytes",
-                          "type": "integer"
-                      },
-                      {
-                          "name": "server_datacenter",
-                          "type": "string"
-                      },
-                      {
-                          "name": "status",
-                          "type": "string"
-                      },
-                      {
-                          "name": "uri",
-                          "type": "string"
-                      },
-                      {
-                          "name": "user_agent",
-                          "type": "string"
-                      },
-                      {
-                          "name": "is_ok_2    ",
-                          "type": "boolean"
-                      },
-                      {
-                          "name": "city_str_len",
-                          "type": "integer"
-                      }
-                  ],
-                  "order": [
-                      {
-                          "field": "_time",
-                          "desc": true
-                      }
-                  ],
-                  "groups": [],
-                  "range": {
-                      "field": "_time",
-                      "start": "1970-01-01T00:00:00Z",
-                      "end": "2025-03-26T12:12:43Z"
-                  },
-                  "columns": [
-                      [
-                          "2025-03-26T12:12:42.68112905Z",
-                          "2025-03-26T12:12:42.68112905Z",
-                          "2025-03-26T12:12:42.68112905Z"
-                      ],
-                      [
-                          "2025-03-26T12:12:42Z",
-                          "2025-03-26T12:12:42Z",
-                          "2025-03-26T12:12:42Z"
-                      ],
-                      [
-                          "text/html",
-                          "text/plain-charset=utf-8",
-                          "image/jpeg"
-                      ],
-                      [
-                          "Ojinaga",
-                          "Humboldt",
-                          "Nevers"
-                      ],
-                      [
-                          "Mexico",
-                          "United States",
-                          "France"
-                      ],
-                      [
-                          "8af366cf-6f25-42e6-bbb4-d860ab535a60",
-                          "032e7f68-b0ab-47c0-a24a-35af566359e5",
-                          "4d2c7baa-ff28-4b1f-9db9-8e6c0ed5a9c9"
-                      ],
-                      [
-                          false,
-                          false,
-                          true
-                      ],
-                      [
-                          "QCD permutations were not solvable in linear time, expected compressed time",
-                          "QCD permutations were not solvable in linear time, expected compressed time",
-                          "Expected a new layer of particle physics but got a Higgs Boson"
-                      ],
-                      [
-                          "GET",
-                          "GET",
-                          "GET"
-                      ],
-                      [
-                          1.396373193863436,
-                          0.16252390534308514,
-                          0.4093416175186162
-                      ],
-                      [
-                          3448,
-                          2533,
-                          1906
-                      ],
-                      [
-                          84,
-                          31,
-                          29
-                      ],
-                      [
-                          "DCA",
-                          "GRU",
-                          "FRA"
-                      ],
-                      [
-                          "201",
-                          "200",
-                          "200"
-                      ],
-                      [
-                          "/api/v1/buy/commit/id/go",
-                          "/api/v1/textdata/cnfigs",
-                          "/api/v1/bank/warn"
-                      ],
-                      [
-                          "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
-                          "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/535.24 (KHTML, like Gecko) Chrome/19.0.1055.1 Safari/535.24",
-                          "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
-                      ],
-                      [
-                          true,
-                          true,
-                          true
-                      ],
-                      [
-                          7,
-                          8,
-                          6
-                      ]
-                  ]
-              }
-            ],
-            "datasetNames": [
-                "dataset-name"
-            ],
-            "fieldsMetaMap": {
-                "dataset-name": [
-                    {
-                        "name": "status",
-                        "type": "",
-                        "unit": "",
-                        "hidden": false,
-                        "description": "HTTP status code"
-                    },
-                    {
-                        "name": "resp_header_size_bytes",
-                        "type": "integer",
-                        "unit": "none",
-                        "hidden": false,
-                        "description": ""
-                    },
-                    {
-                        "name": "geo.city",
-                        "type": "string",
-                        "unit": "",
-                        "hidden": false,
-                        "description": "the city"
-                    },
-                    {
-                        "name": "resp_body_size_bytes",
-                        "type": "integer",
-                        "unit": "decbytes",
-                        "hidden": false,
-                        "description": ""
-                    },
-                    {
-                        "name": "content_type",
-                        "type": "string",
-                        "unit": "",
-                        "hidden": false,
-                        "description": ""
-                    },
-                    {
-                        "name": "geo.country",
-                        "type": "string",
-                        "unit": "",
-                        "hidden": false,
-                        "description": ""
-                    },
-                    {
-                        "name": "req_duration_ms",
-                        "type": "float",
-                        "unit": "ms",
-                        "hidden": false,
-                        "description": "Request duration"
-                    }
+            {
+              "name": "0",
+              "sources": [
+                {
+                  "name": "dataset-name"
+                }
+              ],
+              "fields": [
+                {
+                  "name": "_sysTime",
+                  "type": "datetime"
+                },
+                {
+                  "name": "_time",
+                  "type": "datetime"
+                },
+                {
+                  "name": "content_type",
+                  "type": "string"
+                },
+                {
+                  "name": "geo.city",
+                  "type": "string"
+                },
+                {
+                  "name": "geo.country",
+                  "type": "string"
+                },
+                {
+                  "name": "id",
+                  "type": "string"
+                },
+                {
+                  "name": "is_tls",
+                  "type": "boolean"
+                },
+                {
+                  "name": "message",
+                  "type": "string"
+                },
+                {
+                  "name": "method",
+                  "type": "string"
+                },
+                {
+                  "name": "req_duration_ms",
+                  "type": "float"
+                },
+                {
+                  "name": "resp_body_size_bytes",
+                  "type": "integer"
+                },
+                {
+                  "name": "resp_header_size_bytes",
+                  "type": "integer"
+                },
+                {
+                  "name": "server_datacenter",
+                  "type": "string"
+                },
+                {
+                  "name": "status",
+                  "type": "string"
+                },
+                {
+                  "name": "uri",
+                  "type": "string"
+                },
+                {
+                  "name": "user_agent",
+                  "type": "string"
+                },
+                {
+                  "name": "is_ok_2    ",
+                  "type": "boolean"
+                },
+                {
+                  "name": "city_str_len",
+                  "type": "integer"
+                }
+              ],
+              "order": [
+                {
+                  "field": "_time",
+                  "desc": true
+                }
+              ],
+              "groups": [],
+              "range": {
+                "field": "_time",
+                "start": "1970-01-01T00:00:00Z",
+                "end": "2025-03-26T12:12:43Z"
+              },
+              "columns": [
+                [
+                  "2025-03-26T12:12:42.68112905Z",
+                  "2025-03-26T12:12:42.68112905Z",
+                  "2025-03-26T12:12:42.68112905Z"
+                ],
+                [
+                  "2025-03-26T12:12:42Z",
+                  "2025-03-26T12:12:42Z",
+                  "2025-03-26T12:12:42Z"
+                ],
+                [
+                  "text/html",
+                  "text/plain-charset=utf-8",
+                  "image/jpeg"
+                ],
+                [
+                  "Ojinaga",
+                  "Humboldt",
+                  "Nevers"
+                ],
+                [
+                  "Mexico",
+                  "United States",
+                  "France"
+                ],
+                [
+                  "8af366cf-6f25-42e6-bbb4-d860ab535a60",
+                  "032e7f68-b0ab-47c0-a24a-35af566359e5",
+                  "4d2c7baa-ff28-4b1f-9db9-8e6c0ed5a9c9"
+                ],
+                [
+                  false,
+                  false,
+                  true
+                ],
+                [
+                  "QCD permutations were not solvable in linear time, expected compressed time",
+                  "QCD permutations were not solvable in linear time, expected compressed time",
+                  "Expected a new layer of particle physics but got a Higgs Boson"
+                ],
+                [
+                  "GET",
+                  "GET",
+                  "GET"
+                ],
+                [
+                  1.396373193863436,
+                  0.16252390534308514,
+                  0.4093416175186162
+                ],
+                [
+                  3448,
+                  2533,
+                  1906
+                ],
+                [
+                  84,
+                  31,
+                  29
+                ],
+                [
+                  "DCA",
+                  "GRU",
+                  "FRA"
+                ],
+                [
+                  "201",
+                  "200",
+                  "200"
+                ],
+                [
+                  "/api/v1/buy/commit/id/go",
+                  "/api/v1/textdata/cnfigs",
+                  "/api/v1/bank/warn"
+                ],
+                [
+                  "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
+                  "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/535.24 (KHTML, like Gecko) Chrome/19.0.1055.1 Safari/535.24",
+                  "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
+                ],
+                [
+                  true,
+                  true,
+                  true
+                ],
+                [
+                  7,
+                  8,
+                  6
                 ]
+              ]
             }
+          ],
+          "datasetNames": [
+            "dataset-name"
+          ],
+          "fieldsMetaMap": {
+            "dataset-name": [
+              {
+                "name": "status",
+                "type": "",
+                "unit": "",
+                "hidden": false,
+                "description": "HTTP status code"
+              },
+              {
+                "name": "resp_header_size_bytes",
+                "type": "integer",
+                "unit": "none",
+                "hidden": false,
+                "description": ""
+              },
+              {
+                "name": "geo.city",
+                "type": "string",
+                "unit": "",
+                "hidden": false,
+                "description": "the city"
+              },
+              {
+                "name": "resp_body_size_bytes",
+                "type": "integer",
+                "unit": "decbytes",
+                "hidden": false,
+                "description": ""
+              },
+              {
+                "name": "content_type",
+                "type": "string",
+                "unit": "",
+                "hidden": false,
+                "description": ""
+              },
+              {
+                "name": "geo.country",
+                "type": "string",
+                "unit": "",
+                "hidden": false,
+                "description": ""
+              },
+              {
+                "name": "req_duration_ms",
+                "type": "float",
+                "unit": "ms",
+                "hidden": false,
+                "description": "Request duration"
+              }
+            ]
+          }
         },
         "x-go-type": {
           "hints": {
@@ -3339,6 +3370,14 @@
           "type": "integer",
           "format": "int64",
           "default": 0
+        }
+      },
+      "X-Axiom-Org-ID": {
+        "name": "X-Axiom-Org-ID",
+        "in": "header",
+        "description": "Organization ID. Required when using a personal access token (PAT) for authentication. Not required when using an API token. For more information, see [Determine org ID](/reference/tokens#determine-org-id).",
+        "schema": {
+          "type": "string"
         }
       }
     },

--- a/restapi/versions/v2.json
+++ b/restapi/versions/v2.json
@@ -37,6 +37,9 @@
         "operationId": "getAnnotations",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "Optional: Filter for dataset names.",
             "name": "datasets",
             "in": "query",
@@ -116,7 +119,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/annotations/{id}": {
@@ -134,6 +142,9 @@
         ],
         "operationId": "getAnnotation",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -165,6 +176,9 @@
         ],
         "operationId": "updateAnnotation",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -206,6 +220,9 @@
         ],
         "operationId": "deleteAnnotation",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -264,7 +281,12 @@
             "$ref": "#/components/responses/ForbiddenError"
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -281,6 +303,9 @@
         "summary": "Create dataset",
         "operationId": "createDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Referrer slug",
             "name": "referrer",
@@ -333,6 +358,9 @@
         "operationId": "getDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -376,6 +404,9 @@
         "summary": "Update dataset",
         "operationId": "updateDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -428,6 +459,9 @@
         "operationId": "deleteDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -463,6 +497,9 @@
         "summary": "Trim dataset by duration",
         "operationId": "trimDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -511,6 +548,9 @@
         "operationId": "vacuumDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -551,6 +591,9 @@
         ],
         "operationId": "getFieldsForDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -595,6 +638,9 @@
         "operationId": "getFieldForDataset",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -637,6 +683,9 @@
         ],
         "operationId": "updateFieldForDataset",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -693,6 +742,9 @@
         "operationId": "getMapFields",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -728,6 +780,9 @@
         ],
         "operationId": "updateMapFields",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -776,6 +831,9 @@
         "operationId": "createMapField",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "dataset_id",
             "in": "path",
             "required": true,
@@ -823,6 +881,9 @@
         ],
         "operationId": "deleteMapField",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset_id",
             "in": "path",
@@ -877,7 +938,12 @@
             }
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -907,7 +973,12 @@
             }
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/monitors/{id}": {
@@ -925,6 +996,9 @@
         ],
         "operationId": "getMonitor",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the monitor (format: mon_*)",
             "name": "id",
@@ -962,6 +1036,9 @@
         ],
         "operationId": "updateMonitor",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1003,6 +1080,9 @@
         "operationId": "deleteMonitor",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -1034,6 +1114,9 @@
         ],
         "operationId": "getMonitorHistory",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1110,7 +1193,12 @@
             }
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -1148,7 +1236,12 @@
             }
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/notifiers/{id}": {
@@ -1166,6 +1259,9 @@
         ],
         "operationId": "getNotifier",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the notifier (format: notify_*)",
             "name": "id",
@@ -1204,6 +1300,9 @@
         ],
         "operationId": "updateNotifier",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1251,6 +1350,9 @@
         ],
         "operationId": "deleteNotifier",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1344,6 +1446,9 @@
         "operationId": "getOrg",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -1376,6 +1481,9 @@
         ],
         "operationId": "updateOrg",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1438,7 +1546,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -1476,7 +1589,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/rbac/roles/{id}": {
@@ -1495,6 +1613,9 @@
         "summary": "Get role by ID",
         "operationId": "getRoleById",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the role to retrieve",
             "name": "id",
@@ -1533,6 +1654,9 @@
         "summary": "Update role",
         "operationId": "updateRole",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the role to update",
             "name": "id",
@@ -1583,6 +1707,9 @@
         "operationId": "deleteRole",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "Unique identifier of the role to delete",
             "name": "id",
             "in": "path",
@@ -1628,7 +1755,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -1666,7 +1798,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/rbac/groups/{id}": {
@@ -1685,6 +1822,9 @@
         "summary": "Get group by ID",
         "operationId": "getGroupById",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the group to retrieve",
             "name": "id",
@@ -1723,6 +1863,9 @@
         "summary": "Update group",
         "operationId": "updateGroup",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "description": "Unique identifier of the group to update",
             "name": "id",
@@ -1773,6 +1916,9 @@
         "operationId": "deleteGroup",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "description": "Unique identifier of the group to delete",
             "name": "id",
             "in": "path",
@@ -1803,6 +1949,9 @@
         ],
         "operationId": "getStarredQueries",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "$ref": "#/components/parameters/Limit"
           },
@@ -1860,6 +2009,11 @@
           "starred"
         ],
         "operationId": "createStarred",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ],
         "requestBody": {
           "$ref": "#/components/requestBodies/StarredQuery"
         },
@@ -1891,6 +2045,9 @@
         ],
         "operationId": "getStarred",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1926,6 +2083,9 @@
         ],
         "operationId": "updateStarred",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -1964,6 +2124,9 @@
         ],
         "operationId": "deleteStarred",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2008,7 +2171,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -2045,7 +2213,12 @@
             }
           }
         },
-        "x-axiom-not-suspended": true
+        "x-axiom-not-suspended": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/tokens/{id}": {
@@ -2063,6 +2236,9 @@
         ],
         "operationId": "getAPIToken",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2100,6 +2276,9 @@
         "operationId": "deleteAPIToken",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -2130,6 +2309,9 @@
         ],
         "operationId": "regenerateAPIToken",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2256,7 +2438,12 @@
             }
           }
         },
-        "x-axiom-preview": true
+        "x-axiom-preview": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -2314,6 +2501,9 @@
         "operationId": "getUser",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -2351,6 +2541,9 @@
         "operationId": "removeUserFromOrg",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -2382,6 +2575,9 @@
         ],
         "operationId": "updateUserRole",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2430,6 +2626,9 @@
         ],
         "operationId": "getVirtualFields",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "dataset",
             "in": "query",
@@ -2481,7 +2680,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/vfields/{id}": {
@@ -2498,6 +2702,9 @@
         ],
         "operationId": "getVirtualField",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2533,6 +2740,9 @@
         ],
         "operationId": "updateVirtualField",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2571,6 +2781,9 @@
         ],
         "operationId": "deleteVirtualField",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2614,7 +2827,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       },
       "post": {
         "security": [
@@ -2642,7 +2860,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/views/{id}": {
@@ -2659,6 +2882,9 @@
         ],
         "operationId": "getView",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2694,6 +2920,9 @@
         ],
         "operationId": "updateView",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "id",
             "in": "path",
@@ -2733,6 +2962,9 @@
         "operationId": "deleteView",
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "id",
             "in": "path",
             "required": true,
@@ -2762,6 +2994,9 @@
           }
         ],
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "$ref": "#/components/parameters/Limit"
           },
@@ -2858,7 +3093,12 @@
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          }
+        ]
       }
     },
     "/dashboards/uid/{uid}": {
@@ -2875,6 +3115,9 @@
           }
         ],
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "uid",
             "in": "path",
@@ -2920,6 +3163,9 @@
           }
         ],
         "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
           {
             "name": "uid",
             "in": "path",
@@ -3006,6 +3252,9 @@
         ],
         "parameters": [
           {
+            "$ref": "#/components/parameters/X-Axiom-Org-ID"
+          },
+          {
             "name": "uid",
             "in": "path",
             "required": true,
@@ -3053,6 +3302,14 @@
           "format": "int64",
           "minimum": 0,
           "default": 0
+        }
+      },
+      "X-Axiom-Org-ID": {
+        "name": "X-Axiom-Org-ID",
+        "in": "header",
+        "description": "Organization ID. Required when using a personal access token (PAT) for authentication. Not required when using an API token. For more information, see [Determine org ID](/reference/tokens#determine-org-id).",
+        "schema": {
+          "type": "string"
         }
       },
       "id": {


### PR DESCRIPTION
The interactive "Try it" playground on the API reference pages only showed an Authorization input field but no X-Axiom-Org-ID input. This caused 400 errors for customers using personal access tokens (PATs), which require the org ID header.

Added the X-Axiom-Org-ID header parameter to 85 endpoints across all OpenAPI spec files (v2.json, v1.json, v1-edge-query.json, v1-edge-ingest.json). 