### PR TITLE
Redirect the deployment root to /docs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,13 @@ const config = {
   },
   async redirects() {
     const { redirects } = await import('./lib/redirects.mjs');
-    return redirects;
+    return [
+      // The app lives entirely under basePath /docs, so the deployment root
+      // would otherwise 404 — which Vercel's checks read as a broken site.
+      // basePath: false keeps the source at the bare origin root.
+      { source: '/', destination: '/docs', basePath: false, permanent: false },
+      ...redirects,
+    ];
   },
   async rewrites() {
     return [{ source: '/:path*.md', destination: '/api/md/:path*' }];


### PR DESCRIPTION
## Summary

The app lives entirely under `basePath: '/docs'`, so hitting the deployment root `/` returned a 404 — which Vercel's deployment checks read as a broken site. This adds a `307` from `/` to `/docs` (`basePath: false` keeps the redirect source at the bare origin root, since redirect sources are otherwise auto-prefixed with the basePath).

## Test plan

- [x] `curl -I /` → `307` with `location: /docs`, following it lands on the docs landing page with `200`
- [x] Existing content redirects from `lib/redirects.mjs` unaffected
- [x] `pnpm lint`, `pnpm typecheck`