### PR TITLE
docs(aws-lambda): add best practices for production workloads

### DIFF
--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -49,6 +49,10 @@ To install the Axiom Lambda Extension, choose one of the following methods:
 - [Terraform](#install-with-terraform)
 - [AWS Lambda function UI](#install-with-aws-lambda-function-ui)
 
+<Warning>
+The layer `VERSION` in the ARN isn’t the same as the extension release version on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. AWS assigns layer version numbers automatically, one per publish, so the two numbering schemes differ. For example, extension release v16 is published as layer version `17` in all supported regions. After you install or upgrade, [verify the extension version](#verify-the-extension-version) that your functions run.
+</Warning>
+
 ### Install with AWS CLI
 
 <Steps>
@@ -63,7 +67,7 @@ aws lambda update-function-configuration --function-name my-function \
 
 - Replace `AWS_REGION` with the AWS Region to send the request to. For example, `us-west-1`.
 - Replace `ARCH` with the system architecture type. For example, `arm64`.
-- Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
+- Replace `VERSION` with the latest Lambda layer version. For example, `17`, which contains extension release v16. The layer version doesn’t match the release version on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page because AWS assigns layer version numbers automatically.
 
 </Step>
 <Step>
@@ -123,7 +127,7 @@ resource "aws_lambda_function" "test_lambda" {
 <Info>
 Replace `AWS_REGION` with the AWS Region to send the request to. For example, `us-west-1`.
 Replace `ARCH` with the system architecture type. For example, `arm64`.
-Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
+Replace `VERSION` with the latest Lambda layer version. For example, `17`, which contains extension release v16. The layer version doesn’t match the release version on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page because AWS assigns layer version numbers automatically.
 <ReplaceDatasetToken />
 <ReplaceDomain />
 </Info>
@@ -160,7 +164,7 @@ module "lambda_function" {
 <Info>
 Replace `AWS_REGION` with the AWS Region to send the request to. For example, `us-west-1`.
 Replace `ARCH` with the system architecture type. For example, `arm64`.
-Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
+Replace `VERSION` with the latest Lambda layer version. For example, `17`, which contains extension release v16. The layer version doesn’t match the release version on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page because AWS assigns layer version numbers automatically.
 <ReplaceDatasetToken />
 <ReplaceDomain />
 </Info>
@@ -182,7 +186,7 @@ arn:aws:lambda:AWS_REGION:694952825951:layer:axiom-extension-ARCH:VERSION
 <Info>
 Replace `AWS_REGION` with the AWS Region to send the request to. For example, `us-west-1`.
 Replace `ARCH` with the system architecture type. For example, `arm64`.
-Replace `VERSION` with the latest version number specified on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page. For example, `11`.
+Replace `VERSION` with the latest Lambda layer version. For example, `17`, which contains extension release v16. The layer version doesn’t match the release version on the [GitHub Releases](https://github.com/axiomhq/axiom-lambda-extension/releases) page because AWS assigns layer version numbers automatically.
 </Info>
 
 </Step>
@@ -203,6 +207,18 @@ AXIOM_DATASET: DATASET_NAME
 </Steps>
 
 You have installed the Axiom Lambda Extension. Go to the Axiom UI and ensure your dataset receives events properly.
+
+## Verify the extension version
+
+The extension stamps its release version on every event it sends to Axiom. After you install or upgrade, check which release your functions actually run:
+
+```kusto
+['DATASET_NAME']
+| where isnotnull(['axiom.awsLambdaExtensionVersion'])
+| summarize count() by ['axiom.awsLambdaExtensionVersion']
+```
+
+The result is the extension release version, such as `v16`. If the result shows an older release than you expect, the layer version in your function configuration points to an older build. Update the layer ARN to the latest layer version and redeploy.
 
 ## Turn off Amazon CloudWatch logging
 
@@ -233,7 +249,7 @@ For most workloads, this trade-off is the right default. If you run high-volume 
 - **Alternatively, use Amazon CloudWatch as the buffer.** Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). Delivery to Axiom is then fully decoupled from your functions, with CloudWatch providing durable storage and retries, at the cost of CloudWatch pricing and some added latency.
 
 <Note>
-With extension v16 and later, you can tune the in-memory buffer size with the `AXIOM_MAX_BUFFERED_EVENTS` environment variable (default `10000`; the oldest events are dropped beyond this limit) and the per-flush time budget with `AXIOM_FLUSH_TIMEOUT` (a Go duration, default `5s`; a flush never runs past the invocation deadline).
+With extension release v16 (layer version `17`) and later, you can tune the in-memory buffer size with the `AXIOM_MAX_BUFFERED_EVENTS` environment variable (default `10000`; the oldest events are dropped beyond this limit) and the per-flush time budget with `AXIOM_FLUSH_TIMEOUT` (a Go duration, default `5s`; a flush never runs past the invocation deadline).
 </Note>
 
 ## Troubleshooting

--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -240,36 +240,22 @@ The Stream and Query tabs allow you to easily detect warnings and errors in your
 
 ## Best practices for production workloads
 
-The Axiom Lambda Extension runs inside your Lambda execution environment and shares its CPU, memory, and network with your function. It favors the performance of your function over guaranteed log delivery. It buffers events in memory, sends them to Axiom as your function is invoked and when the execution environment shuts down, and retries failed sends on later invocations. The buffer only lives as long as the execution environment. When Axiom is unreachable for a sustained period, the extension drops the oldest buffered events.
+The Axiom Lambda Extension runs inside your Lambda execution environment and shares its CPU, memory, and network with your function. It favors the performance of your function over guaranteed log delivery: it buffers events in memory and, when Axiom is unreachable for a sustained period, drops the oldest buffered events. The buffer only lives as long as the execution environment. For low-to-medium volume workloads that tolerate occasional loss, sending directly from the extension to Axiom works well.
 
-Both the memory the buffer uses and the time the extension spends sending are bounded. A slow or unreachable endpoint can’t grow the buffer without limit, and the extension abandons a stalled send in time to shut the execution environment down normally instead of holding it open until your function times out. Tune the bounds with the following environment variables:
+For high-volume, high-concurrency, or delivery-critical workloads, don’t send directly to Axiom from your functions. Decouple your functions from Axiom with a durable collector that you run on separate infrastructure. Your functions hand logs to a nearby collector and return immediately, and the collector owns buffering, batching, backpressure, and retries before forwarding to Axiom. This keeps your function durations predictable and prevents log loss when Axiom is briefly unreachable.
 
-| Environment variable | Default | Description |
-| --- | --- | --- |
-| `AXIOM_MAX_BUFFERED_EVENTS` | `10000` | The maximum number of events in the in-memory buffer. Beyond this limit, the extension drops the oldest events. |
-| `AXIOM_FLUSH_TIMEOUT` | `5s` | The time budget for a single send, expressed as a Go duration. The extension also ends a send early to stay within the invocation deadline. |
+### Forward to a collector you manage (recommended)
 
-<Warning>
-These bounds only exist in extension release v16 (layer version `17`) and later. On earlier releases, a sustained inability to reach Axiom grows the buffer until your function reaches its memory limit, and a stalled send holds the execution environment open, and billed, until your function times out. Upgrade to v16 or later before you run high-volume or delivery-critical workloads. To check the version your functions run, see [Verify the extension version](#verify-the-extension-version).
-</Warning>
+Run a durable log pipeline such as Vector or the OpenTelemetry Collector on always-on infrastructure you manage, such as Amazon ECS or EC2. The collector forwards to Axiom: Vector through its native [Axiom sink](/send-data/vector), and the OpenTelemetry Collector over OTLP, which Axiom ingests [natively](/send-data/opentelemetry). The sizing and operation of the collector are up to you.
 
-For most workloads, sending directly from the extension is the right default. If you run high-volume, high-concurrency, or delivery-critical workloads, decouple your functions from Axiom by placing a collector between them. Your functions hand logs to a nearby collector instead of waiting on the network path to Axiom, which keeps your function durations predictable and isolates your functions from any slowness or downtime on that path. The collector takes care of durable buffering, batching, backpressure, and retries.
+Get logs from your functions to this collector in one of the following ways:
 
-### Run a collector you manage
-
-Run a log pipeline such as Vector or the OpenTelemetry Collector on infrastructure you manage, such as Amazon ECS or EC2. Vector ships with a native [Axiom sink](/send-data/vector), and Axiom ingests [OpenTelemetry](/send-data/opentelemetry) data natively. The choice, sizing, and operation of the collector are up to you.
-
-To keep using the extension with your collector, set the `AXIOM_URL` environment variable to your collector’s endpoint. The extension sends gzip-compressed NDJSON to the `/v1/datasets/DATASET_NAME/ingest` path of that URL, so any intermediary that accepts the [Axiom ingest API](/restapi/ingest) and forwards to Axiom works.
-
-### Run a collector as a Lambda layer
-
-If you want a collector without managing separate infrastructure, use the [OpenTelemetry Lambda layer](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md) instead of the Axiom Lambda Extension. It runs an OpenTelemetry Collector as a layer on your function, and you configure it to export OpenTelemetry data to Axiom. For more information, see [Send OpenTelemetry data to Axiom](/send-data/opentelemetry).
-
-Because this collector also runs inside the execution environment, it shares your function’s resources. It doesn’t isolate your functions from the network path to Axiom the way a collector you run separately does.
+- **Axiom Lambda Extension.** Set the `AXIOM_URL` environment variable to your collector’s endpoint. The extension sends gzip-compressed NDJSON to the `/v1/datasets/DATASET_NAME/ingest` path of that URL, so any intermediary that accepts the [Axiom ingest API](/restapi/ingest) and forwards to Axiom works.
+- **OpenTelemetry Lambda layer.** Use the [OpenTelemetry Lambda layer](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md) as a replacement for the Axiom Lambda Extension, and configure its exporter to forward to your collector. For more information, see [Send OpenTelemetry data to Axiom](/send-data/opentelemetry).
 
 ### Use Amazon CloudWatch as the buffer
 
-If you prefer not to run a collector, use AWS-native tooling to decouple delivery. Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). Delivery to Axiom is then fully decoupled from your functions, with CloudWatch providing durable storage and retries, at the cost of CloudWatch pricing and some added latency.
+If you prefer not to run collector infrastructure, use AWS-native tooling to decouple delivery. Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). CloudWatch durably stores the logs, and the forwarder delivers them to Axiom fully decoupled from your functions, at the cost of CloudWatch pricing and some added latency.
 
 ## Troubleshooting
 

--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -240,17 +240,36 @@ The Stream and Query tabs allow you to easily detect warnings and errors in your
 
 ## Best practices for production workloads
 
-The Axiom Lambda Extension favors the performance of your function over guaranteed log delivery. It buffers events in memory inside the Lambda execution environment and sends them to Axiom as your function is invoked and when the execution environment shuts down. Failed sends are retried on later invocations, but the time the extension spends sending is strictly capped so it can never block your function until timeout, and the buffer only lives as long as the execution environment. During a sustained inability to reach Axiom, the oldest buffered events are dropped.
+The Axiom Lambda Extension runs inside your Lambda execution environment and shares its CPU, memory, and network with your function. It favors the performance of your function over guaranteed log delivery. It buffers events in memory, sends them to Axiom as your function is invoked and when the execution environment shuts down, and retries failed sends on later invocations. The buffer only lives as long as the execution environment. When Axiom is unreachable for a sustained period, the extension drops the oldest buffered events.
 
-For most workloads, this trade-off is the right default. If you run high-volume or delivery-critical workloads, the best practice is to decouple your functions from Axiom by placing a collector between them:
+Both the memory the buffer uses and the time the extension spends sending are bounded. A slow or unreachable endpoint can’t grow the buffer without limit, and the extension abandons a stalled send in time to shut the execution environment down normally instead of holding it open until your function times out. Tune the bounds with the following environment variables:
 
-- **Deploy a collector you control between Lambda and Axiom.** Run a log pipeline such as Vector or the OpenTelemetry Collector on infrastructure you manage. Your functions hand logs to the nearby collector quickly, and the collector takes care of durable buffering, batching, backpressure, and retries before forwarding to Axiom. This isolates your functions from any slowness or downtime between your environment and Axiom. Vector ships with a native [Axiom sink](/send-data/vector), and Axiom ingests [OpenTelemetry](/send-data/opentelemetry) data natively. The choice, sizing, and operation of the collector are up to you.
-- **Keep using the extension by pointing it at your collector.** Set the `AXIOM_URL` environment variable to your collector's endpoint. The extension sends gzip-compressed NDJSON to the `/v1/datasets/DATASET_NAME/ingest` path of that URL, so any intermediary that accepts the [Axiom ingest API](/restapi/ingest) and forwards to Axiom works.
-- **Alternatively, use Amazon CloudWatch as the buffer.** Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). Delivery to Axiom is then fully decoupled from your functions, with CloudWatch providing durable storage and retries, at the cost of CloudWatch pricing and some added latency.
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `AXIOM_MAX_BUFFERED_EVENTS` | `10000` | The maximum number of events in the in-memory buffer. Beyond this limit, the extension drops the oldest events. |
+| `AXIOM_FLUSH_TIMEOUT` | `5s` | The time budget for a single send, expressed as a Go duration. The extension also ends a send early to stay within the invocation deadline. |
 
-<Note>
-With extension release v16 (layer version `17`) and later, you can tune the in-memory buffer size with the `AXIOM_MAX_BUFFERED_EVENTS` environment variable (default `10000`; the oldest events are dropped beyond this limit) and the per-flush time budget with `AXIOM_FLUSH_TIMEOUT` (a Go duration, default `5s`; a flush never runs past the invocation deadline).
-</Note>
+<Warning>
+These bounds only exist in extension release v16 (layer version `17`) and later. On earlier releases, a sustained inability to reach Axiom grows the buffer until your function reaches its memory limit, and a stalled send holds the execution environment open, and billed, until your function times out. Upgrade to v16 or later before you run high-volume or delivery-critical workloads. To check the version your functions run, see [Verify the extension version](#verify-the-extension-version).
+</Warning>
+
+For most workloads, sending directly from the extension is the right default. If you run high-volume, high-concurrency, or delivery-critical workloads, decouple your functions from Axiom by placing a collector between them. Your functions hand logs to a nearby collector instead of waiting on the network path to Axiom, which keeps your function durations predictable and isolates your functions from any slowness or downtime on that path. The collector takes care of durable buffering, batching, backpressure, and retries.
+
+### Run a collector you manage
+
+Run a log pipeline such as Vector or the OpenTelemetry Collector on infrastructure you manage, such as Amazon ECS or EC2. Vector ships with a native [Axiom sink](/send-data/vector), and Axiom ingests [OpenTelemetry](/send-data/opentelemetry) data natively. The choice, sizing, and operation of the collector are up to you.
+
+To keep using the extension with your collector, set the `AXIOM_URL` environment variable to your collector’s endpoint. The extension sends gzip-compressed NDJSON to the `/v1/datasets/DATASET_NAME/ingest` path of that URL, so any intermediary that accepts the [Axiom ingest API](/restapi/ingest) and forwards to Axiom works.
+
+### Run a collector as a Lambda layer
+
+If you want a collector without managing separate infrastructure, use the [OpenTelemetry Lambda layer](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md) instead of the Axiom Lambda Extension. It runs an OpenTelemetry Collector as a layer on your function, and you configure it to export OpenTelemetry data to Axiom. For more information, see [Send OpenTelemetry data to Axiom](/send-data/opentelemetry).
+
+Because this collector also runs inside the execution environment, it shares your function’s resources. It doesn’t isolate your functions from the network path to Axiom the way a collector you run separately does.
+
+### Use Amazon CloudWatch as the buffer
+
+If you prefer not to run a collector, use AWS-native tooling to decouple delivery. Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). Delivery to Axiom is then fully decoupled from your functions, with CloudWatch providing durable storage and retries, at the cost of CloudWatch pricing and some added latency.
 
 ## Troubleshooting
 

--- a/send-data/aws-lambda.mdx
+++ b/send-data/aws-lambda.mdx
@@ -222,6 +222,20 @@ The Stream and Query tabs allow you to easily detect warnings and errors in your
 - `record.severity`
 - `type`
 
+## Best practices for production workloads
+
+The Axiom Lambda Extension favors the performance of your function over guaranteed log delivery. It buffers events in memory inside the Lambda execution environment and sends them to Axiom as your function is invoked and when the execution environment shuts down. Failed sends are retried on later invocations, but the time the extension spends sending is strictly capped so it can never block your function until timeout, and the buffer only lives as long as the execution environment. During a sustained inability to reach Axiom, the oldest buffered events are dropped.
+
+For most workloads, this trade-off is the right default. If you run high-volume or delivery-critical workloads, the best practice is to decouple your functions from Axiom by placing a collector between them:
+
+- **Deploy a collector you control between Lambda and Axiom.** Run a log pipeline such as Vector or the OpenTelemetry Collector on infrastructure you manage. Your functions hand logs to the nearby collector quickly, and the collector takes care of durable buffering, batching, backpressure, and retries before forwarding to Axiom. This isolates your functions from any slowness or downtime between your environment and Axiom. Vector ships with a native [Axiom sink](/send-data/vector), and Axiom ingests [OpenTelemetry](/send-data/opentelemetry) data natively. The choice, sizing, and operation of the collector are up to you.
+- **Keep using the extension by pointing it at your collector.** Set the `AXIOM_URL` environment variable to your collector's endpoint. The extension sends gzip-compressed NDJSON to the `/v1/datasets/DATASET_NAME/ingest` path of that URL, so any intermediary that accepts the [Axiom ingest API](/restapi/ingest) and forwards to Axiom works.
+- **Alternatively, use Amazon CloudWatch as the buffer.** Keep CloudWatch logging turned on (skip the [turn-off step](#turn-off-amazon-cloudwatch-logging) above) and ship logs with the [Axiom CloudWatch Forwarder](/send-data/cloudwatch). Delivery to Axiom is then fully decoupled from your functions, with CloudWatch providing durable storage and retries, at the cost of CloudWatch pricing and some added latency.
+
+<Note>
+With extension v16 and later, you can tune the in-memory buffer size with the `AXIOM_MAX_BUFFERED_EVENTS` environment variable (default `10000`; the oldest events are dropped beyond this limit) and the per-flush time budget with `AXIOM_FLUSH_TIMEOUT` (a Go duration, default `5s`; a flush never runs past the invocation deadline).
+</Note>
+
 ## Troubleshooting
 
 - Ensure the Axiom API token has permission to ingest data into the dataset.


### PR DESCRIPTION
## What

Adds a **Best practices for production workloads** section to the AWS Lambda send-data page, placed before Troubleshooting.