### PR TITLE
docs(monitor): clarify .Value is 0 when a threshold monitor resolves on no data

### DIFF
--- a/monitor-data/custom-webhook-notifier.mdx
+++ b/monitor-data/custom-webhook-notifier.mdx
@@ -23,7 +23,7 @@ To create a custom webhook notifier, follow these steps:
     - `.QueryStartTime` is the start time applied in the monitor query that gave rise to the notification.
     - `.Timestamp` is the time the notification was generated.
     - `.Title` is the name of the monitor associated with the notification.
-    - `.Value` is the value that gave rise to the monitor triggering or resolving. It’s only applicable if the notification corresponds to a threshold monitor.
+    - `.Value` is the value that gave rise to the monitor triggering or resolving. It’s only applicable if the notification corresponds to a threshold monitor. When a threshold monitor resolves because its query stops returning data for a series (for example, a grouped series that goes idle or drops out), there’s no current value to report and `.Value` is `0`. A non-zero value on resolution appears only when the query still returns data and the value crosses back past the threshold.
     - `.MatchedEvent` is a JSON object that represents the event that matched the criteria of the monitor. It’s only applicable if the notification corresponds to a match monitor.
     - `.GroupKeys` and `.GroupValues` are JSON arrays that contain the keys and the values returned by the group-by attributes of your query. They’re only applicable if the APL query of the monitor groups by a non-time field.
     You can fully customize the content of the webhook to match the requirements of your environment.

--- a/monitor-data/custom-webhook-notifier.mdx
+++ b/monitor-data/custom-webhook-notifier.mdx
@@ -23,7 +23,7 @@ To create a custom webhook notifier, follow these steps:
     - `.QueryStartTime` is the start time applied in the monitor query that gave rise to the notification.
     - `.Timestamp` is the time the notification was generated.
     - `.Title` is the name of the monitor associated with the notification.
-    - `.Value` is the value that gave rise to the monitor triggering or resolving. It’s only applicable if the notification corresponds to a threshold monitor. When a threshold monitor resolves because its query stops returning data for a series (for example, a grouped series that goes idle or drops out), there’s no current value to report and `.Value` is `0`. A non-zero value on resolution appears only when the query still returns data and the value crosses back past the threshold.
+    - `.Value` is the value that gave rise to the monitor triggering or resolving. It’s only applicable if the notification corresponds to a threshold monitor. When a threshold monitor resolves because its query stops returning data for a series (for example, a grouped series that goes idle or drops out), there’s no current value to report and `.Value` is `0`.
     - `.MatchedEvent` is a JSON object that represents the event that matched the criteria of the monitor. It’s only applicable if the notification corresponds to a match monitor.
     - `.GroupKeys` and `.GroupValues` are JSON arrays that contain the keys and the values returned by the group-by attributes of your query. They’re only applicable if the APL query of the monitor groups by a non-time field.
     You can fully customize the content of the webhook to match the requirements of your environment.


### PR DESCRIPTION
## What

Clarifies the `.Value` template variable description on the **Custom webhook notifier** page (`monitor-data/custom-webhook-notifier.mdx`).

