### PR TITLE
Fix snippet MDX rendering and polish article chrome

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -6,6 +6,7 @@ import { ApiOperation } from '@/components/api-operation';
 import { mdxComponents } from '@/components/mdx-components';
 import { TableOfContents, type TocItem } from '@/components/table-of-contents';
 import { ArticleFooter } from '@/components/article-footer';
+import { CopyPageMenu } from '@/components/copy-page';
 import { ZoneLink as Link } from '@/components/zone-link';
 import { withoutDocsBasePath } from '@/lib/docs-paths';
 import { getAdjacentNavigation, getBreadcrumbs, getNavigation, getSection } from '@/lib/navigation';
@@ -29,6 +30,10 @@ export default async function DocumentationPage({ params }: PageProps) {
   const adjacentNavigation = getAdjacentNavigation(navigation, href);
   const breadcrumbs = getBreadcrumbs(navigation, href);
   if (breadcrumbs.length > 0) breadcrumbs[breadcrumbs.length - 1] = { title: page.data.title };
+  // Structured data keeps the full trail; the visible breadcrumb shows only the
+  // first two ancestor groups — never the page itself, whose title sits directly
+  // below — so deep sections can't produce long trails.
+  const visibleBreadcrumbs = breadcrumbs.slice(0, -1).slice(0, 2);
   const querySyntaxTitle = section === 'query' && slug?.at(-1) !== 'overview' && slug?.some((segment) => /(?:function|operator)s?$/.test(segment));
   const Body = page.data.body;
   const tocItems: TocItem[] = page.data.openapi
@@ -56,17 +61,20 @@ export default async function DocumentationPage({ params }: PageProps) {
       />
       <div className="article-layout">
         <article className={querySyntaxTitle ? 'doc-article query-syntax-article' : 'doc-article'}>
-          <nav className="doc-breadcrumbs" aria-label="Breadcrumb">
-            {breadcrumbs.map((item, index) => {
-              const current = index === breadcrumbs.length - 1;
-              return (
-                <span className="doc-breadcrumb" key={`${item.title}-${index}`}>
-                  {item.href && !current ? <Link href={item.href} prefetch={false}>{item.title}</Link> : <span aria-current={current ? 'page' : undefined}>{item.title}</span>}
-                  {!current && <b aria-hidden="true">/</b>}
-                </span>
-              );
-            })}
-          </nav>
+          <div className="doc-topline">
+            <nav className="doc-breadcrumbs" aria-label="Breadcrumb">
+              {visibleBreadcrumbs.map((item, index) => {
+                const last = index === visibleBreadcrumbs.length - 1;
+                return (
+                  <span className="doc-breadcrumb" key={`${item.title}-${index}`}>
+                    {item.href ? <Link href={item.href} prefetch={false}>{item.title}</Link> : <span>{item.title}</span>}
+                    {!last && <b aria-hidden="true">/</b>}
+                  </span>
+                );
+              })}
+            </nav>
+            {!page.data.openapi && <CopyPageMenu markdownPath={`${href}.md`} />}
+          </div>
           <DocsTitle className={querySyntaxTitle ? 'query-syntax-title' : undefined}>{page.data.title}</DocsTitle>
           <DocsDescription>{page.data.description}</DocsDescription>
           <DocsBody>

--- a/app/globals.css
+++ b/app/globals.css
@@ -260,13 +260,14 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 
 .article-layout { position: relative; min-height: calc(100vh - 56px); padding: 56px clamp(32px, 6vw, 96px) 96px; }
 .doc-article { width: min(720px, 100%); margin: 0 auto; transform: translateX(-130px); }
+.doc-topline { margin: 0 0 20px; display: flex; align-items: flex-start; justify-content: space-between; gap: 8px 16px; }
+.doc-topline .doc-breadcrumbs { margin: 0; }
 .doc-breadcrumbs { margin: 0 0 20px; display: flex; flex-wrap: wrap; gap: 4px 8px; color: var(--text-quaternary); font: 450 12px/16px var(--font-mono); }
 .doc-breadcrumb { display: inline-flex; gap: 8px; min-width: 0; }
 .doc-breadcrumbs a:hover { color: var(--text-secondary); }
 .doc-breadcrumbs b { color: var(--border-strong); font-weight: 400; }
 .doc-article > h1, .doc-article [data-docs-title] { margin: 0; color: var(--text-primary); font: 600 34px/42px var(--font-sans); letter-spacing: -.03em; text-wrap: balance; }
 .doc-article .query-syntax-title { font: 600 32px/40px var(--font-query) !important; font-variant-ligatures: none; letter-spacing: 0; }
-.query-syntax-article .doc-breadcrumbs span:last-child,
 .query-syntax-article .prose a:is([href*='/scalar-functions/'], [href*='/aggregation-functions/'], [href*='/operators/']) { font-family: var(--font-query); font-variant-ligatures: none; letter-spacing: 0; }
 .doc-article > p:first-of-type { max-width: 640px; margin: 6px 0 34px; color: var(--text-tertiary); font: 400 17px/27px var(--font-sans); letter-spacing: -.012em; text-wrap: pretty; }
 .doc-article .prose {
@@ -312,7 +313,20 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-notice-success { --notice-accent: var(--color-success); }
 .doc-notice > strong { display: block; margin-bottom: 5px; color: var(--text-primary); font-weight: 600; }
 .doc-notice :where(p, ul, ol) { margin: 0; }
-.doc-article .prose .doc-notice :where(p, ul, ol) + :where(p, ul, ol) { margin-top: 10px; }
+.doc-article .prose .doc-notice :where(p, ul, ol) + :where(p, ul, ol) { margin-top: 14px; }
+.copy-page { position: relative; margin-left: auto; display: flex; flex-shrink: 0; }
+.copy-page-main { height: 26px; padding: 0 9px; display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border-primary); border-radius: 3px 0 0 3px; color: var(--text-tertiary); background: var(--bg-surface); font: 500 11px/15px var(--font-sans); cursor: pointer; }
+.copy-page-main:hover { color: var(--text-primary); background: var(--bg-inert); }
+.copy-page-menu > summary { height: 26px; width: 22px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border-primary); border-left: 0; border-radius: 0 3px 3px 0; color: var(--text-quaternary); background: var(--bg-surface); cursor: pointer; list-style: none; }
+.copy-page-menu > summary::-webkit-details-marker { display: none; }
+.copy-page-menu > summary:hover, .copy-page-menu[open] > summary { color: var(--text-primary); background: var(--bg-inert); }
+.copy-page-menu:not([open]) > .copy-page-popover { display: none; }
+.copy-page-popover { position: absolute; top: 30px; right: 0; z-index: 70; width: 212px; padding: 4px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-overlay); box-shadow: 0 8px 28px rgba(0,0,0,.28); }
+.copy-page-popover button, .copy-page-popover a { width: 100%; height: 30px; padding: 0 8px; display: flex; align-items: center; gap: 8px; border: 0; border-radius: 3px; color: var(--text-tertiary); background: transparent; font: 500 12px/16px var(--font-sans); text-decoration: none; cursor: pointer; }
+.copy-page-popover button:hover, .copy-page-popover a:hover { color: var(--text-primary); background: var(--bg-emph-tertiary); }
+.copy-page-popover svg { flex-shrink: 0; }
+.copy-page-popover hr { margin: 4px 0; border: 0; border-top: 1px solid var(--border-primary); }
+@media (max-width: 640px) { .copy-page { display: none; } }
 .anchor-heading { scroll-margin-top: 88px; }
 .anchor-heading > a { display: inline-flex; align-items: baseline; gap: .35em; text-decoration: none !important; }
 .anchor-hash { color: var(--text-quaternary); font-family: var(--font-mono); font-size: .72em; font-weight: 500; opacity: 0; transform: translateX(-3px); transition: opacity .15s ease, transform .15s ease; }
