### PR TITLE
Fix duplicate title in Quickstart callout

### DIFF
--- a/content/docs/(documentation)/getting-started.mdx
+++ b/content/docs/(documentation)/getting-started.mdx
@@ -19,7 +19,6 @@ Axiom is the modern machine data platform. Machine data is any record a system p
 **Fields** are named pieces of data on each record, like columns in a spreadsheet. Fields have a name (for example, `status`, `resp_body_size_bytes`, `geo.city`) and a value. Axiom supports various data types including strings, numbers, booleans, and complex JSON objects.
 
 <Tip title="When to split a dataset">
-When to split a dataset:
 - **Single dataset:** Use one dataset when events share many common fields and you often query them together.
 - **Multiple datasets:** Split into multiple datasets when the data is structurally different or serves entirely different use cases. This prevents a single dataset from accumulating fields that are only relevant to a small subset of its events.
 </Tip>


### PR DESCRIPTION
## What

The **"When to split a dataset"** `<Tip>` callout on `/docs/getting-started` (Quickstart) rendered its title twice — once as the callout's bold heading (from the `title` prop) and again as the first body line.

## Fix

Removed the redundant `When to split a dataset:` first line from the callout body, leaving the `title` prop as the sole heading.

## Verification

Scanned every callout (`Info`/`Note`/`Tip`/`Warning`/`CallOut`) across all MDX docs — this was the only one repeating its title in the body.