### PR TITLE
support ca-central-1 for cross regions us-east-1 privatelink

### DIFF
--- a/apps/aws-privatelink.mdx
+++ b/apps/aws-privatelink.mdx
@@ -12,7 +12,7 @@ Axiom supports native cross-region PrivateLink for the following regions:
 
 | Axiom edge deployment | Supported PrivateLink regions |
 | :--- | :--- |
-| `US East 1 (AWS)` | `us-east-1`<br />`us-east-2`<br />`us-west-1`<br />`us-west-2`<br />`eu-west-1`<br />`eu-west-2`<br />`eu-west-3`<br />`eu-central-1` |
+| `US East 1 (AWS)` | `us-east-1`<br />`us-east-2`<br />`us-west-1`<br />`us-west-2`<br />`eu-west-1`<br />`eu-west-2`<br />`eu-west-3`<br />`eu-central-1`<br />`ca-central-1` |
 | `EU Central 1 (AWS)` | `eu-central-1`<br />`eu-north-1` |
 
 To connect to a region that isn't listed above, [contact Axiom](https://axiom.co/contact).


### PR DESCRIPTION
Client requested adding ca-central-1 to supported regions, which we did. now time to document that change