@@ -323,6 +337,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article .prose a:focus-visible { border-radius: 2px; outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .doc-article .prose :not(pre) > code { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 4px; background: var(--bg-inert); font-family: var(--font-mono); font-size: .84em; }
 .doc-article figure[data-rehype-pretty-code-figure], .doc-article figure.shiki, .doc-article .fd-codeblock { border-color: var(--border-primary); border-radius: 4px !important; background: var(--bg-surface); box-shadow: none !important; }
+.doc-article figure:has(+ .placeholder-config) { border-bottom-left-radius: 0 !important; border-bottom-right-radius: 0 !important; }
 .accordion-group { width: 100%; margin: 12px 0; }
 .accordion-group > div { width: 100%; margin: 0 !important; overflow: hidden; border: 1px solid var(--border-primary) !important; border-radius: 4px !important; background: var(--bg-surface); }
 .accordion-group h3 { margin: 0 !important; }
@@ -378,15 +393,17 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .axiom-toast-title { font-size: 12px !important; font-weight: 600 !important; }
 .axiom-toast-description { color: var(--text-tertiary) !important; font-size: 11px !important; }
 .article-footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border-primary); color: var(--text-quaternary); font: 450 12px/16px var(--font-mono); }
-.page-feedback { min-height: 32px; display: flex; align-items: center; gap: 10px; color: var(--text-tertiary); }
+.article-footer-meta { margin-top: 18px; display: flex; align-items: center; justify-content: space-between; gap: 8px 24px; flex-wrap: wrap; }
+.page-feedback { display: flex; align-items: center; gap: 12px; color: var(--text-tertiary); }
 .page-feedback > span:first-child { color: var(--text-secondary); font-weight: 550; }
