### PR TITLE
docs: document dataset schema locking

### DIFF
--- a/apl/data-types/map-fields.mdx
+++ b/apl/data-types/map-fields.mdx
@@ -71,7 +71,7 @@ Replace `MAP_FIELD` with the name of the field that you want to change to a map 
 </Info>
 
 <Note>
-Changes to map fields affect the schema of the dataset. If the dataset’s schema is locked, Axiom automatically regenerates the locked schema when you create, change, or remove a map field so that the locked schema reflects the change. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
+Creating a map field affects the schema of the dataset. If the dataset’s schema is locked, Axiom automatically regenerates the locked schema when you create a map field so that the locked schema reflects the change. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
 </Note>
 
 ## View map fields

--- a/apl/data-types/map-fields.mdx
+++ b/apl/data-types/map-fields.mdx
@@ -70,6 +70,10 @@ curl --request POST \
 Replace `MAP_FIELD` with the name of the field that you want to change to a map field.
 </Info>
 
+<Note>
+Changes to map fields affect the schema of the dataset. If the dataset’s schema is locked, Axiom automatically regenerates the locked schema when you create, change, or remove a map field so that the locked schema reflects the change. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
+</Note>
+
 ## View map fields
 
 To view map fields:

--- a/query-data/datasets.mdx
+++ b/query-data/datasets.mdx
@@ -38,7 +38,7 @@ When you select a dataset, Axiom displays the list of fields within the dataset 
 
 This view flattens field names with dot notation. This means that the event `{"foo": { "bar": "baz" }}` appears as `foo.bar`. Field names containing periods (`.`) are folded.
 
-By default, when you ingest an event with a field that isn’t yet part of the dataset’s schema, Axiom adds the new field to the schema. To freeze the set of fields in an event dataset, lock its schema. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
+By default, when you ingest an event with a field that isn’t yet part of the dataset’s schema, Axiom adds the new field to the schema. To freeze the set of fields in an event dataset and the type of each field, lock its schema. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
 
 On the right, you see the following:
 

--- a/query-data/datasets.mdx
+++ b/query-data/datasets.mdx
@@ -38,6 +38,8 @@ When you select a dataset, Axiom displays the list of fields within the dataset 
 
 This view flattens field names with dot notation. This means that the event `{"foo": { "bar": "baz" }}` appears as `foo.bar`. Field names containing periods (`.`) are folded.
 
