### PR TITLE
fix(docs): update "starred" terminology to "saved" to match UI

### DIFF
--- a/query-data/datasets.mdx
+++ b/query-data/datasets.mdx
@@ -84,7 +84,7 @@ For more information, see [Views](/query-data/views).
 ## Queries
 
 Every query has a unique ID that you can save and share with your team members. The Datasets tab allows you to do the following:
-- Star a query so that you and your team members can easily find it in the future.
+- Save a query so that you and your team members can easily find it in the future.
 - Browse previous queries and find a past query.
 
 ### Saved queries

--- a/query-data/stream.mdx
+++ b/query-data/stream.mdx
@@ -2,7 +2,7 @@
 title: 'Stream data with Axiom'
 description: 'The Stream tab enables you to process and analyze high volumes of high-velocity data from a variety of sources in real time.'
 sidebarTitle: Stream data
-keywords: ['axiom documentation', 'documentation', 'axiom', 'stream', 'streaming data', 'events', 'filtering', 'starred queries', 'level', 'debug', 'error', 'info', 'severity']
+keywords: ['axiom documentation', 'documentation', 'axiom', 'stream', 'streaming data', 'events', 'filtering', 'saved queries', 'level', 'debug', 'error', 'info', 'severity']
 ---
 
 The Stream tab allows you to inspect individual events and watch as they’re ingested live.
@@ -13,7 +13,7 @@ This section introduces the Stream tab and its components that unlock powerful i
 
 ## Choose a dataset
 
-The default view is one where you can easily see which datasets are available and also see some recent Starred Queries in case you want to jump directly into a stream:
+The default view is one where you can easily see which datasets are available and also see some recent saved queries in case you want to jump directly into a stream:
 
 <Frame caption="Datasets overview">
   <img src="/doc-assets/shots/choose-a-dataset-1.png" alt="Datasets overview" />
@@ -88,15 +88,15 @@ Options include:
 - Show the raw event details
 - Fields to display in their own column
 
-## Starred queries
+## Saved queries
 
-The starred queries slide-out is activated via the toolbar:
+The saved queries slide-out is activated via the toolbar:
 
-<Frame caption="Starred queries">
-  <img src="/doc-assets/shots/stream-starred.png" alt="Starred queries" />
+<Frame caption="Saved queries">
+  <img src="/doc-assets/shots/stream-starred.png" alt="Saved queries" />
 </Frame>
 
-For more information, see [Starred queries](/query-data/datasets#starred-queries).
+For more information, see [Saved queries](/query-data/datasets#saved-queries).
 
 ## Highlight severity
 


### PR DESCRIPTION
The UI uses "Save" / "Saved queries" but the docs referenced "Star" / "Starred queries", causing customer confusion. Aligns docs terminology with the actual frontend labels.