-.page-feedback-actions { display: flex; gap: 6px; }
-.page-feedback-actions button { min-height: 28px; padding: 0 9px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--border-primary); border-radius: 3px; color: var(--text-tertiary); background: var(--bg-surface); font: inherit; cursor: pointer; }
-.page-feedback-actions button:hover:not(:disabled) { border-color: var(--border-strong); color: var(--text-primary); background: var(--bg-raised); }
-.page-feedback-actions button[aria-pressed='true'] { border-color: var(--color-accent); color: var(--text-primary); background: color-mix(in srgb, var(--color-accent) 10%, var(--bg-surface)); }
+.page-feedback-actions { display: flex; gap: 14px; }
+.page-feedback-actions button { padding: 0; border: 0; color: var(--text-tertiary); background: transparent; font: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: var(--border-strong); text-underline-offset: 3px; }
+.page-feedback-actions button:hover:not(:disabled) { color: var(--text-primary); text-decoration-color: var(--color-accent); }
+.page-feedback-actions button[aria-pressed='true'] { color: var(--text-primary); text-decoration-color: var(--color-accent); }
 .page-feedback-actions button:disabled { cursor: default; }
+.page-feedback-actions button:disabled[aria-pressed='false'] { color: var(--text-quaternary); text-decoration: none; }
 .page-feedback-thanks { color: var(--text-quaternary); }
