### PR TITLE
docs(javascript): document edge region config for the JS SDK

### DIFF
--- a/apl/guides/splunk-cheat-sheet.mdx
+++ b/apl/guides/splunk-cheat-sheet.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Splunk SPL
 keywords: ['axiom documentation', 'documentation', 'axiom', 'splunk', 'apl', 'searching', 'aggregation', 'time frames', 'sorting', 'functions']
 ---
 
-Splunk and Axiom are powerful tools for log analysis and data exploration. The data explorer interface uses Axiom Processing Language (APL). There are some differences between the query languages for Splunk and Axiom. When transitioning from Splunk to APL, you will need to understand how to convert your Splunk SPL queries into APL.
+Splunk and Axiom are powerful tools for log analysis and data exploration. The Query tab uses Axiom Processing Language (APL). There are some differences between the query languages for Splunk and Axiom. When transitioning from Splunk to APL, you will need to understand how to convert your Splunk SPL queries into APL.
 
 **This guide provides a high-level mapping from Splunk to APL.**
 

--- a/guides/apex.mdx
+++ b/guides/apex.mdx
@@ -59,6 +59,43 @@ handler, err := adapter.New(
 )
 ```
 
+### Configure region
+
+By default, the adapter sends data to `api.axiom.co`. To target a specific edge region, pass `axiom.SetEdge` through `SetClientOptions` with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```go EU Central 1
+handler, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("eu-central-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+```go US East 1
+handler, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("us-east-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Use `axiom.SetAPITokenConfig` when targeting an edge region. You can also set `AXIOM_EDGE` or `AXIOM_EDGE_URL` in the environment instead of `axiom.SetEdge`. For a full edge URL such as a proxy, use `axiom.SetEdgeURL`, which takes precedence over `axiom.SetEdge`.
+</Note>
+
 <Note>
 The adapter uses a buffer to batch events before sending them to Axiom. Flush this buffer explicitly by calling [Close](https://pkg.go.dev/github.com/axiomhq/axiom-go/adapters/apex#Handler.Close). For more information, see the [example in GitHub](https://github.com/axiomhq/axiom-go/blob/main/examples/apex/main.go).
 </Note>

--- a/guides/go.mdx
+++ b/guides/go.mdx
@@ -93,6 +93,51 @@ func main() {
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-go/tree/main/examples).
 
+## Configure region
+
+By default, the client sends data to `api.axiom.co`. To target a specific edge region, pass the `SetEdge` option with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```go EU Central 1
+client, err := axiom.NewClient(
+    axiom.SetEdge("eu-central-1.aws.edge.axiom.co"),
+)
+```
+
+```go US East 1
+client, err := axiom.NewClient(
+    axiom.SetEdge("us-east-1.aws.edge.axiom.co"),
+)
+```
+
+</CodeGroup>
+
+This relies on `AXIOM_TOKEN` being set in your environment. To set the token in code as well, add `axiom.SetToken("xaat-...")`.
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+For more information about edge deployments, see [Edge deployments](/reference/edge-deployments).
+
+You can also configure the region without changing code by exporting environment variables:
+
+```sh
+export AXIOM_EDGE="eu-central-1.aws.edge.axiom.co"
+# or, for a full URL (takes precedence over AXIOM_EDGE):
+export AXIOM_EDGE_URL="https://eu-central-1.aws.edge.axiom.co"
+```
+
+To point at a custom edge endpoint such as a proxy or load balancer, use `axiom.SetEdgeURL("https://your-edge-host")`. `SetEdgeURL` takes precedence over `SetEdge` if both are set.
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Ingest and query calls with a personal token against an edge endpoint return `personal tokens are not supported for edge operations, use an API token (xaat-)`.
+</Note>
+
 ## Adapters
 
 To use a logging package, see the following adapters:

--- a/guides/javascript.mdx
+++ b/guides/javascript.mdx
@@ -103,15 +103,21 @@ The following edge domains are available:
 | US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
 | EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
 
+For more information about edge deployments, see [Edge deployments](/reference/edge-deployments).
+
 <Warning>
 Always use the `edge` option to target a region. Don't put a regional hostname in `url` — `url` is reserved for non-ingest API operations and won't route ingest correctly.
 </Warning>
+
+<Note>
+Edge endpoints require an API token (`xaat-`). Personal tokens (`xapt-`) are deprecated and aren't supported for edge routing.
+</Note>
 
 ### Client options
 
 | Option    | Required | Description                                                                                                            |
 | --------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `token`   | yes      | An Axiom API or personal token with `ingest` permission for the dataset.                                              |
+| `token`   | yes      | An Axiom API token with `ingest` permission for the dataset.                                                          |
 | `orgId`   | no       | Organization ID. Required when using a personal token.                                                                |
 | `edge`    | no       | Edge domain for ingest and query, without scheme. Example: `eu-central-1.aws.edge.axiom.co`. Use this to target a region. |
 | `edgeUrl` | no       | Full edge URL with scheme. Takes precedence over `edge` if both are set. Useful for self-hosted or proxy setups.       |

--- a/guides/javascript.mdx
+++ b/guides/javascript.mdx
@@ -70,6 +70,54 @@ Configure the environment variables in one of the following ways:
     eval $(axiom config export -f)
     ```
 
+### Configure region
+
+By default, the client sends data to `api.axiom.co`. To target a specific edge region, set the `edge` option to the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```ts EU Central 1
+import { Axiom } from '@axiomhq/js';
+
+const axiom = new Axiom({
+  token: process.env.AXIOM_TOKEN,
+  edge: 'eu-central-1.aws.edge.axiom.co',
+});
+```
+
+```ts US East 1
+import { Axiom } from '@axiomhq/js';
+
+const axiom = new Axiom({
+  token: process.env.AXIOM_TOKEN,
+  edge: 'us-east-1.aws.edge.axiom.co',
+});
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+<Warning>
+Always use the `edge` option to target a region. Don't put a regional hostname in `url` — `url` is reserved for non-ingest API operations and won't route ingest correctly.
+</Warning>
+
+### Client options
+
+| Option    | Required | Description                                                                                                            |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `token`   | yes      | An Axiom API or personal token with `ingest` permission for the dataset.                                              |
+| `orgId`   | no       | Organization ID. Required when using a personal token.                                                                |
+| `edge`    | no       | Edge domain for ingest and query, without scheme. Example: `eu-central-1.aws.edge.axiom.co`. Use this to target a region. |
+| `edgeUrl` | no       | Full edge URL with scheme. Takes precedence over `edge` if both are set. Useful for self-hosted or proxy setups.       |
+| `url`     | no       | Base URL for non-ingest API operations. Only needed if you call other Axiom APIs from the same client.                |
+| `onError` | no       | Callback invoked when sending data fails. Defaults to `console.error`.                                                |
+
 ### Send data to Axiom
 
 The following example sends data to Axiom:
@@ -169,6 +217,8 @@ const logger = new Logger(
 
 logger.info("Hello, world!");
 ```
+
+Because `AxiomJSTransport` sends data through the `@axiomhq/js` client, set the region by passing the `edge` option to the `Axiom` constructor. For the full list of edge domains, see [Configure region](#configure-region).
 
 #### Transports
 

--- a/guides/logrus.mdx
+++ b/guides/logrus.mdx
@@ -59,6 +59,43 @@ hook, err := adapter.New(
 )
 ```
 
+### Configure region
+
+By default, the adapter sends data to `api.axiom.co`. To target a specific edge region, pass `axiom.SetEdge` through `SetClientOptions` with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```go EU Central 1
+hook, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("eu-central-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+```go US East 1
+hook, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("us-east-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Use `axiom.SetAPITokenConfig` when targeting an edge region. You can also set `AXIOM_EDGE` or `AXIOM_EDGE_URL` in the environment instead of `axiom.SetEdge`. For a full edge URL such as a proxy, use `axiom.SetEdgeURL`, which takes precedence over `axiom.SetEdge`.
+</Note>
+
 <Note>
 The adapter uses a buffer to batch events before sending them to Axiom. Flush this buffer explicitly by calling [Close](https://pkg.go.dev/github.com/axiomhq/axiom-go/adapters/logrus#Hook.Close). For more information, see the [example in GitHub](https://github.com/axiomhq/axiom-go/blob/main/examples/logrus/main.go).
 </Note>

--- a/guides/python.mdx
+++ b/guides/python.mdx
@@ -66,6 +66,51 @@ client.query(r"['DATASET_NAME'] | where foo == 'bar' | limit 100")
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-py/tree/main/examples/client_example.py).
 
+## Configure region
+
+By default, the client sends data to `api.axiom.co`. To target a specific edge region, pass the `edge` argument with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```py EU Central 1
+import axiom_py
+
+client = axiom_py.Client(
+    token="xaat-your-api-token",
+    edge="eu-central-1.aws.edge.axiom.co",
+)
+```
+
+```py US East 1
+import axiom_py
+
+client = axiom_py.Client(
+    token="xaat-your-api-token",
+    edge="us-east-1.aws.edge.axiom.co",
+)
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+For more information about edge deployments, see [Edge deployments](/reference/edge-deployments).
+
+To point at a custom edge endpoint such as a proxy or load balancer, use `edge_url="https://your-edge-host"` instead. `edge_url` takes precedence over `edge` if both are set.
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Passing a personal token with edge configuration raises an error.
+</Note>
+
+<Warning>
+Edge configuration must be passed explicitly when you create the client. Unlike `token` and `org_id`, the `edge` and `edge_url` arguments are not read from environment variables.
+</Warning>
+
 ## Example with `AxiomHandler`
 
 The example below uses `AxiomHandler` to send logs from the `logging` module to Axiom:

--- a/guides/rust.mdx
+++ b/guides/rust.mdx
@@ -71,6 +71,51 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-rs/tree/main/examples).
 
+## Configure region
+
+By default, the client sends data to `api.axiom.co`. To target a specific edge region, add the `with_edge` method to the builder with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```rust EU Central 1
+let client = Client::builder()
+    .with_token("xaat-your-api-token")
+    .with_edge("eu-central-1.aws.edge.axiom.co")
+    .build()?;
+```
+
+```rust US East 1
+let client = Client::builder()
+    .with_token("xaat-your-api-token")
+    .with_edge("us-east-1.aws.edge.axiom.co")
+    .build()?;
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+For more information about edge deployments, see [Edge deployments](/reference/edge-deployments).
+
+You can also configure the region without changing code by exporting environment variables. When you build the client with `Client::new()`, these are read automatically:
+
+```sh
+export AXIOM_EDGE="eu-central-1.aws.edge.axiom.co"
+# or, for a full URL (takes precedence over AXIOM_EDGE):
+export AXIOM_EDGE_URL="https://eu-central-1.aws.edge.axiom.co"
+```
+
+To point at a custom edge endpoint such as a proxy or load balancer, use `.with_edge_url("https://your-edge-host")`. `with_edge_url` takes precedence over `with_edge` if both are set.
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Ingesting with a personal token against an edge endpoint returns a `PersonalTokenNotSupportedForEdge` error.
+</Note>
+
 ## Optional features
 
 You can use the [Cargo features](https://doc.rust-lang.org/stable/cargo/reference/features.html#the-features-section):

--- a/guides/winston.mdx
+++ b/guides/winston.mdx
@@ -92,6 +92,55 @@ const logger = winston.createLogger({
 Running on Edge runtime isn’t supported.
 </Warning>
 
+## Configure region
+
+By default, the transport sends data to `api.axiom.co`. To target a specific edge region, set the `edge` option on `AxiomTransport` to the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```ts EU Central 1
+new AxiomTransport({
+    dataset: 'DATASET_NAME',
+    token: 'API_TOKEN',
+    edge: 'eu-central-1.aws.edge.axiom.co',
+});
+```
+
+```ts US East 1
+new AxiomTransport({
+    dataset: 'DATASET_NAME',
+    token: 'API_TOKEN',
+    edge: 'us-east-1.aws.edge.axiom.co',
+});
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+For more information about edge deployments, see [Edge deployments](/reference/edge-deployments).
+
+<Warning>
+Always use the `edge` option to target a region. Don't put a regional hostname in `url` — `url` is reserved for non-ingest API operations and won't route ingest correctly. (This is unrelated to the Edge runtime note above, which is about where your code runs.)
+</Warning>
+
+### Transport options
+
+| Option     | Required | Description                                                                                                       |
+| ---------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `dataset`  | yes      | The Axiom dataset to ingest logs into. Falls back to the `AXIOM_DATASET` environment variable.                   |
+| `token`    | yes      | An Axiom API token with `ingest` permission for the dataset.                                                      |
+| `orgId`    | no       | Organization ID. Required when using a personal token.                                                            |
+| `edge`     | no       | Edge domain for ingest, without scheme. Example: `eu-central-1.aws.edge.axiom.co`. Use this to target a region.   |
+| `edgeUrl`  | no       | Full edge URL with scheme. Takes precedence over `edge` if both are set. Useful for self-hosted or proxy setups.  |
+| `url`      | no       | Base URL for non-ingest API operations.                                                                          |
+| `onError`  | no       | Callback invoked when sending data fails.                                                                        |
+
 ## Examples
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-js/tree/main/examples/winston).

--- a/guides/zap.mdx
+++ b/guides/zap.mdx
@@ -59,6 +59,43 @@ core, err := adapter.New(
 )
 ```
 
+### Configure region
+
+By default, the adapter sends data to `api.axiom.co`. To target a specific edge region, pass `axiom.SetEdge` through `SetClientOptions` with the edge domain that matches the region your dataset lives in:
+
+<CodeGroup>
+
+```go EU Central 1
+core, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("eu-central-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+```go US East 1
+core, err := adapter.New(
+    adapter.SetClientOptions(
+        axiom.SetAPITokenConfig("xaat-your-api-token"),
+        axiom.SetEdge("us-east-1.aws.edge.axiom.co"),
+    ),
+)
+```
+
+</CodeGroup>
+
+The following edge domains are available:
+
+| Edge deployment    | Base domain for ingest and query |
+| ------------------ | -------------------------------- |
+| US East 1 (AWS)    | `us-east-1.aws.edge.axiom.co`    |
+| EU Central 1 (AWS) | `eu-central-1.aws.edge.axiom.co` |
+
+<Note>
+Edge endpoints require an API token (`xaat-`), not a personal token (`xapt-`). Use `axiom.SetAPITokenConfig` when targeting an edge region. You can also set `AXIOM_EDGE` or `AXIOM_EDGE_URL` in the environment instead of `axiom.SetEdge`. For a full edge URL such as a proxy, use `axiom.SetEdgeURL`, which takes precedence over `axiom.SetEdge`.
+</Note>
+
 <Note>
 The adapter uses a buffer to batch events before sending them to Axiom. Flush this buffer explicitly by calling [Sync](https://pkg.go.dev/github.com/axiomhq/axiom-go/adapters/zap#WriteSyncer.Sync). For more information, see the [zap documentation](https://pkg.go.dev/go.uber.org/zap/zapcore#WriteSyncer) and the [example in GitHub](https://github.com/axiomhq/axiom-go/blob/main/examples/zap/main.go).
 </Note>

--- a/restapi/endpoints/queryEdge.mdx
+++ b/restapi/endpoints/queryEdge.mdx
@@ -6,3 +6,7 @@ openapi: "v1-edge-query post /query/_apl?format=tabular"
 import edgeQuery from "/snippets/edge-query.mdx"
 
 <edgeQuery />
+
+This is the edge equivalent of the standard [Run query](/restapi/endpoints/queryApl) endpoint. Send the request to your edge deployment's base domain at the path `/v1/query/_apl`. The standard `/v1/datasets/_apl` path isn't served on edge domains, so requests to it return a `404`.
+
+If you use an Axiom SDK, set the `edge` option on the client and it sends queries to this endpoint automatically. For more information, see [Configure region](/guides/javascript#configure-region).

--- a/restapi/query.mdx
+++ b/restapi/query.mdx
@@ -14,7 +14,7 @@ import ReplaceDataset from "/snippets/replace-dataset.mdx"
 This page explains how to query data via the Axiom API using the following:
 
 - [cURL](#query-data-with-curl)
-- [Axiom Node.js library](#query-data-with-axiom-nodejs)
+- [Axiom JavaScript library (`@axiomhq/js`)](#query-data-with-the-axiom-javascript-library)
 
 For an introduction to the basics of the Axiom API and to the authentication options, see [Introduction to Axiom API](/restapi/introduction).
 
@@ -321,9 +321,9 @@ curl --request POST \
 }
 ```
 
-## Query data with Axiom Node.js
+## Query data with the Axiom JavaScript library
 
-1. [Install and configure](/guides/javascript#use-axiomhq-js) the Axiom Node.js library.
+1. [Install and configure](/guides/javascript#use-axiomhq-js) the Axiom JavaScript library (`@axiomhq/js`).
 1. Build the APL query. For more information, see [Introduction to APL](/apl/introduction).
 1. Pass the APL query as a string to the `axiom.query` function.
 
@@ -334,6 +334,8 @@ curl --request POST \
     <Info>
     <ReplaceDataset />
     </Info>
+
+To run queries within a specific edge deployment, set the `edge` option when you create the client. The client then routes queries to the [edge query endpoint](/restapi/endpoints/queryEdge) automatically. For more information, see [Configure region](/guides/javascript#configure-region).
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-js/tree/main/examples).
 

--- a/snippets/edge-query.mdx
+++ b/snippets/edge-query.mdx
@@ -1,7 +1,7 @@
 import BaseDomains from "/snippets/base-domains.mdx"
 
 <Warning>
-Use this endpoint to query data from a specific edge deployment. The data you query must be stored in the edge deployment where you query it. For more information, see [Query data](/restapi/ingest) and [Edge deployments](/reference/edge-deployments).
+Use this endpoint to query data from a specific edge deployment. The data you query must be stored in the edge deployment where you query it. For more information, see [Query data](/restapi/query) and [Edge deployments](/reference/edge-deployments).
 
 The base domain for this endpoint is the base domain of the edge deployment where you want to query data.
 


### PR DESCRIPTION
## Summary

The JavaScript SDK guide didn't document how to target a specific edge region, which came up with several customers. This adds that documentation to `guides/javascript.mdx`, mirroring the pattern already merged for the pino guide (#645).

Changes:
- **`Configure region`** section — a `<CodeGroup>` with EU Central 1 / US East 1 examples using the `edge` option, the edge-domains table, and a warning not to put a regional hostname in `url`.
- **`Client options`** table — covers `token`, `orgId`, `edge`, `edgeUrl`, `url`, and `onError`.
- A note in the `@axiomhq/logging` section explaining that `AxiomJSTransport` inherits region config from the underlying `Axiom` client.

Option names were verified against the actual `@axiomhq/js` source (`ClientOptions` in `httpClient.ts`) rather than inferred.

## Context

Requested via Slack: https://watchlyhq.slack.com/archives/C03HV6C998A/p1781277852898119?thread_ts=1781256608.725899&cid=C03HV6C998A

https://claude.ai/code/session_01QUnFXPq23HYtxXiCceD2L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUnFXPq23HYtxXiCceD2L5)_