### PR TITLE
Move DocsShell into the root layout

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/page';
-import { DocsShell } from '@/components/docs-shell';
 import { ApiOperation } from '@/components/api-operation';
 import { mdxComponents } from '@/components/mdx-components';
 import { TableOfContents, type TocItem } from '@/components/table-of-contents';
@@ -46,7 +45,7 @@ export default async function DocumentationPage({ params }: PageProps) {
     : page.data.toc.map((item) => ({ title: item.title, url: item.url, depth: item.depth }));
 
   return (
-    <DocsShell navigation={navigation} activeHref={href}>
+    <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={structuredDataProps(
@@ -90,7 +89,7 @@ export default async function DocumentationPage({ params }: PageProps) {
         </article>
         {tocItems.length > 0 && <TableOfContents items={tocItems} />}
       </div>
-    </DocsShell>
+    </>
   );
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import { RootProvider } from 'fumadocs-ui/provider/next';
+import { DocsShell } from '@/components/docs-shell';
 import { DocsToaster } from '@/components/docs-toaster';
 import { DocsSearchProvider } from '@/components/docs-search-provider';
+import { getNavigation } from '@/lib/navigation';
 import { siteGraph, structuredDataProps } from '@/lib/structured-data';
 import './globals.css';
 
@@ -40,7 +42,18 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           search={{ enabled: false }}
         >
           <DocsSearchProvider>
-            {children}
+            {/* The shell renders here — in a segment with no params — so client
+                navigation reuses it and page payloads carry only the article. */}
+            <DocsShell
+              navigations={{
+                documentation: getNavigation('documentation'),
+                query: getNavigation('query'),
+                api: getNavigation('api'),
+                changelog: getNavigation('changelog'),
+              }}
+            >
+              {children}
+            </DocsShell>
             <DocsToaster />
           </DocsSearchProvider>
         </RootProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
-import { DocsShell } from '@/components/docs-shell';
 import { AskAiPrompt, SearchPrompt } from '@/components/search-prompt';
 import { ZoneLink as Link } from '@/components/zone-link';
-import { getNavigation } from '@/lib/navigation';
 import { ogImage } from '@/lib/og';
 
 const quickCards = [
@@ -40,26 +38,24 @@ export const metadata: Metadata = {
 
 export default function DocsLandingPage() {
   return (
-    <DocsShell navigation={getNavigation('documentation')} activeHref="/docs" landing>
-      <div className="landing-content">
-        <section className="landing-hero">
-          <h1>From first event to petabyte scale.</h1>
-          <p>Send, store, and query logs, traces, metrics, and events. From first ingest to petabyte scale.</p>
-          <SearchPrompt />
-        </section>
-        <section className="quick-grid" aria-label="Popular starting points">
-          {quickCards.map((card) => <Link href={card.href} prefetch={false} className="quick-card" key={card.title}><strong>{card.title}</strong><span>{card.description}</span><small>{card.action}</small></Link>)}
-        </section>
-        <section className="landing-section">
-          <div className="section-heading"><h2>Send data</h2><span /><Link href="/docs/apps/introduction" prefetch={false}>All integrations →</Link></div>
-          <div className="integration-list">{integrations.map(([label, href]) => <Link href={href} prefetch={false} key={label}>{label}</Link>)}</div>
-        </section>
-        <section className="landing-section platform-index">
-          <div className="section-heading"><h2>Explore the platform</h2><span /></div>
-          {platformRows.map(([title, description, href]) => <Link href={href} prefetch={false} key={title}><strong>{title}</strong><span>{description}</span><b>→</b></Link>)}
-        </section>
-        <footer className="landing-footer"><span>Can’t find it?</span><AskAiPrompt /><a href="https://discord.gg/axiomco">Discord</a><a href="https://axiom.co/contact">Support</a><small>axiom.co/docs</small></footer>
-      </div>
-    </DocsShell>
+    <div className="landing-content">
+      <section className="landing-hero">
+        <h1>From first event to petabyte scale.</h1>
+        <p>Send, store, and query logs, traces, metrics, and events. From first ingest to petabyte scale.</p>
+        <SearchPrompt />
+      </section>
+      <section className="quick-grid" aria-label="Popular starting points">
+        {quickCards.map((card) => <Link href={card.href} prefetch={false} className="quick-card" key={card.title}><strong>{card.title}</strong><span>{card.description}</span><small>{card.action}</small></Link>)}
+      </section>
+      <section className="landing-section">
+        <div className="section-heading"><h2>Send data</h2><span /><Link href="/docs/apps/introduction" prefetch={false}>All integrations →</Link></div>
+        <div className="integration-list">{integrations.map(([label, href]) => <Link href={href} prefetch={false} key={label}>{label}</Link>)}</div>
+      </section>
+      <section className="landing-section platform-index">
+        <div className="section-heading"><h2>Explore the platform</h2><span /></div>
+        {platformRows.map(([title, description, href]) => <Link href={href} prefetch={false} key={title}><strong>{title}</strong><span>{description}</span><b>→</b></Link>)}
+      </section>
+      <footer className="landing-footer"><span>Can’t find it?</span><AskAiPrompt /><a href="https://discord.gg/axiomco">Discord</a><a href="https://axiom.co/contact">Support</a><small>axiom.co/docs</small></footer>
+    </div>
   );
 }

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -2,9 +2,22 @@
 
 import { ZoneLink as Link } from '@/components/zone-link';
 import { ChevronRight } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import { withDocsBasePath } from '@/lib/docs-paths';
 import type { NavigationGroup, NavigationItem } from '@/lib/navigation';
 import { DocumentationSections, SiteHeader } from './site-header';
+
+type Section = 'documentation' | 'query' | 'api' | 'changelog';
+
+// Mirrors lib/navigation's getSection rather than importing it: that module
+// pulls docs.json and the fumadocs source into any bundle that imports it.
+function sectionOf(pathname: string): Section {
+  if (pathname === '/docs/changelog' || pathname.startsWith('/docs/changelog/')) return 'changelog';
+  if (pathname.startsWith('/docs/apl/') || pathname.startsWith('/docs/mpl/')) return 'query';
+  if (pathname.startsWith('/docs/restapi/')) return 'api';
+  return 'documentation';
+}
 
 function containsActive(item: NavigationItem, activeHref: string): boolean {
   if (item.href === activeHref) return true;
@@ -34,7 +47,14 @@ function NavItem({ item, activeHref, onNavigate, depth = 0 }: { item: Navigation
   );
 }
 
-export function DocsShell({ navigation, activeHref, children, landing = false }: { navigation: NavigationGroup[]; activeHref: string; children: React.ReactNode; landing?: boolean }) {
+export function DocsShell({ navigations, children }: { navigations: Record<Section, NavigationGroup[]>; children: React.ReactNode }) {
+  // The shell lives in the root layout so navigation payloads exclude it; the
+  // active page and sidebar section are derived from the pathname instead of
+  // per-page props. usePathname reports app-relative paths (no /docs basePath).
+  const pathname = usePathname();
+  const landing = pathname === '/';
+  const activeHref = landing ? '/docs' : withDocsBasePath(pathname);
+  const navigation = navigations[sectionOf(activeHref)];
   const [drawerOpen, setDrawerOpen] = useState(false);
   const drawerRef = useRef<HTMLElement>(null);
 


### PR DESCRIPTION
## Summary

Follow-up to #686, the structural half of making navigation feel instant.

Each page rendered `DocsShell` (header + full sidebar tree) itself, so every client navigation refetched and re-rendered ~40KB of navigation JSON alongside the article — even a prefetch-primed click still paid that parse and re-render. The shell now lives in the root layout, a segment with no params, so the router's segment cache fetches it once per session and page payloads carry only the article.

- `DocsShell` derives the active section, active link, and landing treatment from `usePathname` instead of per-page props. All four section navigations ship once with the layout.
- Section detection is mirrored locally in the shell rather than imported: `lib/navigation` pulls `docs.json` and the fumadocs source into any bundle that imports it.
- A side benefit: the sidebar no longer remounts on navigation, so its scroll position and manually-expanded groups persist.

## Measurements (production standalone builds, per-request RSC accounting)

Before (main): every navigation re-shipped the shell inside the page segment — **68–112KB per click**.

After: the layout segment (~53KB, all four navs) is fetched **once** on the first prefetch and then served from the client segment cache; subsequent navigations fetch only the article segment plus ~4KB of tree/head metadata:

```
hover Quickstart:   _tree=654B  _head=3009B  _index=53004B  page=40824B   ← one-time layout fetch
hover Architecture: _tree=669B  _head=2873B               page=19604B
hover Features:     _tree=665B  _head=2942B               page=34035B
```

Clicks after a hover-prefetch issue zero requests. Initial-load HTML grows ~54KB uncompressed (the four navs render once in the layout); that is a one-time cost that compresses well and is repaid on the first click.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, production build
- [x] Full Playwright suite 36/36 (desktop + mobile)
- [x] Manual verification on the production build: active-link tracking, cross-section sidebar switching (Documentation → Query reference → API reference), landing-page treatment, mobile drawer