### PR TITLE
docs: fix broken internal links and refresh Segment ingest instructions

### DIFF
--- a/apl/scalar-functions/mathematical-functions/set-difference.mdx
+++ b/apl/scalar-functions/mathematical-functions/set-difference.mdx
@@ -95,6 +95,5 @@ Use `set_difference` to return the difference between two arrays.
 
 ## List of related functions
 
-- [set_difference](apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
 - [set_has_element](/apl/scalar-functions/mathematical-functions/set-has-element): Tests whether a set contains a specific value. Prefer it when you only need a Boolean result.
 - [set_union](/apl/scalar-functions/mathematical-functions/set-union): Returns the union of two or more sets. Use it when you need any element that appears in at least one set instead of every set.

--- a/apl/scalar-functions/mathematical-functions/set-has-element.mdx
+++ b/apl/scalar-functions/mathematical-functions/set-has-element.mdx
@@ -95,5 +95,5 @@ Use `set_has_element` to determine if a set contains a specific value.
 
 ## List of related functions
 
-- [set_difference](apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
+- [set_difference](/apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
 - [set_union](/apl/scalar-functions/mathematical-functions/set-union): Returns the union of two or more sets. Use it when you need any element that appears in at least one set instead of every set.

--- a/apl/scalar-functions/mathematical-functions/set-intersect.mdx
+++ b/apl/scalar-functions/mathematical-functions/set-intersect.mdx
@@ -95,6 +95,6 @@ Use `set_intersect` to return the intersection of two arrays.
 
 ## List of related functions
 
-- [set_difference](apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
+- [set_difference](/apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
 - [set_has_element](/apl/scalar-functions/mathematical-functions/set-has-element): Tests whether a set contains a specific value. Prefer it when you only need a Boolean result.
 - [set_union](/apl/scalar-functions/mathematical-functions/set-union): Returns the union of two or more sets. Use it when you need any element that appears in at least one set instead of every set.

--- a/apl/scalar-functions/mathematical-functions/set-union.mdx
+++ b/apl/scalar-functions/mathematical-functions/set-union.mdx
@@ -91,6 +91,6 @@ Use `set_union` to return the union of two arrays.
 
 ## List of related functions
 
-- [set_difference](apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
+- [set_difference](/apl/scalar-functions/mathematical-functions/set-difference): Returns elements in the first array that aren’t in the second. Use it to find exclusions.
 - [set_has_element](/apl/scalar-functions/mathematical-functions/set-has-element): Tests whether a set contains a specific value. Prefer it when you only need a Boolean result.
 - [set_union](/apl/scalar-functions/mathematical-functions/set-union): Returns the union of two or more sets. Use it when you need any element that appears in at least one set instead of every set.

--- a/apl/scalar-functions/string-functions/unicode-codepoints-from-string.mdx
+++ b/apl/scalar-functions/string-functions/unicode-codepoints-from-string.mdx
@@ -151,5 +151,5 @@ This query helps detect tampered user IDs that use emojis or hidden characters t
 
 - [array_concat](/apl/scalar-functions/array-functions/array-concat): Combines multiple arrays. Useful when merging code point arrays from different strings.
 - [array_length](/apl/scalar-functions/array-functions/array-length): Returns the number of elements in an array. Use it to check how many code points a string contains.
-- [parse_path](apl/scalar-functions/string-functions/parse-path): Parses a path into components. Use it with `unicode_codepoints_from_string` when decoding or inspecting URL paths.
+- [parse_path](/apl/scalar-functions/string-functions/parse-path): Parses a path into components. Use it with `unicode_codepoints_from_string` when decoding or inspecting URL paths.
 - [unicode_codepoints_to_string](/apl/scalar-functions/string-functions/unicode-codepoints-to-string): Converts an array of Unicode code points into a UTF-8 encoded string.

--- a/apl/scalar-functions/string-functions/unicode-codepoints-to-string.mdx
+++ b/apl/scalar-functions/string-functions/unicode-codepoints-to-string.mdx
@@ -147,5 +147,5 @@ This example shows how to reconstruct a denied URI (`/login`) from its obfuscate
 
 - [array_concat](/apl/scalar-functions/array-functions/array-concat): Combines multiple arrays. Useful when merging code point arrays from different strings.
 - [array_length](/apl/scalar-functions/array-functions/array-length): Returns the number of elements in an array. Use it to check how many code points a string contains.
-- [parse_path](apl/scalar-functions/string-functions/parse-path): Parses a path into components. Use it with `unicode_codepoints_from_string` when decoding or inspecting URL paths.
+- [parse_path](/apl/scalar-functions/string-functions/parse-path): Parses a path into components. Use it with `unicode_codepoints_from_string` when decoding or inspecting URL paths.
 - [unicode_codepoints_from_string](/apl/scalar-functions/string-functions/unicode-codepoints-from-string): Converts a UTF-8 string into an array of Unicode code points.

--- a/getting-started-guide/product-analytics.mdx
+++ b/getting-started-guide/product-analytics.mdx
@@ -4,6 +4,9 @@ description: "This page explains how Axiom helps you leverage timestamped event 
 sidebarTitle: Product analytics
 ---
 
+import ReplaceDomain from "/snippets/replace-domain.mdx"
+import ReplaceDatasetToken from "/snippets/replace-dataset-token.mdx"
+
 Axiom helps you leverage the power of timestamped event data. Axiom believes that event data reflects a broad range of interactions, crossing boundaries from engineering to product management, security, and beyond.
 
 This page explains how you can leverage the power of event data for the product analytics use case.
@@ -52,8 +55,18 @@ These event types are foundational to many analytics workflows and are supported
 
 To send Segment data to Axiom:
 
-1. Create an [HTTP destionation](/process-data/destinations/http) in Axiom.
-1. Add a webhook destination in Segment. For more information, see the [Segment documentation](https://segment.com/docs/connections/destinations/catalog/webhooks/).
+1. In Axiom, [create a dataset](/reference/datasets) for the Segment events and [generate an API token](/reference/tokens) with permission to ingest into that dataset.
+1. In Segment, add a [webhook destination](https://segment.com/docs/connections/destinations/catalog/webhooks/) with the following settings:
+    - **Webhook URL**: `https://AXIOM_DOMAIN/v1/ingest/DATASET_NAME`
+    - **Header** `Authorization`: `Bearer API_TOKEN`
+    - **Header** `Content-Type`: `application/x-ndjson`
+
+<Info>
+<ReplaceDomain />
+<ReplaceDatasetToken />
+</Info>
+
+For more details on the ingest endpoint, see [Send data via the REST API](/restapi/ingest).
 
 Segment sends event payloads to Axiom in JSON format. Axiom stores each incoming payload as a structured event, preserving keys such as `event`, `userId`, `traits`, `properties`, and `_time` (automatically inferred or provided). No custom transformation is required. Segment’s default schema maps naturally into Axiom’s JSON ingestion pipeline.
 

--- a/query-data/metrics.mdx
+++ b/query-data/metrics.mdx
@@ -82,7 +82,7 @@ You can query metric data in one of the following ways:
     Support for MPL (Metrics Processing Language) is currently in public preview. For more information, see [Feature states](/platform-overview/roadmap#feature-states).
     </Info>
 - **Skills**: Use the [Query metrics skill](/console/intelligence/skills/query-metrics) to give AI agents the ability to query your metrics data via API.
-- **MCP**: Use the [Axiom MCP server](console/intelligence/mcp-server) to allow an MCP-compatible client to query your metrics data.
+- **MCP**: Use the [Axiom MCP server](/console/intelligence/mcp-server) to allow an MCP-compatible client to query your metrics data.
 
 <Frame>
 <img src="/doc-assets/shots/example-metrics-query.png" alt="Example metrics query" />

--- a/restapi/ingest.mdx
+++ b/restapi/ingest.mdx
@@ -19,7 +19,7 @@ This page explains how to send data to Axiom via cURL commands in each of these 
 
 For more information on choosing an ingest format, see [Optimize data loading](/reference/optimize-usage#optimize-data-loading).
 
-For more information on other ingest options, see [Send data](send-data/methods).
+For more information on other ingest options, see [Send data](/send-data/methods).
 
 For an introduction to the basics of the Axiom API and to the authentication options, see [Introduction to Axiom API](/restapi/introduction).
 
@@ -304,7 +304,7 @@ curl -X 'POST' 'https://AXIOM_DOMAIN/v1/ingest/DATASET_NAME' \
 <ReplaceDatasetToken />
 </Info>
 
-For more information on other libraries you can use to query data, see [Send data](send-data/methods).
+For more information on other libraries you can use to send data, see [Send data](/send-data/methods).
 
 ## What’s next
 

--- a/restapi/query.mdx
+++ b/restapi/query.mdx
@@ -338,5 +338,3 @@ curl --request POST \
 To run queries within a specific edge deployment, set the `edge` option when you create the client. The client then routes queries to the [edge query endpoint](/restapi/endpoints/queryEdge) automatically. For more information, see [Configure region](/guides/javascript#configure-region).
 
 For more examples, see the [examples in GitHub](https://github.com/axiomhq/axiom-js/tree/main/examples).
-
-For more information on other libraries you can use to query data, see [Send data](/send-data/methods).


### PR DESCRIPTION
## Summary

- Fix broken internal links in the REST API, APL function, and metrics docs by converting relative cross-section paths to absolute paths.
- On the product analytics page, replace the outdated Segment setup step with current REST API ingest instructions (webhook URL, `Authorization` and `Content-Type` headers) using the standard `ReplaceDomain` and `ReplaceDatasetToken` snippets.

## Files changed

- `restapi/ingest.mdx`, `restapi/query.mdx`
- `query-data/metrics.mdx`
- `apl/scalar-functions/string-functions/unicode-codepoints-from-string.mdx`
- `apl/scalar-functions/string-functions/unicode-codepoints-to-string.mdx`
- `apl/scalar-functions/mathematical-functions/set-has-element.mdx`
- `apl/scalar-functions/mathematical-functions/set-intersect.mdx`
- `apl/scalar-functions/mathematical-functions/set-union.mdx`
- `apl/scalar-functions/mathematical-functions/set-difference.mdx`
- `getting-started-guide/product-analytics.mdx`

## Test plan

- [x] Confirm previously broken links resolve to the expected pages in the preview build.
- [x] Confirm the updated Segment section on the product analytics page renders correctly with the `ReplaceDomain` and `ReplaceDatasetToken` snippets.