### PR TITLE
docs(cloudflare-logpush): document Zero Trust: PII Read token permission

### DIFF
--- a/apps/cloudflare-logpush.mdx
+++ b/apps/cloudflare-logpush.mdx
@@ -29,11 +29,17 @@ Cloudflare Logpush enables Cloudflare users to automatically export their logs i
 </Frame>
 
 You can create a token that has access to a single zone, single account or a mix of all these, depending on your needs. For account access, the token must
-have theses permissions:
+have these permissions:
   - Logs: Edit
   - Account settings: Read
 
 For the zones, only edit permission is required for logs.
+
+<Note>
+**Zero Trust datasets require an additional permission.** To create Logpush jobs for Cloudflare Zero Trust datasets (Access, Gateway, and DEX) — for example **Access requests**, **Gateway DNS**, **Gateway HTTP**, **Gateway Network**, and **Zero Trust Network Session Logs** — your token must also have the **Zero Trust: PII Read** permission in addition to **Logs: Edit**. These datasets can contain personally identifiable information (such as private IP addresses, user names, and device names), and Cloudflare blocks the job with a `missing required permissions` error when this permission isn't granted.
+
+The standard **Administrator** role includes **Logs: Edit** but not Zero Trust PII access, so an admin or owner account alone is not enough. A **Super Administrator** must assign the **Cloudflare Zero Trust PII** role to the user (or grant the token the **Zero Trust: PII Read** permission) before these jobs can be created. If you don't use Cloudflare Zero Trust, Gateway, or Access, you can leave these datasets unselected.
+</Note>
 
 ## Steps
 
@@ -121,3 +127,7 @@ Account-scoped
 - Network Analytics Logs
 - Workers Trace Events
 - Zero Trust Network Session Logs
+
+<Note>
+The Zero Trust, Gateway, and Access datasets (**Access requests**, **Gateway DNS**, **Gateway HTTP**, **Gateway Network**, and **Zero Trust Network Session Logs**) require the **Zero Trust: PII Read** token permission in addition to **Logs: Edit**. See [Prerequisites](#prerequisites) above. Without it, Cloudflare returns a `missing required permissions` error for these datasets.
+</Note>

--- a/apps/cloudflare-logpush.mdx
+++ b/apps/cloudflare-logpush.mdx
@@ -38,7 +38,7 @@ For the zones, only edit permission is required for logs.
 <Note>
 **Zero Trust datasets require an additional permission.** To create Logpush jobs for Cloudflare Zero Trust datasets (Access, Gateway, and DEX) — for example **Access requests**, **Gateway DNS**, **Gateway HTTP**, **Gateway Network**, and **Zero Trust Network Session Logs** — your token must also have the **Zero Trust: PII Read** permission in addition to **Logs: Edit**. These datasets can contain personally identifiable information (such as private IP addresses, user names, and device names), and Cloudflare blocks the job with a `missing required permissions` error when this permission isn't granted.
 
-The standard **Administrator** role includes **Logs: Edit** but not Zero Trust PII access, so an admin or owner account alone is not enough. A **Super Administrator** must assign the **Cloudflare Zero Trust PII** role to the user (or grant the token the **Zero Trust: PII Read** permission) before these jobs can be created. If you don't use Cloudflare Zero Trust, Gateway, or Access, you can leave these datasets unselected.
+The standard **Administrator** role includes **Logs: Edit** but not Zero Trust PII access, so an admin or owner account alone isn't enough. A **Super Administrator** must assign the **Cloudflare Zero Trust PII** role to the user (or grant the token the **Zero Trust: PII Read** permission) before these jobs can be created. If you don't use Cloudflare Zero Trust, Gateway, or Access, you can leave these datasets unselected.
 </Note>
 
 ## Steps


### PR DESCRIPTION
## What

Documents that Cloudflare Logpush jobs for **Zero Trust datasets** (Access, Gateway, DEX) require the **`Zero Trust: PII Read`** API-token permission in addition to **`Logs: Edit`**.

## Why

A customer (via support) hit `missing required permissions` errors when installing the Cloudflare Logpush app for the Zero Trust datasets — `access_requests`, `gateway_dns`, `gateway_http`, `gateway_network`, `zero_trust_network_sessions` — even using admin and owner Cloudflare accounts.

Root cause is a 2025 Cloudflare change: those datasets contain PII (private IPs, user/device names), so Cloudflare now requires both `Logs: Edit` and `Zero Trust: PII Read`. The standard **Administrator** role does not include Zero Trust PII; a **Super Administrator** must assign the **Cloudflare Zero Trust PII** role. Confirmed against Cloudflare's docs:

- https://developers.cloudflare.com/logs/logpush/permissions/
- https://developers.cloudflare.com/cloudflare-one/insights/logs/gateway-logs/manage-pii/

Axiom only relays Cloudflare's API error, so the fix is documentation only.

## Changes

- `apps/cloudflare-logpush.mdx`:
  - Add a Note in **Prerequisites** explaining the extra `Zero Trust: PII Read` permission and the Super Administrator role step.
  - Add a Note in **Supported Datasets** flagging the affected datasets.
  - Fix a "theses" typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
