### PR TITLE
docs: update Next.js guide for the Next.js 16 middleware to proxy rename

### DIFF
--- a/send-data/nextjs.mdx
+++ b/send-data/nextjs.mdx
@@ -118,15 +118,15 @@ For more information on React client side helpers, see [React](/send-data/react)
 
 ### Capture traffic requests
 
-To capture traffic requests, create a `middleware.ts` file in the root folder of your Next.js app with the following content:
+To capture traffic requests, create a `proxy.ts` file in the root folder of your Next.js app with the following content:
 
-```ts middleware.ts [expandable]
+```ts proxy.ts [expandable]
 import { logger } from "@/lib/axiom/server";
 import { transformMiddlewareRequest } from "@axiomhq/nextjs";
 import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 
-export async function middleware(request: NextRequest, event: NextFetchEvent) {
+export async function proxy(request: NextRequest, event: NextFetchEvent) {
   logger.info(...transformMiddlewareRequest(request));
 
   event.waitUntil(logger.flush());
@@ -146,6 +146,10 @@ export const config = {
   ],
 };
 ```
+
+<Note>
+Next.js 16 renamed middleware to proxy. If your app uses Next.js 15 or earlier, name the file `middleware.ts` and the exported function `middleware` instead. The file contents are otherwise identical. `middleware.ts` still works in Next.js 16, but it's deprecated and will be removed in a future version.
+</Note>
 
 ### Web Vitals
 
@@ -628,35 +632,38 @@ export const withAxiom = createAxiomRouteHandler(logger, {
 });
 ```
 
-#### Sever context on arbitrary functions
+#### Server context on arbitrary functions
 
-You can also add the server context to any function that runs in the server. For example, server actions, middleware, and server components.
+You can also add the server context to any function that runs in the server. For example, server actions, proxy (formerly middleware), and server components.
 
 ```ts [expandable]
 "use server";
 import { runWithServerContext } from "@axiomhq/nextjs";
 
 export const serverAction = () =>
-  runWithServerContext({ request_id: crypto.randomUUID() }, () => {
+  runWithServerContext(() => {
     return "Hello World";
-  });
+  }, { request_id: crypto.randomUUID() });
 
 ```
 
-```ts middleware.ts [expandable]
-import { runWithServerContext } from '@axiomhq/nextjs';
+```ts proxy.ts [expandable]
+import { logger } from "@/lib/axiom/server";
+import { runWithServerContext, transformMiddlewareRequest } from "@axiomhq/nextjs";
+import { NextResponse } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
 
-export const middleware = (req: NextRequest) => 
-  runWithServerContext({ trace_id: req.headers.get('x-trace-id') }, () => {
+export const proxy = (request: NextRequest, event: NextFetchEvent) =>
+  runWithServerContext(() => {
     // trace_id will be added to the log fields
     logger.info(...transformMiddlewareRequest(request));
 
     // trace_id will also be added to the log fields
-    log.info("Hello from middleware");
+    logger.info("Hello from proxy");
 
     event.waitUntil(logger.flush());
     return NextResponse.next();
-  });
+  }, { trace_id: request.headers.get("x-trace-id") });
 ```
 
 ## Use next-axiom library
@@ -707,6 +714,10 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
 export const config = {
 }
 ```
+
+<Note>
+Next.js 16 renamed middleware to proxy. If your app uses Next.js 16 or later, name the file `proxy.ts` and the exported function `proxy` instead. `middleware.ts` still works in Next.js 16, but it's deprecated.
+</Note>
 
 ### Web Vitals
 


### PR DESCRIPTION
## What

Next.js 16 renamed the middleware file convention to proxy: `middleware.ts` → `proxy.ts`, and the exported function `middleware` → `proxy`. The old names still work in Next.js 16 but are deprecated and will be removed in a future version (proxy also defaults to the Node.js runtime). See the [proxy file convention](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) and the [rename note](https://nextjs.org/docs/messages/middleware-to-proxy).

- Update the `@axiomhq/nextjs` **Capture traffic requests** example to `proxy.ts` / `export async function proxy`, with a `<Note>` for Next.js 15 and earlier.
- Update the server-context proxy example the same way. The legacy next-axiom section keeps `middleware.ts` as primary and gains a `<Note>` about the Next.js 16 rename.
- Fix the server-context examples to match the actual `runWithServerContext(callback, context)` signature — the docs passed the arguments in reverse order (see `packages/nextjs/src/context/storage.ts` in axiom-js: `runWithServerContext = (callback, store) => storage.run(store, callback)`). The proxy example also referenced `logger`, `transformMiddlewareRequest`, `NextResponse`, `log`, `event`, and `request` without importing or defining them; it now compiles as written.
- Fix a heading typo: "Sever context" → "Server context".
