### PR TITLE
Prefetch routes on link hover intent

### DIFF
--- a/components/zone-link.tsx
+++ b/components/zone-link.tsx
@@ -1,8 +1,33 @@
+'use client';
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useRef } from 'react';
 import type { ComponentProps } from 'react';
 import { withoutDocsBasePath } from '@/lib/docs-paths';
 
-export function ZoneLink({ href, ...props }: ComponentProps<typeof Link>) {
+// Viewport prefetch stays off everywhere (prefetch={false} at call sites): the
+// sidebar alone holds hundreds of links and would flood the network. Instead the
+// first hover/focus/touch on a link primes its route, so the payload is cached
+// by the time the click lands and navigation renders without a visible wait.
+export function ZoneLink({ href, onPointerEnter, onFocus, onTouchStart, ...props }: ComponentProps<typeof Link>) {
+  const router = useRouter();
+  const primed = useRef(false);
   const target = typeof href === 'string' ? withoutDocsBasePath(href) : href;
-  return <Link href={target} {...props} />;
+
+  function prime() {
+    if (primed.current || props.prefetch === true) return;
+    primed.current = true;
+    if (typeof target === 'string' && target.startsWith('/')) router.prefetch(target);
+  }
+
+  return (
+    <Link
+      href={target}
+      onPointerEnter={(event) => { prime(); onPointerEnter?.(event); }}
+      onFocus={(event) => { prime(); onFocus?.(event); }}
+      onTouchStart={(event) => { prime(); onTouchStart?.(event); }}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Follow-up to #685. On the built site, clicking any link took a visible beat (~1s depending on network) before the page rendered.

Every link sets `prefetch={false}` — deliberate, since viewport-prefetching the sidebar's hundreds of links would flood the network — but in the App Router that disables prefetching entirely, so each click paid a full RSC round trip (which also carries the serialized sidebar tree) before anything rendered.

All links already flow through `ZoneLink`, so this upgrades that one component to prime its route once on first `pointerenter`/`focus`/`touchstart` via `router.prefetch`. The fetch happens during the natural hover-before-click window, and the click renders from cache. Call sites keep `prefetch={false}`, so page load still issues zero prefetch requests.

Measured against the production standalone build:
- 0 RSC prefetch requests on page load (no sidebar flood)
- Hovering a sidebar link immediately fires its route's RSC prefetch
- Click-to-render after hover: ~50ms

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, production build
- [x] Playwright suite green against the dev server (the API "Try it" test 503s against a bare standalone server with no Upstash credentials — environmental, unrelated)
- [x] Network-level verification of prefetch behavior on the standalone build (counts and timings above)