-.article-pagination { margin-top: 28px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.article-pagination { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 .article-pagination a { min-height: 76px; padding: 13px 14px; display: flex; align-items: center; gap: 11px; border: 1px solid var(--border-primary); border-radius: 4px; color: var(--text-tertiary); background: var(--bg-surface); text-decoration: none; transition: border-color .15s ease, background .15s ease, color .15s ease; }
 .article-pagination a:hover { border-color: var(--border-strong); color: var(--text-primary); background: var(--bg-raised); }
 .article-pagination a > span { min-width: 0; display: flex; flex: 1; flex-direction: column; gap: 3px; }
@@ -394,7 +411,6 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .article-pagination strong { overflow: hidden; color: var(--text-secondary); font: 550 13px/18px var(--font-sans); text-overflow: ellipsis; white-space: nowrap; }
 .article-pagination a:hover strong { color: var(--text-primary); }
 .article-next { grid-column: 2; text-align: right; }
-.article-footer-links { margin-top: 18px; }
 .article-footer-links a { color: var(--text-quaternary); text-decoration: none; }
 .article-footer-links a:hover { color: var(--text-secondary); text-decoration: underline; text-underline-offset: 3px; }
 .doc-frame { margin: 24px 0; padding: 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-surface); }
@@ -513,7 +529,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .status-dot.error { background: var(--red-400); }
 .axiom-placeholder-highlight { color: var(--blue-500); }
 .dark .axiom-placeholder-highlight { color: #60a5fa; }
-.placeholder-config { margin: -12px 0 24px; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; border: 1px solid var(--border-primary); border-top: 0; border-radius: 0 0 4px 4px; background: var(--bg-surface); }
+.placeholder-config { margin: 0 0 24px; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; border: 1px solid var(--border-primary); border-top: 0; border-radius: 0 0 4px 4px; background: var(--bg-surface); }
 .placeholder-config label { display: grid; grid-template-columns: 110px 1fr; align-items: center; gap: 12px; color: var(--text-tertiary); font: 500 12px/16px var(--font-sans); }
 .placeholder-config input, .placeholder-config select { min-width: 0; height: 32px; padding: 0 10px; border: 1px solid var(--border-primary); border-radius: 4px; outline: none; color: var(--text-secondary); background: var(--bg-canvas); font: 400 12px/16px var(--font-mono); }
 .placeholder-config input:focus, .placeholder-config select:focus { border-color: var(--blue-500); box-shadow: 0 0 0 2px rgba(59,130,246,.15); }

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -3,8 +3,8 @@ import { source } from '@/lib/source';
 export const dynamic = 'force-static';
 
 export async function GET() {
-  const pages = source.getPages().filter((page) => !page.data.noindex);
-  const content = await Promise.all(pages.map(async (page) => `\n\n---\n\n# ${page.data.title}\n\nSource: ${page.url}\n\n${await page.data.getText('processed')}`));
+  const pages = source.getPages().filter((page) => !page.data.noindex && !page.data.url);
+  const content = await Promise.all(pages.map(async (page) => `\n\n---\n\n# ${page.data.title}\n\nSource: https://axiom.co${page.url}\n\n${await page.data.getText('processed')}`));
   return new Response(`# Axiom documentation\n${content.join('')}`, {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   });

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,11 +1,59 @@
-import { llms } from 'fumadocs-core/source';
+import { getNavigation, type NavigationItem } from '@/lib/navigation';
 import { source } from '@/lib/source';
 
 export const dynamic = 'force-static';
 
+// Links must be absolute: llms.txt consumers fetch this file once and resolve
+// nothing, and the .md suffix hands them clean Markdown instead of the HTML shell.
+const ORIGIN = 'https://axiom.co';
+
+const SECTIONS = [
+  { title: 'Documentation', section: 'documentation' },
+  { title: 'Query reference', section: 'query' },
+  { title: 'API reference', section: 'api' },
+  { title: 'Changelog', section: 'changelog' },
+] as const;
+
+function flattenHrefs(items: NavigationItem[]): string[] {
+  return items.flatMap((item) => (item.href ? [item.href] : flattenHrefs(item.children ?? [])));
+}
+
+function entryLine(page: { url: string; data: { title: string; description?: string } }) {
+  return `- [${page.data.title}](${ORIGIN}${page.url}.md)${page.data.description ? `: ${page.data.description}` : ''}`;
+}
+
 export function GET() {
-  const index = llms(source).index();
-  return new Response(`${index}\n\n## Complete corpus\n\n- [All documentation in one file](/docs/llms-full.txt)\n`, {
+  // Link-out stubs (`url` frontmatter) redirect rather than render, and noindex
+  // pages are excluded from every AI-readable surface.
+  const pages = new Map(
+    source.getPages().filter((page) => !page.data.noindex && !page.data.url).map((page) => [page.url, page]),
+  );
+  const seen = new Set<string>();
+
+  const lines = [
+    '# Axiom documentation',
+    '',
+    '> Axiom is a data platform for ingesting, storing, and querying logs, traces, and other event data. This documentation covers the Axiom Console, sending data, the Axiom Processing Language (APL), and the REST API.',
+    '',
+    `Every page below is served as plain Markdown at the linked \`.md\` URL. The entire corpus in one file: [llms-full.txt](${ORIGIN}/docs/llms-full.txt). A standalone APL language reference: [llms-apl.md](${ORIGIN}/docs/llms-apl.md).`,
+  ];
+
+  for (const { title, section } of SECTIONS) {
+    const entries = getNavigation(section)
+      .flatMap((group) => flattenHrefs(group.items))
+      .filter((href) => pages.has(href) && !seen.has(href))
+      .map((href) => {
+        seen.add(href);
+        return entryLine(pages.get(href)!);
+      });
+    if (entries.length > 0) lines.push('', `## ${title}`, '', ...entries);
+  }
+
+  // Routable pages missing from the docs.json navigation still belong in the index.
+  const unlisted = [...pages.values()].filter((page) => !seen.has(page.url)).map(entryLine);
+  if (unlisted.length > 0) lines.push('', '## Other pages', '', ...unlisted);
+
+  return new Response(`${lines.join('\n')}\n`, {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   });
 }

--- a/components/article-footer.tsx
+++ b/components/article-footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ZoneLink as Link } from '@/components/zone-link';
-import { ArrowLeft, ArrowRight, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { useState } from 'react';
 import { captureDocsEvent } from '@/lib/docs-analytics';
 import type { AdjacentNavigationItem } from '@/lib/navigation';
@@ -35,19 +35,6 @@ export function ArticleFooter({
 
   return (
     <footer className="article-footer">
-      <div className="page-feedback">
-        <span>Was this page helpful?</span>
-        <div className="page-feedback-actions">
-          <button type="button" aria-label="Yes, this page was helpful" aria-pressed={feedback === 'yes'} disabled={feedback !== null} onClick={() => submitFeedback('yes')}>
-            <ThumbsUp size={13} aria-hidden="true" /> Yes
-          </button>
-          <button type="button" aria-label="No, this page was not helpful" aria-pressed={feedback === 'no'} disabled={feedback !== null} onClick={() => submitFeedback('no')}>
-            <ThumbsDown size={13} aria-hidden="true" /> No
-          </button>
-        </div>
-        {feedback && <span className="page-feedback-thanks" role="status">Thanks for the feedback.</span>}
-      </div>
-
       {(previous || next) && (
         <nav className="article-pagination" aria-label="Adjacent documentation pages">
           {previous && (
@@ -65,15 +52,25 @@ export function ArticleFooter({
         </nav>
       )}
 
-      <div className="article-footer-links">
-        <a
-          href={editHref}
-          target="_blank"
-          rel="noreferrer"
-          onClick={() => captureDocsEvent('docs_edit_opened', { page_path: pageHref })}
-        >
-          Suggest edits on GitHub
-        </a>
+      <div className="article-footer-meta">
+        <div className="page-feedback">
+          <span>Was this page helpful?</span>
+          <div className="page-feedback-actions">
+            <button type="button" aria-label="Yes, this page was helpful" aria-pressed={feedback === 'yes'} disabled={feedback !== null} onClick={() => submitFeedback('yes')}>Yes</button>
+            <button type="button" aria-label="No, this page was not helpful" aria-pressed={feedback === 'no'} disabled={feedback !== null} onClick={() => submitFeedback('no')}>No</button>
+          </div>
+          {feedback && <span className="page-feedback-thanks" role="status">Thanks for the feedback.</span>}
+        </div>
+        <div className="article-footer-links">
+          <a
+            href={editHref}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => captureDocsEvent('docs_edit_opened', { page_path: pageHref })}
+          >
+            Suggest edits on GitHub
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/components/copy-page.tsx
+++ b/components/copy-page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Check, ChevronDown, Copy, ExternalLink, FileText } from 'lucide-react';
+import { toast } from 'sonner';
+import { captureDocsEvent } from '@/lib/docs-analytics';
+
+// Assistant links must reference the production origin: a preview or localhost
+// URL is unreachable from the assistant's fetcher.
+const SITE_ORIGIN = 'https://axiom.co';
+
+export function CopyPageMenu({ markdownPath }: { markdownPath: string }) {
+  const menu = useRef<HTMLDetailsElement>(null);
+  const resetTimer = useRef<number | undefined>(undefined);
+  const [copied, setCopied] = useState(false);
+
+  const markdownUrl = `${SITE_ORIGIN}${markdownPath}`;
+  const assistantPrompt = encodeURIComponent(`Read ${markdownUrl} so I can ask questions about it.`);
+
+  async function copyPage() {
+    menu.current?.removeAttribute('open');
+    try {
+      const response = await fetch(markdownPath);
+      if (!response.ok) throw new Error(`${response.status}`);
+      await navigator.clipboard.writeText(await response.text());
+      setCopied(true);
+      window.clearTimeout(resetTimer.current);
+      resetTimer.current = window.setTimeout(() => setCopied(false), 2000);
+      captureDocsEvent('docs_page_context_action', { action: 'copy_markdown' });
+    } catch {
+      toast.error('Couldn’t copy page');
+    }
+  }
+
+  function chooseAction(action: 'view_markdown' | 'open_chatgpt' | 'open_claude' | 'open_perplexity') {
+    menu.current?.removeAttribute('open');
+    captureDocsEvent('docs_page_context_action', { action });
+  }
+
+  return (
+    <div className="copy-page">
+      <button type="button" className="copy-page-main" onClick={copyPage}>
+        {copied ? <Check size={13} /> : <Copy size={13} />}
+        <span>{copied ? 'Copied' : 'Copy page'}</span>
+      </button>
+      <details className="copy-page-menu" ref={menu}>
+        <summary role="button" aria-haspopup="menu" aria-label="More page actions"><ChevronDown size={13} /></summary>
+        <div className="copy-page-popover" role="menu" aria-label="Page actions">
+          <button type="button" role="menuitem" onClick={copyPage}><Copy size={13} /><span>Copy page as Markdown</span></button>
+          <a role="menuitem" href={markdownPath} target="_blank" rel="noreferrer" onClick={() => chooseAction('view_markdown')}><FileText size={13} /><span>View as Markdown</span></a>
+          <hr />
+          <a role="menuitem" href={`https://chatgpt.com/?hints=search&q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_chatgpt')}><ExternalLink size={13} /><span>Open in ChatGPT</span></a>
+          <a role="menuitem" href={`https://claude.ai/new?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_claude')}><ExternalLink size={13} /><span>Open in Claude</span></a>
+          <a role="menuitem" href={`https://www.perplexity.ai/search?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_perplexity')}><ExternalLink size={13} /><span>Open in Perplexity</span></a>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/lib/docs-analytics.ts
+++ b/lib/docs-analytics.ts
@@ -56,6 +56,9 @@ type DocsAnalyticsEvents = {
     language?: string;
   };
   docs_example_customized: { field_name: ExampleField };
+  docs_page_context_action: {
+    action: 'copy_markdown' | 'view_markdown' | 'open_chatgpt' | 'open_claude' | 'open_perplexity';
+  };
   docs_playground_opened: Record<string, never>;
   docs_console_opened: { placement: 'header' };
   docs_edit_opened: { page_path: string };

--- a/source.config.ts
+++ b/source.config.ts
@@ -22,4 +22,11 @@ export const docs = defineDocs({
   },
 });
 
-export default defineConfig();
+export default defineConfig({
+  mdxOptions: {
+    // Imported snippet MDX compiles as standalone modules that never receive the
+    // components prop page.tsx passes, so they need the provider to pick up the
+    // shared pre/notice/link mappings from mdx-components.tsx.
+    providerImportSource: '@/mdx-components',
+  },
+});

--- a/tests/e2e/docs.spec.ts
+++ b/tests/e2e/docs.spec.ts
@@ -229,8 +229,8 @@ test('table links and notice blocks retain clear affordance and rhythm', async (
 
   const noticeParagraphs = page.locator('.doc-notice').first().locator('p');
   await expect(noticeParagraphs).toHaveCount(3);
-  await expect(noticeParagraphs.nth(1)).toHaveCSS('margin-top', '10px');
-  await expect(noticeParagraphs.nth(2)).toHaveCSS('margin-top', '10px');
+  await expect(noticeParagraphs.nth(1)).toHaveCSS('margin-top', '14px');
+  await expect(noticeParagraphs.nth(2)).toHaveCSS('margin-top', '14px');
 });
 
 test('analytics is silent without a PostHog project token', async ({ page }) => {
@@ -440,13 +440,27 @@ test('article hierarchy and footer navigation follow the compact docs pattern', 
   await expect(page.getByRole('link', { name: 'Suggest edits on GitHub' })).toBeVisible();
 });
 
-test('deep documentation pages show their complete navigation ancestry', async ({ page }) => {
+test('deep documentation pages cap the breadcrumb at the first two ancestors', async ({ page }) => {
   await page.goto('/docs/dashboard-elements/pie-chart');
 
   const breadcrumbs = page.getByRole('navigation', { name: 'Breadcrumb' });
-  await expect(breadcrumbs).toHaveText(/Understand data\s*\/\s*Console\s*\/\s*Dashboard\s*\/\s*Elements\s*\/\s*Element types\s*\/\s*Pie chart/);
-  await expect(breadcrumbs.getByRole('link', { name: 'Dashboard', exact: true })).toHaveAttribute('href', '/docs/dashboards/create');
-  await expect(breadcrumbs.getByText('Pie chart', { exact: true })).toHaveAttribute('aria-current', 'page');
+  await expect(breadcrumbs).toHaveText(/^\s*Understand data\s*\/\s*Console\s*$/);
+  await expect(breadcrumbs.getByText('Pie chart')).toHaveCount(0);
+  await expect(breadcrumbs.getByRole('link')).toHaveCount(2);
+});
+
+test('the copy page menu offers the Markdown surface and assistant links', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/docs/dashboard-elements/pie-chart');
+
+  await page.locator('.copy-page-menu summary').click();
+  await expect(page.getByRole('menuitem', { name: 'View as Markdown' })).toHaveAttribute('href', '/docs/dashboard-elements/pie-chart.md');
+  await expect(page.getByRole('menuitem', { name: 'Open in ChatGPT' })).toHaveAttribute('href', /chatgpt\.com.*axiom\.co%2Fdocs%2Fdashboard-elements%2Fpie-chart\.md/);
+
+  await page.getByRole('button', { name: 'Copy page', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Copied' })).toBeVisible();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain('# Pie chart');
 });
 
 test('placeholder forms update and copy every matching code example', async ({ page, context }) => {


### PR DESCRIPTION
## Summary

Fixes a rendering root cause plus a batch of article-chrome polish that came out of reviewing the skills pages.

### Snippet MDX rendering (root cause)
Snippets imported into pages (`content/snippets/*.mdx`) compiled as standalone MDX modules and never received the shared component mapping from `mdx-components.tsx`. Their code fences rendered as bare `<pre>` elements picking up per-line inline-code chrome (each line looked like its own tiny code block), and their markdown links were missing the `/docs` base path — silently broken on every page using a snippet. Setting `providerImportSource` in `source.config.ts` fixes all snippets at once; they now get the full CodeBlock treatment (highlighting, copy control, placeholder inputs) and correct links.

### Callout + placeholder panel spacing
- Notice paragraphs get 14px separation (was 10px) so multi-paragraph callouts read as distinct paragraphs on the 12px/19px mono grid.
- The "customize this example" panel had a `-12px` top margin tuned for the old rendering; it overlapped the code block and swallowed its own top padding. It now sits flush with full padding, and the code block squares its bottom corners where the panel attaches.

### Copy page menu
Split control on the breadcrumb row (parity with the Mintlify contextual menu): **Copy page** copies the page's `.md` to the clipboard; the dropdown offers copy, **View as Markdown**, and **Open in ChatGPT / Claude / Perplexity** with a read-this-URL prompt. Hidden on OpenAPI endpoint pages (their `.md` carries no content) and below 640px. Actions emit a typed `docs_page_context_action` PostHog event (path-only properties).

### llms.txt overhaul
Previous output was the fumadocs default: generic heading, relative URLs without `.md` — unresolvable by any consumer that fetched it. Now: proper llms.txt shape (title, `>` summary, pointers to `llms-full.txt`/`llms-apl.md`), absolute `https://axiom.co/docs/….md` links with frontmatter descriptions, grouped Documentation / Query reference / API reference / Changelog in sidebar order, plus an "Other pages" section for routable pages missing from the nav. Noindex pages and Mintlify link-out stubs are excluded; `llms-full.txt` gets absolute `Source:` URLs and the same stub exclusion.

### Breadcrumbs
Visible trail caps at the **first two ancestor groups** and never includes the page title (Mintlify behavior) — deep sections no longer produce four-crumb rows. JSON-LD `BreadcrumbList` keeps the full trail for SEO.

### Article footer
Previous/next cards come first; beneath them, "Was this page helpful? Yes / No" and "Suggest edits on GitHub" share one space-between row. Yes/no are underlined text links (accent underline on hover/selection) instead of bordered buttons.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` (35), `pnpm audit:content`, `pnpm build`
- [x] Full Playwright suite: 36/36 passing (breadcrumb + notice-spacing tests updated to the new contracts; new e2e covers the copy-page menu including clipboard content)
- [x] Visual pass on skills/SRE, introduction, APL `strlen`, and `getDatasets` in light + dark, desktop + 390px