### PR TITLE
docs: update us-east-1 PrivateLink service name

### DIFF
--- a/apps/aws-privatelink.mdx
+++ b/apps/aws-privatelink.mdx
@@ -25,7 +25,7 @@ Use the service details for your edge deployment to set up the VPC endpoint.
 
 | Axiom edge deployment | PrivateLink service name | PrivateLink service region |
 | :--- | :--- | :--- |
-| `US East 1 (AWS)` | `com.amazonaws.vpce.us-east-1.vpce-svc-05a64735cdf68866b` | `us-east-1` |
+| `US East 1 (AWS)` | `com.amazonaws.vpce.us-east-1.vpce-svc-0daeb6c5a00337061` | `us-east-1` |
 | `EU Central 1 (AWS)` | `com.amazonaws.vpce.eu-central-1.vpce-svc-00e8d47e8c60784f7` | `eu-central-1` |
 
 1. In your VPC Console, go to **PrivateLink and Lattice > Endpoints**, and then click **Create endpoint**.


### PR DESCRIPTION
Update the production US East 1 (AWS) PrivateLink service name in `apps/aws-privatelink.mdx`.

- **Before:** `com.amazonaws.vpce.us-east-1.vpce-svc-05a64735cdf68866b`
- **After:** `com.amazonaws.vpce.us-east-1.vpce-svc-0daeb6c5a00337061`

The EU Central 1 entry is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)