+By default, when you ingest an event with a field that isn’t yet part of the dataset’s schema, Axiom adds the new field to the schema. To freeze the set of fields in an event dataset, lock its schema. For more information, see [Lock dataset schema](/reference/datasets#lock-dataset-schema).
+
 On the right, you see the following:
 
 - [Views](#views)

--- a/reference/datasets.mdx
+++ b/reference/datasets.mdx
@@ -140,6 +140,38 @@ To vacuum fields, follow these steps:
 1. In the list, find the dataset where you want to vacuum fields, and then click <img src="/doc-assets/icons/vacuum.svg" className="inline-icon" alt="Vacuum fields icon" /> **Vacuum fields** on the right.
 1. Select the checkbox, and then click **Vacuum**.
 
+## Lock dataset schema
+
+By default, the data schema of a dataset grows together with your data. When you ingest an event with a field that isn’t yet part of the data schema, Axiom adds the new field to the schema.
+
+Locking the schema of a dataset freezes its set of fields. When you lock the schema, Axiom takes a snapshot of the fields that occur in events within your retention period. While the schema is locked, Axiom discards fields that aren’t part of this snapshot during the data ingestion process. Axiom still ingests the events themselves and only drops the fields that aren’t part of the locked schema.
+
+Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, or if you want to keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [vacuum its fields](#vacuum-fields).
+
+Locking and unlocking the schema take effect immediately and don’t change the data stored in the dataset. When you unlock the schema, Axiom restores the default behavior and adds new fields to the schema during the data ingestion process. Unlocking doesn’t restore fields that Axiom discarded while the schema was locked.
+
+<Note>
+- You can only lock the schema of event datasets. Metrics datasets don’t support schema locking.
+- To lock or unlock the schema, you need update permissions for datasets. Without these permissions, Axiom doesn’t display the menu options below.
+- You can’t lock the schema of a dataset that another organization has shared with your organization.
+</Note>
+
+To lock the schema of a dataset, follow these steps:
+
+1. Go to the Datasets tab.
+1. In the list, select the dataset whose schema you want to lock.
+1. In the **Fields** panel, click <Icon icon="ellipsis-vertical" iconType="solid"/> **More > Lock schema**.
+
+Axiom displays a **Schema locked** message. While the schema is locked, the title of the Fields panel is **Fields (Locked)**.
+
+To unlock the schema of a dataset, follow these steps:
+
+1. Go to the Datasets tab.
+1. In the list, select the dataset whose schema you want to unlock.
+1. In the **Fields** panel, click <Icon icon="ellipsis-vertical" iconType="solid"/> **More > Unlock schema**.
+
+Axiom displays a **Schema unlocked** message.
+
 ## Share datasets
 
 You can share your datasets with other Axiom organizations. The receiving organization:

--- a/reference/datasets.mdx
+++ b/reference/datasets.mdx
@@ -130,6 +130,8 @@ In this case, vacuuming fields in a dataset can help you reduce the number of fi
 
 Vacuuming fields doesn’t delete any events from your dataset. To delete events, [trim the dataset](#trim-dataset). You can use trimming and vacuuming in combination. For example, if you accidentally ingested events with fields you didn’t want to send to Axiom, and these events are within your retention period, vacuuming alone doesn’t solve your problem. In this case, first trim the dataset to delete the events with the unintended fields, and then vacuum the fields to rebuild the data schema.
 
+You can vacuum the fields of a dataset whose schema is locked. In this case, Axiom vacuums the fields and then regenerates the locked schema so that it matches the vacuumed fields. For more information, see [Lock dataset schema](#lock-dataset-schema).
+
 <Note>
 You can only vacuum fields once per day for each dataset.
 </Note>
@@ -142,12 +144,12 @@ To vacuum fields, follow these steps:
 
 ## Lock dataset schema
 
-By default, the data schema of a dataset grows together with your data. When you ingest an event with a field that isn’t yet part of the data schema, Axiom adds the new field to the schema.
+By default, the data schema of a dataset grows together with your data. When you ingest an event with a field that isn’t yet part of the data schema, Axiom adds the new field to the schema. Similarly, when you ingest an event where the value of an existing field has a new type, Axiom extends the field’s type to support both the existing and the new type.
 
 Locking the schema of a dataset freezes its set of fields and the type of each field. While the schema is locked, Axiom discards the following during the data ingestion process:
 
 - Fields that aren’t part of the locked schema.
-- Field values whose type doesn’t match the type of the field in the locked schema. For example, if the locked schema defines a field as a number and you ingest an event where the field contains a string, Axiom drops the field’s value from that event.
+- Field values whose type doesn’t match the type of the field in the locked schema and can’t be promoted to that type. For example, if the locked schema defines a field as a number and you ingest an event where the field contains a string, Axiom drops the field’s value from that event. Axiom keeps values that it can promote to the locked type. For example, if the locked type of a field is float, Axiom accepts integer values in that field. Null values never violate a locked schema.
 
 Axiom still ingests the events themselves and only drops the fields that don’t match the locked schema. When Axiom drops a field, the response to the ingest request contains a warning message that identifies the field and the reason. For example:
 

--- a/reference/datasets.mdx
+++ b/reference/datasets.mdx
@@ -144,12 +144,31 @@ To vacuum fields, follow these steps:
 
 By default, the data schema of a dataset grows together with your data. When you ingest an event with a field that isn’t yet part of the data schema, Axiom adds the new field to the schema.
 
-Locking the schema of a dataset freezes its set of fields and the type of each field. When you lock the schema, Axiom takes a snapshot of the fields that occur in events within your retention period, together with their types. While the schema is locked, Axiom discards the following during the data ingestion process:
+Locking the schema of a dataset freezes its set of fields and the type of each field. While the schema is locked, Axiom discards the following during the data ingestion process:
 
-- Fields that aren’t part of the snapshot.
-- Field values whose type doesn’t match the type of the field in the snapshot. For example, if the locked schema defines a field as a number and you ingest an event where the field contains a string, Axiom drops the field’s value from that event.
+- Fields that aren’t part of the locked schema.
+- Field values whose type doesn’t match the type of the field in the locked schema. For example, if the locked schema defines a field as a number and you ingest an event where the field contains a string, Axiom drops the field’s value from that event.
 
-Axiom still ingests the events themselves and only drops the fields that don’t match the locked schema.
+Axiom still ingests the events themselves and only drops the fields that don’t match the locked schema. When Axiom drops a field, the response to the ingest request contains a warning message that identifies the field and the reason. For example:
+
+```json
+"messages": [
+  {
+    "priority": "warn",
+    "code": "schema_rules_drop:debug",
+    "count": 1,
+    "msg": "field \"debug\" dropped: not in declared schema"
+  },
+  {
+    "priority": "warn",
+    "code": "schema_rules_drop:status",
+    "count": 1,
+    "msg": "field \"status\" dropped: type rule violated (allowed integer, saw string)"
+  }
+]
+```
+
+Axiom calculates ingest usage based on the data as it arrives. Fields that Axiom discards because the schema is locked still count towards your ingest usage.
 
 Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, ensure that fields have consistent types, or keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [vacuum its fields](#vacuum-fields).
 

--- a/reference/datasets.mdx
+++ b/reference/datasets.mdx
@@ -144,11 +144,16 @@ To vacuum fields, follow these steps:
 
 By default, the data schema of a dataset grows together with your data. When you ingest an event with a field that isn’t yet part of the data schema, Axiom adds the new field to the schema.
 
-Locking the schema of a dataset freezes its set of fields. When you lock the schema, Axiom takes a snapshot of the fields that occur in events within your retention period. While the schema is locked, Axiom discards fields that aren’t part of this snapshot during the data ingestion process. Axiom still ingests the events themselves and only drops the fields that aren’t part of the locked schema.
+Locking the schema of a dataset freezes its set of fields and the type of each field. When you lock the schema, Axiom takes a snapshot of the fields that occur in events within your retention period, together with their types. While the schema is locked, Axiom discards the following during the data ingestion process:
 
-Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, or if you want to keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [vacuum its fields](#vacuum-fields).
+- Fields that aren’t part of the snapshot.
+- Field values whose type doesn’t match the type of the field in the snapshot. For example, if the locked schema defines a field as a number and you ingest an event where the field contains a string, Axiom drops the field’s value from that event.
 
-Locking and unlocking the schema take effect immediately and don’t change the data stored in the dataset. When you unlock the schema, Axiom restores the default behavior and adds new fields to the schema during the data ingestion process. Unlocking doesn’t restore fields that Axiom discarded while the schema was locked.
+Axiom still ingests the events themselves and only drops the fields that don’t match the locked schema.
+
+Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, ensure that fields have consistent types, or keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [vacuum its fields](#vacuum-fields).
+
+Locking and unlocking the schema take effect immediately and don’t change the data stored in the dataset. When you unlock the schema, Axiom restores the default behavior and adds new fields to the schema during the data ingestion process. Unlocking doesn’t restore fields or values that Axiom discarded while the schema was locked.
 
 <Note>
 - You can only lock the schema of event datasets. Metrics datasets don’t support schema locking.

--- a/reference/datasets.mdx
+++ b/reference/datasets.mdx
@@ -159,6 +159,7 @@ Locking and unlocking the schema take effect immediately and don’t change the 
 - You can only lock the schema of event datasets. Metrics datasets don’t support schema locking.
 - To lock or unlock the schema, you need update permissions for datasets. Without these permissions, Axiom doesn’t display the menu options below.
 - You can’t lock the schema of a dataset that another organization has shared with your organization.
+- You can’t lock the schema of a dataset that you have set up through the [Cloudflare Logpush](/apps/cloudflare-logpush), [Vercel](/apps/vercel), or [Netlify](/apps/netlify) integration.
 </Note>
 
 To lock the schema of a dataset, follow these steps:

--- a/reference/limits.mdx
+++ b/reference/limits.mdx
@@ -47,6 +47,8 @@ To reduce the number of fields in a dataset, use one of the following approaches
 - [Trim the dataset](/reference/datasets#trim-dataset) and [vacuum its fields](/reference/datasets#vacuum-fields).
 - Use [map fields](/apl/data-types/map-fields).
 
+To prevent new fields from being added to an event dataset, [lock its schema](/reference/datasets#lock-dataset-schema).
+
 ## System-wide limits
 
 The following limits are applied to all accounts, irrespective of the pricing plan.


### PR DESCRIPTION
## What

Documents the new dataset schema locking feature as a console workflow.

- **reference/datasets.mdx**: new [Lock dataset schema](https://axiom.co/docs/reference/datasets#lock-dataset-schema) section alongside the trim and vacuum sections. Covers what locking does (snapshots the schema — fields **and their types** — over the retention window; off-schema fields and type-mismatched field values are discarded at ingest while events are still ingested), that it's instant and reversible without modifying stored data, and the constraints (event datasets only, requires datasets update permission, not available on shared datasets). Includes lock and unlock steps via the Fields panel overflow menu.
- **reference/limits.mdx**: links schema locking from the datasets/fields restrictions section as a way to prevent new fields from being added.
- **query-data/datasets.mdx**: mentions the default add-fields-at-ingest behavior and the locked exception in the Datasets tab overview, linking to the reference section.

## Notes

- No API reference docs: the lock/unlock endpoints are internal-only for now, so this is documented as a console workflow only.
- Vale passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)