### PR TITLE
Improve docs readability: contrast, type scale, copy-page menu

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -252,8 +252,8 @@ The system is flat by default. Canvas, surface, raised, and overlay tones establ
 
 ### Navigation
 
-- **Style:** The fixed 56px header, 260px desktop sidebar, and floating table of contents form one hierarchy. Header tabs and sidebar items are 14px sans; TOC links are 13px sans; sidebar group headers and breadcrumbs use monospace technical chrome. The nav system is sized for comfortable scanning, not maximum density.
-- **States:** Hover uses a subtle tonal shift. Active items gain stronger text weight and a raised neutral background; orange appears only in small selected indicators where established.
+- **Style:** The fixed 56px header, 260px desktop sidebar, and floating table of contents form one hierarchy. Header tabs and sidebar items are 14px sans; TOC links are 13px sans; sidebar group headers and breadcrumbs use monospace technical chrome. The nav system is sized for comfortable scanning, not maximum density. The sidebar sits on a **recessed rail** (`--bg-sidebar`: true black in dark, `gray-100` in light) with a hairline right divider, so it reads a step below the brighter reading column — tonal contrast plus a border, never a shadow (see the Flat-by-Default Rule).
+- **States:** Hover uses a subtle tonal shift. The active **section tab** in the header carries a short orange underline at the header edge; active **sidebar items** gain stronger text weight and a clearly raised neutral background (lifted enough to read against the recessed rail). Orange stays confined to these small selected indicators.
 - **Mobile:** Below the desktop breakpoint, top-level sections and the page hierarchy share one drawer. Never expose two competing hamburger menus.
 
 ### Search and Assistant

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,7 @@ colors:
   signal-white: "#fafafa"
   soft-white: "#e5e5e5"
   muted-gray: "#a3a3a3"
+  mid-gray: "#858585"
   quiet-gray: "#737373"
   paper-white: "#ffffff"
   graphite-copy: "#404040"
@@ -17,6 +18,8 @@ colors:
   warning-amber: "#f59e0b"
   success-green: "#10b981"
   information-blue: "#3b82f6"
+  accent-text-light: "#b8461d"
+  warning-text-light: "#92400e"
 typography:
   display:
     fontFamily: "Geist, -apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
@@ -38,10 +41,16 @@ typography:
     letterSpacing: "-0.022em"
   body:
     fontFamily: "Geist, -apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
-    fontSize: "15px"
+    fontSize: "16px"
     fontWeight: 400
     lineHeight: 1.75
-    letterSpacing: "normal"
+    letterSpacing: "-0.006em"
+  ui:
+    fontFamily: "Geist, -apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 500
+    lineHeight: "18px"
+    letterSpacing: "-0.006em"
   label:
     fontFamily: "Geist Mono, ui-monospace, SF Mono, Menlo, monospace"
     fontSize: "12px"
@@ -50,9 +59,9 @@ typography:
     letterSpacing: "normal"
   code:
     fontFamily: "Geist Mono, ui-monospace, SF Mono, Menlo, monospace"
-    fontSize: "12px"
+    fontSize: "13px"
     fontWeight: 400
-    lineHeight: "20px"
+    lineHeight: "21px"
     letterSpacing: "normal"
 rounded:
   hairline: "2px"
@@ -97,10 +106,10 @@ components:
   navigation-item:
     backgroundColor: "{colors.graphite-canvas}"
     textColor: "{colors.muted-gray}"
-    typography: "{typography.label}"
+    typography: "{typography.ui}"
     rounded: "{rounded.control}"
     padding: "6px 10px"
-    height: "28px"
+    height: "30px"
 ---
 
 # Design System: Axiom Docs
@@ -145,9 +154,17 @@ The palette behaves like instrument markings on graphite: neutral surfaces carry
 - **Graphite Raised:** The dark hover and nested-surface layer.
 - **Graphite Overlay:** The dark popover and dialog layer.
 - **Signal White and Soft White:** Primary and secondary dark-theme text, respectively.
-- **Muted Gray and Quiet Gray:** Supporting text, metadata, breadcrumbs, inactive navigation, and low-priority chrome.
+- **Muted Gray, Mid Gray, and Quiet Gray:** Supporting text, metadata, breadcrumbs, inactive navigation, and low-priority chrome. The neutral text ramp is tuned so every rung that carries text clears WCAG AA in both themes: dark quaternary uses Mid Gray (#858585 ≥ 4.5:1), and in light the tertiary/quaternary rungs shift down one step (Graphite Copy / Quiet Gray) so the bottom rung still reads. Quiet Gray is never used for text at metadata scale on the light canvas.
 - **Paper White:** The light-theme surface and inverse text reference.
-- **Graphite Copy:** The primary long-form copy value in light mode.
+- **Graphite Copy:** The primary long-form copy value in light mode, and the light-theme tertiary text rung.
+
+### Text-on-Light Variants
+
+Two accents need a darkened value to stay legible when they carry **text** on the light canvas, since the brand hues only reach ~3.6:1 there. These are theme-aware tokens (`--color-accent-text`, `--color-warning-text`) that resolve to the brand hue in dark and to the darker value in light:
+
+- **Accent Text (light #b8461d):** Axiom Orange used as text or fill — search-match highlights, hovered links (5.1:1).
+- **Warning Text (light #92400e):** Amber used as text — the API `REQUIRED` markers (6+:1).
+- **Method badges** likewise carry theme-aware text colors: the bright dark-theme greens/blues/ambers/reds are replaced by darker values on the light tint so `GET`/`POST`/`PUT`/`DELETE` clear AA in both themes.
 
 ### Named Rules
 
@@ -171,16 +188,19 @@ The palette behaves like instrument markings on graphite: neutral surfaces carry
 
 - **Display** (600, 44px, 48px): Landing-page statements only; reduce to 36px/40px on phones.
 - **Headline** (600, 34px, 42px): Article titles; use the query monospace treatment for APL/MPL function and operator pages.
-- **Title** (600, 24px, 31px): Primary article sections with balanced wrapping.
-- **Body** (400, 15px, 1.75): Long-form reading at a maximum article measure of 720px and a practical text measure around 65–75 characters.
-- **Intro** (400, 17px, 27px): The first article summary; lower contrast than the title and more open than body copy.
-- **UI** (450–600, 13px, 16px): Navigation and compact controls.
-- **Label** (450–600, 10–12px, 14–16px): Breadcrumbs, table headers, metadata, and compact technical chrome; uppercase only when the label is genuinely categorical.
-- **Code** (400, 12px, 20px): Multiline code and API samples; inline code scales to the surrounding prose.
+- **Title** (600, 24px, 31px): Primary article sections (h2) with balanced wrapping.
+- **Subsection** (600, 20px/17px): Article h3 (20px) and h4 (17px), sized to stay clearly above the 16px body.
+- **Body** (400, 16px, 1.75): Long-form reading in a 768px article column. The column is deliberately generous; body was lifted from 15px→16px to ease sustained technical reading.
+- **Intro** (400, 18px, 29px): The first article summary; lower contrast than the title and more open than body copy.
+- **UI** (450–600, 14px, 18px): Header nav, sidebar items, and drawer navigation. The whole nav system (header tabs, sidebar, dropdown menus) reads at 13–14px so navigation is comfortable, not cramped.
+- **TOC** (450–550, 13px): Floating table-of-contents links.
+- **Label** (450–600, 10–13px, 14–18px): Breadcrumbs, table headers, metadata, and compact technical chrome; uppercase only when the label is genuinely categorical. The `DOCS` brand badge is 14px mono with a 2px orange separator.
+- **Code** (400, 13px, 21px): Multiline code and API samples in the reading column; inline code scales to the surrounding prose (`.84em`), except inside table cells where it inherits the 14px cell size.
+- **Prose tables** (400, 14px body / 550, 13px mono header): Content tables read at body-adjacent size, not label size.
 
 ### Named Rules
 
-**The Reading First Rule.** Long-form text stays within 65–75 characters, uses a generous 1.75 line height, and never inherits compact UI leading.
+**The Reading First Rule.** Long-form text lives in a fixed 768px column at 16px/1.75, and never inherits compact UI leading. Code, tables, and figures may use the full column; running prose shares the same width so the article reads as one measured block.
 
 **The Mono With Purpose Rule.** Monospace means code, query syntax, identifiers, values, or technical chrome. It is never a blanket aesthetic applied to ordinary prose.
 
@@ -213,15 +233,15 @@ The system is flat by default. Canvas, surface, raised, and overlay tones establ
 
 ### Chips
 
-- **Style:** Use only for compact status, source, or API-method metadata. Corners stay at 3px; labels are 8–11px monospace or compact sans.
-- **State:** Color communicates the method or status and is paired with text. Avoid pill shapes for navigation or ordinary actions.
+- **Style:** Use only for compact status, source, or API-method metadata. Corners stay at 3px; labels are 9–11px monospace or compact sans.
+- **State:** Color communicates the method or status and is always paired with text. Method-badge colors are theme-aware so they clear AA on both the dark and light tints. Avoid pill shapes for navigation or ordinary actions.
 
 ### Cards / Containers
 
 - **Corner Style:** Restrained 4px corners for search results, code, frames, tables, and API surfaces.
 - **Background:** Canvas, surface, or raised neutral tokens according to nesting depth.
 - **Shadow Strategy:** None in document flow; follow the Elevation rules for overlays only.
-- **Border:** One-pixel neutral borders define grouping. Semantic notices are the deliberate exception: they use a 2–3px semantic left rule and a subtle inert background.
+- **Border:** One-pixel neutral borders define grouping. Semantic notices (callouts) are the deliberate exception: a 3px semantic left rule, a subtle inert background, a soft 3px radius, and sans-serif body copy at 14px (never monospace — callouts are prose, not code).
 - **Internal Padding:** Usually 12–16px; larger landing-page regions create separation with whitespace instead of card chrome.
 
 ### Inputs / Fields
@@ -232,7 +252,7 @@ The system is flat by default. Canvas, surface, raised, and overlay tones establ
 
 ### Navigation
 
-- **Style:** The fixed 56px header, 260px desktop sidebar, and floating table of contents form one hierarchy. Header tabs are compact sans labels; sidebar groups and breadcrumbs use monospace technical chrome.
+- **Style:** The fixed 56px header, 260px desktop sidebar, and floating table of contents form one hierarchy. Header tabs and sidebar items are 14px sans; TOC links are 13px sans; sidebar group headers and breadcrumbs use monospace technical chrome. The nav system is sized for comfortable scanning, not maximum density.
 - **States:** Hover uses a subtle tonal shift. Active items gain stronger text weight and a raised neutral background; orange appears only in small selected indicators where established.
 - **Mobile:** Below the desktop breakpoint, top-level sections and the page hierarchy share one drawer. Never expose two competing hamburger menus.
 
@@ -240,13 +260,17 @@ The system is flat by default. Canvas, surface, raised, and overlay tones establ
 
 Search and Ask AI share one modal entry point. The dialog uses a strong structural border, a 4px radius, and the dialog shadow; mode tabs, the query field, ranked results, assistant messages, sources, and composer remain visually distinct through dividers and tonal layers. Search must feel immediate, while the assistant loads only when requested and remains grounded in documentation sources.
 
+### Copy Page menu
+
+Each article exposes a split "Copy page" control with a dropdown of page actions, styled as two-line items (bold action + muted description). Native actions come first — **Copy page** (Markdown for LLMs), **View as Markdown**, and **Ask AI about this page** (opens the grounded in-product assistant with the page as context) — then a divider and external hand-offs to **Claude, ChatGPT, and Grok**, each with its monochrome brand mark (never a generic external-link glyph) and a `?q=` deep link carrying the page's Markdown URL.
+
 ### Code and Query Controls
 
 Code samples use a surface background, 4px corners, high-contrast syntax themes, and copy controls that appear on hover or focus. Tabs use a compact monospace label and a short orange active indicator. Query examples and API samples share this language while retaining their specific actions and density.
 
 ### Tables and API Schemas
 
-Tables are compact, bordered, and scan-oriented. Headers use small monospace labels on an inert surface; body rows use readable sans copy, consistent 7–12px cell padding, and hairline separators. Nested API schema children are visibly indented, and locations or method metadata occupy dedicated columns or badges.
+Tables are bordered and scan-oriented. Prose content tables read at 14px sans body / 13px mono headers with ~9px cell padding; inline code in a cell drops its chip and inherits the cell size so identifier columns stay legible. The denser API schema tables keep their compact label-scale type. Nested API schema children are visibly indented, and locations or method metadata occupy dedicated columns or badges.
 
 ## Do's and Don'ts
 
@@ -256,7 +280,7 @@ Tables are compact, bordered, and scan-oriented. Headers use small monospace lab
 - **Do** use Axiom Orange as a scarce interaction signal and keep status colors semantic.
 - **Do** preserve the contrast ladder between headings, body copy, metadata, code, and disabled states in both themes.
 - **Do** keep ordinary controls and containers at 3–4px radii with a compact 4px spacing rhythm.
-- **Do** center the reading experience in the viewport, protect 720px article measure, and keep the landing-page TOC column reserved even when empty.
+- **Do** center the reading experience in the viewport, protect the 768px article column, and keep the landing-page TOC column reserved even when empty.
 - **Do** use tonal layers and one-pixel borders for structure; reserve shadows for floating menus and dialogs.
 - **Do** keep documentation, query reference, and API reference coherent while preserving their distinct controls and density.
 - **Do** meet WCAG 2.2 AA, including keyboard access, visible focus, contrast, semantic structure, and reduced-motion behavior.

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,9 +25,10 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .brand-mark { width: 25px; height: 22px; fill: currentColor; }
 .brand-badge { height: 18px; padding-left: 9px; display: inline-flex; align-items: center; border: 0; border-left: 2px solid var(--color-accent); border-radius: 0; color: var(--text-primary); background: transparent; font: 600 14px/18px var(--font-mono); letter-spacing: .04em; text-transform: uppercase; }
 .header-tabs { display: flex; gap: 4px; }
-.header-tabs a { padding: 6px 10px; border-radius: 4px; color: var(--text-tertiary); font: 500 14px/16px var(--font-sans); letter-spacing: -.006em; }
+.header-tabs a { position: relative; padding: 6px 10px; border-radius: 4px; color: var(--text-tertiary); font: 500 14px/16px var(--font-sans); letter-spacing: -.006em; }
 .header-tabs a:hover { background: var(--bg-emph-tertiary); color: var(--text-secondary); }
 .header-tabs a.active { color: var(--text-primary); font-weight: 600; }
+.header-tabs a.active::after { position: absolute; left: 10px; right: 10px; bottom: -14px; height: 2px; border-radius: 1px 1px 0 0; background: var(--color-accent); content: ''; }
 .header-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 .header-search { width: 220px; height: 28px; padding: 0 8px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--border-primary); border-radius: 4px; color: var(--text-tertiary); background: var(--bg-inert); cursor: pointer; }
 .header-search span { flex: 1; text-align: left; font: 450 14px/16px var(--font-sans); }
@@ -202,12 +203,12 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 }
 
 .docs-grid { min-height: 100vh; padding-top: 56px; display: grid; grid-template-columns: 260px minmax(0, 1fr); }
-.sidebar { position: fixed; z-index: 30; left: 0; top: 56px; bottom: 0; width: 260px; overflow-y: auto; padding: 56px 16px 48px 24px; background: var(--bg-canvas); scrollbar-width: thin; }
+.sidebar { position: fixed; z-index: 30; left: 0; top: 56px; bottom: 0; width: 260px; overflow-y: auto; padding: 56px 16px 48px 24px; border-right: 1px solid var(--border-strong); background: var(--bg-sidebar); scrollbar-width: thin; }
 .sidebar-group { margin: 0 0 24px; }
 .sidebar-group h2 { margin: 0 0 8px; color: var(--text-secondary); font: 600 11px/14px var(--font-mono); letter-spacing: .1em; text-transform: uppercase; }
 .sidebar-link, .nav-nested summary { min-height: 30px; margin: 0 -10px; padding: 6px 10px; display: flex; align-items: center; gap: 7px; border-radius: 4px; color: var(--text-tertiary); font: 450 14px/18px var(--font-sans); letter-spacing: -.006em; cursor: pointer; }
 .sidebar-link:hover, .nav-nested summary:hover { background: var(--bg-emph-tertiary); color: var(--text-secondary); }
-.sidebar-link.active { color: var(--text-primary); background: var(--bg-emph-secondary); font-weight: 600; }
+.sidebar-link.active { color: var(--text-primary); background: var(--bg-emph-primary); font-weight: 600; }
 .sidebar-link-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sidebar-link.syntax-reference-link .sidebar-link-label { font-family: var(--font-query); letter-spacing: 0; }
 .sidebar-link .method { margin-left: auto; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -203,7 +203,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 }
 
 .docs-grid { min-height: 100vh; padding-top: 56px; display: grid; grid-template-columns: 260px minmax(0, 1fr); }
-.sidebar { position: fixed; z-index: 30; left: 0; top: 56px; bottom: 0; width: 260px; overflow-y: auto; padding: 56px 16px 48px 24px; border-right: 1px solid var(--border-strong); background: var(--bg-sidebar); scrollbar-width: thin; }
+.sidebar { position: fixed; z-index: 30; left: 0; top: 56px; bottom: 0; width: 260px; overflow-y: auto; padding: 56px 16px 48px 24px; border-right: 1px solid var(--border-primary); background: var(--bg-sidebar); scrollbar-width: thin; }
 .sidebar-group { margin: 0 0 24px; }
 .sidebar-group h2 { margin: 0 0 8px; color: var(--text-secondary); font: 600 11px/14px var(--font-mono); letter-spacing: .1em; text-transform: uppercase; }
 .sidebar-link, .nav-nested summary { min-height: 30px; margin: 0 -10px; padding: 6px 10px; display: flex; align-items: center; gap: 7px; border-radius: 4px; color: var(--text-tertiary); font: 450 14px/18px var(--font-sans); letter-spacing: -.006em; cursor: pointer; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -218,7 +218,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .nav-nested summary span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .nav-nested summary svg { margin-left: auto; transition: transform .15s ease; flex: none; }
 .nav-nested[open] > summary svg { transform: rotate(90deg); }
-.method { flex: none; min-width: 31px; padding: 1px 3px; border-radius: 3px; font: 600 9px/12px var(--font-mono); text-align: center; letter-spacing: .02em; }
+.method { flex: none; min-width: 34px; padding: 1px 4px; border-radius: 3px; font: 600 10px/14px var(--font-mono); text-align: center; letter-spacing: .02em; }
 .method-get { color: #34d399; background: rgba(16,185,129,.11); }
 .method-post { color: #60a5fa; background: rgba(59,130,246,.11); }
 .method-put, .method-patch { color: #fbbf24; background: rgba(245,158,11,.11); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,16 +23,16 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .site-header { position: fixed; inset: 0 0 auto; z-index: 50; height: 56px; display: flex; align-items: center; gap: 24px; padding: 0 24px; border-bottom: 1px solid var(--border-primary); background: color-mix(in srgb, var(--bg-canvas) 94%, transparent); backdrop-filter: blur(12px); }
 .brand { height: 28px; display: flex; align-items: center; gap: 9px; flex: none; }
 .brand-mark { width: 25px; height: 22px; fill: currentColor; }
-.brand-badge { height: 16px; padding-left: 8px; display: inline-flex; align-items: center; border: 0; border-left: 1px solid var(--color-accent); border-radius: 0; color: var(--text-primary); background: transparent; font: 600 12px/16px var(--font-mono); letter-spacing: .06em; text-transform: uppercase; }
+.brand-badge { height: 18px; padding-left: 9px; display: inline-flex; align-items: center; border: 0; border-left: 2px solid var(--color-accent); border-radius: 0; color: var(--text-primary); background: transparent; font: 600 14px/18px var(--font-mono); letter-spacing: .04em; text-transform: uppercase; }
 .header-tabs { display: flex; gap: 4px; }
-.header-tabs a { padding: 6px 10px; border-radius: 4px; color: var(--text-tertiary); font: 500 13px/16px var(--font-sans); }
+.header-tabs a { padding: 6px 10px; border-radius: 4px; color: var(--text-tertiary); font: 500 14px/16px var(--font-sans); letter-spacing: -.006em; }
 .header-tabs a:hover { background: var(--bg-emph-tertiary); color: var(--text-secondary); }
 .header-tabs a.active { color: var(--text-primary); font-weight: 600; }
 .header-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 .header-search { width: 220px; height: 28px; padding: 0 8px; display: flex; align-items: center; gap: 8px; border: 1px solid var(--border-primary); border-radius: 4px; color: var(--text-tertiary); background: var(--bg-inert); cursor: pointer; }
-.header-search span { flex: 1; text-align: left; font: 450 13px/16px var(--font-sans); }
+.header-search span { flex: 1; text-align: left; font: 450 14px/16px var(--font-sans); }
 .header-button, .header-icon { height: 28px; display: inline-flex; align-items: center; justify-content: center; gap: 6px; border: 1px solid var(--border-primary); border-radius: 4px; color: var(--text-secondary); background: transparent; cursor: pointer; }
-.header-button { padding: 0 10px; background: var(--bg-emph-secondary); font: 500 13px/16px var(--font-sans); }
+.header-button { padding: 0 10px; background: var(--bg-emph-secondary); font: 500 14px/16px var(--font-sans); }
 .header-icon { width: 28px; }
 .header-button:hover, .header-icon:hover { background: var(--bg-emph-primary); }
 .theme-menu { position: relative; }
@@ -41,10 +41,10 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .theme-menu[open] > summary { background: var(--bg-emph-primary); }
 .theme-menu:not([open]) > .theme-menu-popover { display: none; }
 .theme-menu-popover { position: absolute; top: 34px; right: 0; z-index: 70; width: 132px; padding: 4px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-overlay); box-shadow: 0 8px 28px rgba(0,0,0,.28); }
-.theme-menu-popover button { width: 100%; height: 30px; padding: 0 7px; display: flex; align-items: center; gap: 8px; border: 0; border-radius: 3px; color: var(--text-tertiary); background: transparent; font: 500 12px/16px var(--font-sans); cursor: pointer; }
+.theme-menu-popover button { width: 100%; height: 32px; padding: 0 7px; display: flex; align-items: center; gap: 8px; border: 0; border-radius: 3px; color: var(--text-tertiary); background: transparent; font: 500 13px/16px var(--font-sans); cursor: pointer; }
 .theme-menu-popover button:hover, .theme-menu-popover button[aria-checked='true'] { color: var(--text-primary); background: var(--bg-emph-tertiary); }
 .theme-menu-popover button span { flex: 1; text-align: left; }
-.console-button { height: 28px; display: inline-flex; align-items: center; gap: 4px; padding: 0 12px; border-radius: 4px; color: var(--text-on-inverse-primary); background: var(--bg-emph-primary-inverse); font: 600 13px/16px var(--font-sans); }
+.console-button { height: 28px; display: inline-flex; align-items: center; gap: 4px; padding: 0 12px; border-radius: 4px; color: var(--text-on-inverse-primary); background: var(--bg-emph-primary-inverse); font: 600 14px/16px var(--font-sans); }
 .mobile-menu-trigger, .drawer-sections, .sidebar-backdrop { display: none; }
 
 .docs-search-dialog { width: min(720px, calc(100vw - 32px)); height: min(650px, calc(100dvh - 64px)); max-width: none; max-height: none; margin: auto; padding: 0; overflow: hidden; border: 1px solid var(--border-strong); border-radius: 4px; color: var(--text-primary); background: var(--bg-overlay); box-shadow: 0 16px 48px rgba(0,0,0,.36); }
@@ -90,7 +90,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .docs-search-result:focus-visible { box-shadow: inset 0 0 0 1px var(--color-accent); }
 .docs-search-result-path { overflow: hidden; color: var(--text-tertiary); font: 450 10px/14px var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .docs-search-result-content { display: -webkit-box; overflow: hidden; font: 450 13px/18px var(--font-sans); -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
-.docs-search-result-content mark { color: var(--color-accent); background: transparent; font-weight: 600; }
+.docs-search-result-content mark { color: var(--color-accent-text); background: transparent; font-weight: 600; }
 .docs-search-footer { min-height: 38px; padding: 7px 12px; display: flex; align-items: center; gap: 14px; border-top: 1px solid var(--border-primary); color: var(--text-tertiary); background: var(--bg-surface); font: 450 10px/14px var(--font-mono); }
 .docs-search-footer span { display: inline-flex; align-items: center; gap: 4px; }
 .docs-search-footer button { margin-left: auto; padding: 0; border: 0; color: var(--text-tertiary); background: transparent; font: 500 11px/16px var(--font-sans); cursor: pointer; transition: color var(--duration-1) var(--ease-out); }
@@ -205,7 +205,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .sidebar { position: fixed; z-index: 30; left: 0; top: 56px; bottom: 0; width: 260px; overflow-y: auto; padding: 56px 16px 48px 24px; background: var(--bg-canvas); scrollbar-width: thin; }
 .sidebar-group { margin: 0 0 24px; }
 .sidebar-group h2 { margin: 0 0 8px; color: var(--text-secondary); font: 600 11px/14px var(--font-mono); letter-spacing: .1em; text-transform: uppercase; }
-.sidebar-link, .nav-nested summary { min-height: 28px; margin: 0 -10px; padding: 6px 10px; display: flex; align-items: center; gap: 7px; border-radius: 4px; color: var(--text-tertiary); font: 450 13px/16px var(--font-sans); letter-spacing: -.005em; cursor: pointer; }
+.sidebar-link, .nav-nested summary { min-height: 30px; margin: 0 -10px; padding: 6px 10px; display: flex; align-items: center; gap: 7px; border-radius: 4px; color: var(--text-tertiary); font: 450 14px/18px var(--font-sans); letter-spacing: -.006em; cursor: pointer; }
 .sidebar-link:hover, .nav-nested summary:hover { background: var(--bg-emph-tertiary); color: var(--text-secondary); }
 .sidebar-link.active { color: var(--text-primary); background: var(--bg-emph-secondary); font-weight: 600; }
 .sidebar-link-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -217,11 +217,17 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .nav-nested summary span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .nav-nested summary svg { margin-left: auto; transition: transform .15s ease; flex: none; }
 .nav-nested[open] > summary svg { transform: rotate(90deg); }
-.method { flex: none; min-width: 31px; padding: 1px 3px; border-radius: 3px; font: 600 8px/12px var(--font-mono); text-align: center; letter-spacing: .02em; }
+.method { flex: none; min-width: 31px; padding: 1px 3px; border-radius: 3px; font: 600 9px/12px var(--font-mono); text-align: center; letter-spacing: .02em; }
 .method-get { color: #34d399; background: rgba(16,185,129,.11); }
 .method-post { color: #60a5fa; background: rgba(59,130,246,.11); }
 .method-put, .method-patch { color: #fbbf24; background: rgba(245,158,11,.11); }
 .method-delete { color: #f87171; background: rgba(239,68,68,.11); }
+/* Light theme: the dark-tuned method colors sit at 1.9–2.5:1 on the light tint.
+   Repoint to darker text values that clear AA (>=4.5:1) on the same tints. */
+:root[data-theme='light'] .method-get { color: #047857; background: rgba(16,185,129,.12); }
+:root[data-theme='light'] .method-post { color: #1d4ed8; background: rgba(59,130,246,.12); }
+:root[data-theme='light'] .method-put, :root[data-theme='light'] .method-patch { color: #92400e; background: rgba(245,158,11,.14); }
+:root[data-theme='light'] .method-delete { color: #b91c1c; background: rgba(239,68,68,.12); }
 .docs-main { grid-column: 2; min-width: 0; }
 .landing-main { padding-right: 260px; }
 
@@ -259,7 +265,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .landing-footer small { margin-left: auto; color: var(--text-quaternary); font: inherit; }
 
 .article-layout { position: relative; min-height: calc(100vh - 56px); padding: 56px clamp(32px, 6vw, 96px) 96px; }
-.doc-article { width: min(720px, 100%); margin: 0 auto; transform: translateX(-130px); }
+.doc-article { width: min(768px, 100%); margin: 0 auto; transform: translateX(-130px); }
 .doc-topline { margin: 0 0 20px; display: flex; align-items: flex-start; justify-content: space-between; gap: 8px 16px; }
 .doc-topline .doc-breadcrumbs { margin: 0; }
 .doc-breadcrumbs { margin: 0 0 20px; display: flex; flex-wrap: wrap; gap: 4px 8px; color: var(--text-quaternary); font: 450 12px/16px var(--font-mono); }
@@ -269,9 +275,9 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article > h1, .doc-article [data-docs-title] { margin: 0; color: var(--text-primary); font: 600 34px/42px var(--font-sans); letter-spacing: -.03em; text-wrap: balance; }
 .doc-article .query-syntax-title { font: 600 32px/40px var(--font-query) !important; font-variant-ligatures: none; letter-spacing: 0; }
 .query-syntax-article .prose a:is([href*='/scalar-functions/'], [href*='/aggregation-functions/'], [href*='/operators/']) { font-family: var(--font-query); font-variant-ligatures: none; letter-spacing: 0; }
-.doc-article > p:first-of-type { max-width: 640px; margin: 6px 0 34px; color: var(--text-tertiary); font: 400 17px/27px var(--font-sans); letter-spacing: -.012em; text-wrap: pretty; }
+.doc-article > p:first-of-type { max-width: 640px; margin: 6px 0 34px; color: var(--text-tertiary); font: 400 18px/29px var(--font-sans); letter-spacing: -.012em; text-wrap: pretty; }
 .doc-article .prose {
-  --docs-type-size: 15px;
+  --docs-type-size: 16px;
   --docs-type-leading: 1.75;
   --docs-type-flow: 1.4em;
   --docs-copy: var(--gray-300);
@@ -291,10 +297,12 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article .prose :where(p, li, dd, td) { color: var(--docs-copy); }
 .doc-article .prose :where(strong, b) { color: var(--text-primary); }
 .doc-article .prose :where(p, ul, ol, blockquote, table, figure, hr) { margin-block: 0; }
+/* Article reading column measure. */
+.doc-article .prose > :where(p, ul, ol, blockquote, dl) { max-width: 768px; }
 .doc-article .prose > :where(p, ul, ol, blockquote, table, figure, hr, .fd-codeblock) + :where(p, ul, ol, blockquote, table, figure, hr, .fd-codeblock) { margin-block-start: var(--docs-type-flow); }
 .doc-article .prose h2 { margin: 58px 0 14px; padding: 0; font: 600 24px/31px var(--font-sans); letter-spacing: -.022em; text-wrap: balance; }
-.doc-article .prose h3 { margin: 40px 0 11px; font: 600 19px/26px var(--font-sans); letter-spacing: -.015em; text-wrap: balance; }
-.doc-article .prose h4 { margin: 32px 0 9px; font: 600 16px/23px var(--font-sans); letter-spacing: -.01em; }
+.doc-article .prose h3 { margin: 40px 0 11px; font: 600 20px/27px var(--font-sans); letter-spacing: -.015em; text-wrap: balance; }
+.doc-article .prose h4 { margin: 32px 0 9px; font: 600 17px/24px var(--font-sans); letter-spacing: -.01em; }
 .doc-article .prose h2 + h3 { margin-top: 18px; }
 .doc-article .prose h3 + h4 { margin-top: 16px; }
 .doc-article .prose :where(h2, h3, h4) + :where(p, ul, ol) { margin-top: 0; }
@@ -305,7 +313,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article .prose :where(blockquote) { margin-top: calc(var(--docs-type-flow) * 1.15); padding: 2px 0 2px 18px; border-left: 2px solid var(--border-strong); color: var(--text-tertiary); font-style: normal; }
 .doc-article .prose :where(hr) { margin-top: calc(var(--docs-type-flow) * 2); border-color: var(--border-primary); }
 .doc-article .prose :where(table) { margin-top: calc(var(--docs-type-flow) * 1.25); font-size: .93em; }
-.doc-notice { --notice-accent: var(--color-info); margin: 24px 0; padding: 14px 16px; border-left: 3px solid var(--notice-accent); background: var(--bg-inert); color: var(--text-secondary); font: 450 12px/19px var(--font-mono); letter-spacing: -.01em; }
+.doc-notice { --notice-accent: var(--color-info); margin: 24px 0; padding: 15px 16px; border-left: 3px solid var(--notice-accent); border-radius: 3px; background: var(--bg-inert); color: var(--text-secondary); font: 450 14px/22px var(--font-sans); letter-spacing: -.005em; }
 .doc-notice-info { --notice-accent: var(--color-info); }
 .doc-notice-idea { --notice-accent: var(--color-accent); }
 .doc-notice-warn { --notice-accent: var(--color-warning); }
@@ -315,17 +323,24 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-notice :where(p, ul, ol) { margin: 0; }
 .doc-article .prose .doc-notice :where(p, ul, ol) + :where(p, ul, ol) { margin-top: 14px; }
 .copy-page { position: relative; margin-left: auto; display: flex; flex-shrink: 0; }
-.copy-page-main { height: 26px; padding: 0 9px; display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border-primary); border-radius: 3px 0 0 3px; color: var(--text-tertiary); background: var(--bg-surface); font: 500 11px/15px var(--font-sans); cursor: pointer; }
+.copy-page-main { height: 30px; padding: 0 11px; display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--border-primary); border-radius: 4px 0 0 4px; color: var(--text-tertiary); background: var(--bg-surface); font: 500 13px/16px var(--font-sans); cursor: pointer; }
 .copy-page-main:hover { color: var(--text-primary); background: var(--bg-inert); }
-.copy-page-menu > summary { height: 26px; width: 22px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border-primary); border-left: 0; border-radius: 0 3px 3px 0; color: var(--text-quaternary); background: var(--bg-surface); cursor: pointer; list-style: none; }
+.copy-page-menu > summary { height: 30px; width: 27px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border-primary); border-left: 0; border-radius: 0 4px 4px 0; color: var(--text-quaternary); background: var(--bg-surface); cursor: pointer; list-style: none; }
 .copy-page-menu > summary::-webkit-details-marker { display: none; }
 .copy-page-menu > summary:hover, .copy-page-menu[open] > summary { color: var(--text-primary); background: var(--bg-inert); }
+.copy-page-main:focus-visible, .copy-page-menu > summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; z-index: 1; }
 .copy-page-menu:not([open]) > .copy-page-popover { display: none; }
-.copy-page-popover { position: absolute; top: 30px; right: 0; z-index: 70; width: 212px; padding: 4px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-overlay); box-shadow: 0 8px 28px rgba(0,0,0,.28); }
-.copy-page-popover button, .copy-page-popover a { width: 100%; height: 30px; padding: 0 8px; display: flex; align-items: center; gap: 8px; border: 0; border-radius: 3px; color: var(--text-tertiary); background: transparent; font: 500 12px/16px var(--font-sans); text-decoration: none; cursor: pointer; }
-.copy-page-popover button:hover, .copy-page-popover a:hover { color: var(--text-primary); background: var(--bg-emph-tertiary); }
-.copy-page-popover svg { flex-shrink: 0; }
-.copy-page-popover hr { margin: 4px 0; border: 0; border-top: 1px solid var(--border-primary); }
+.copy-page-popover { position: absolute; top: 34px; right: 0; z-index: 70; width: 296px; padding: 5px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-overlay); box-shadow: 0 8px 28px rgba(0,0,0,.28); }
+.copy-page-popover button, .copy-page-popover a { width: 100%; padding: 8px 9px; display: flex; align-items: flex-start; gap: 11px; border: 0; border-radius: 4px; color: var(--text-secondary); background: transparent; text-align: left; text-decoration: none; cursor: pointer; }
+.copy-page-popover button:hover, .copy-page-popover a:hover { background: var(--bg-emph-tertiary); }
+.copy-page-popover button:focus-visible, .copy-page-popover a:focus-visible { outline: 2px solid var(--color-accent); outline-offset: -2px; }
+.copy-page-popover button > span, .copy-page-popover a > span { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.copy-page-popover strong { color: var(--text-primary); font: 550 13px/17px var(--font-sans); letter-spacing: -.006em; }
+.copy-page-popover small { color: var(--text-tertiary); font: 400 12px/16px var(--font-sans); }
+.copy-page-popover svg { flex: none; margin-top: 2px; color: var(--icon-secondary); }
+.copy-page-popover .copy-page-brand { width: 15px; height: 15px; }
+.copy-page-popover button:hover svg, .copy-page-popover a:hover svg { color: var(--text-primary); }
+.copy-page-popover hr { margin: 5px 3px; border: 0; border-top: 1px solid var(--border-primary); }
 @media (max-width: 640px) { .copy-page { display: none; } }
 .anchor-heading { scroll-margin-top: 88px; }
 .anchor-heading > a { display: inline-flex; align-items: baseline; gap: .35em; text-decoration: none !important; }
@@ -336,6 +351,8 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article .prose :where(p, li, td, dd) a:not(.playground-link):hover { text-decoration-color: var(--color-accent); }
 .doc-article .prose a:focus-visible { border-radius: 2px; outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .doc-article .prose :not(pre) > code { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 4px; background: var(--bg-inert); font-family: var(--font-mono); font-size: .84em; }
+/* Multi-line code in the reading column tracks the body bump: 12px -> 13px. */
+.doc-article .prose pre, .doc-article .prose pre code { font-size: 13px; line-height: 21px; }
 .doc-article figure[data-rehype-pretty-code-figure], .doc-article figure.shiki, .doc-article .fd-codeblock { border-color: var(--border-primary); border-radius: 4px !important; background: var(--bg-surface); box-shadow: none !important; }
 .doc-article figure:has(+ .placeholder-config) { border-bottom-left-radius: 0 !important; border-bottom-right-radius: 0 !important; }
 .accordion-group { width: 100%; margin: 12px 0; }
@@ -377,14 +394,17 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .query-example figure button[aria-label='Copy Text'] { width: 24px; height: 24px; border: 1px solid var(--border-primary); border-radius: 3px; background: color-mix(in srgb, var(--bg-canvas) 88%, transparent); }
 .doc-article .prose div.relative.overflow-auto:has(> table) { margin: 18px 0 !important; overflow: auto; border: 1px solid var(--border-primary); border-radius: 4px; }
 .doc-article .prose div.relative.overflow-auto:has(> table) > table { width: 100%; margin: 0 !important; border: 0 !important; border-collapse: collapse; font-size: 12px; }
-.doc-article .prose div.relative.overflow-auto:has(> table) th { padding: 7px 10px; border: 0; border-right: 1px solid var(--border-primary); border-bottom: 1px solid var(--border-primary); color: var(--text-secondary); background: var(--bg-inert); font: 550 11px/16px var(--font-mono); text-align: left; }
-.doc-article .prose div.relative.overflow-auto:has(> table) td { padding: 8px 10px; border: 0; border-right: 1px solid var(--border-tertiary); border-bottom: 1px solid var(--border-tertiary); color: var(--docs-copy); font: 400 12px/18px var(--font-sans); vertical-align: top; }
+.doc-article .prose div.relative.overflow-auto:has(> table) th { padding: 8px 10px; border: 0; border-right: 1px solid var(--border-primary); border-bottom: 1px solid var(--border-primary); color: var(--text-secondary); background: var(--bg-inert); font: 550 13px/18px var(--font-mono); text-align: left; }
+.doc-article .prose div.relative.overflow-auto:has(> table) td { padding: 9px 10px; border: 0; border-right: 1px solid var(--border-tertiary); border-bottom: 1px solid var(--border-tertiary); color: var(--docs-copy); font: 400 14px/22px var(--font-sans); vertical-align: top; }
 .doc-article .prose div.relative.overflow-auto:has(> table) :is(th, td):last-child { border-right: 0; }
 .doc-article .prose div.relative.overflow-auto:has(> table) tbody tr:last-child td { border-bottom: 0; }
+/* Inline code in table cells already reads as an identifier via the mono face;
+   drop the chip (border/tint/pad) so dense tables stay calm — just monospace. */
+.doc-article .prose div.relative.overflow-auto:has(> table) :is(th, td) code { padding: 0; border: 0; border-radius: 0; background: transparent; font-size: inherit; }
 .docs-tabs [role='tabpanel'] > div.relative.overflow-auto:has(> table) { margin-top: 11px !important; margin-bottom: 0 !important; }
 .floating-toc { position: fixed; right: 32px; top: 112px; z-index: 20; width: 210px; max-height: calc(100vh - 144px); overflow: auto; padding: 0; background: transparent; }
-.floating-toc strong { display: block; margin-bottom: 9px; color: var(--text-tertiary); font: 600 10px/14px var(--font-mono); letter-spacing: .08em; text-transform: uppercase; }
-.floating-toc a { position: relative; display: block; padding-top: 4px; padding-bottom: 4px; overflow: hidden; color: var(--text-quaternary); font: 450 11px/15px var(--font-sans); text-overflow: ellipsis; white-space: nowrap; transition: color .15s ease; }
+.floating-toc strong { display: block; margin-bottom: 9px; color: var(--text-tertiary); font: 600 11px/14px var(--font-mono); letter-spacing: .08em; text-transform: uppercase; }
+.floating-toc a { position: relative; display: block; padding-top: 5px; padding-bottom: 5px; overflow: hidden; color: var(--text-quaternary); font: 450 13px/17px var(--font-sans); letter-spacing: -.006em; text-overflow: ellipsis; white-space: nowrap; transition: color .15s ease; }
 .floating-toc a code { color: inherit !important; font-size: inherit; }
 .floating-toc a:hover { color: var(--text-primary); }
 .floating-toc a.active { color: var(--text-primary); font-weight: 550; }
@@ -439,13 +459,13 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .endpoint-bar { margin: 16px 0; padding: 10px 12px; display: flex; align-items: center; gap: 10px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-surface); }
 .endpoint-bar > code { flex: 1; overflow-x: auto; color: var(--text-secondary); background: transparent !important; border: 0 !important; font: 450 13px/18px var(--font-mono) !important; white-space: nowrap; }
 .endpoint-method { padding: 3px 7px; border: 1px solid var(--border-primary); border-radius: 4px; font: 600 10px/16px var(--font-mono); letter-spacing: .04em; }
-.endpoint-description { margin: 16px 0 24px; color: var(--text-tertiary); font: 400 15px/25px var(--font-sans); }
+.endpoint-description { margin: 16px 0 24px; color: var(--text-tertiary); font: 400 16px/26px var(--font-sans); }
 .copy-button { margin-left: auto; padding: 4px; display: inline-flex; align-items: center; gap: 6px; border: 0; color: var(--text-quaternary); background: transparent; cursor: pointer; font: 450 11px/16px var(--font-mono); }
 .copy-button:hover { color: var(--text-primary); }
 .api-section { margin-top: 44px; }
 .api-section > h2 { margin: 0 !important; padding: 0; border: 0; color: var(--text-primary); font: 600 18px/24px var(--font-sans) !important; letter-spacing: -.01em; }
 .api-section > h2 a { color: var(--text-quaternary); text-decoration: none !important; font: 450 14px/20px var(--font-mono); }
-.api-section-copy { margin-top: 12px; color: var(--text-secondary); font-size: 14px; line-height: 24px; }
+.api-section-copy { margin-top: 12px; color: var(--text-secondary); font-size: 15px; line-height: 25px; }
 .api-schema-wrap { margin-top: 14px; overflow-x: auto; border: 1px solid var(--border-primary); border-radius: 4px; }
 .api-schema-table { width: 100%; min-width: 620px; margin: 0 !important; border: 0 !important; border-collapse: collapse; table-layout: fixed; font-size: 12px !important; }
 .api-schema-table th { padding: 7px 12px; border: 0 !important; border-bottom: 1px solid var(--border-primary) !important; color: var(--text-quaternary); background: var(--bg-inert); font: 500 10px/14px var(--font-mono); letter-spacing: .06em; text-align: left; text-transform: uppercase; }
@@ -462,10 +482,10 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .api-schema-name code { color: var(--text-primary) !important; font-size: 12px !important; font-weight: 550; }
 .api-schema-branch { margin-right: 6px; color: var(--border-strong); font: 400 11px/14px var(--font-mono); }
 .api-schema-type { white-space: nowrap; }
-.api-schema-type code, .api-schema-type b { margin-right: 7px; color: var(--text-quaternary) !important; font: 450 9px/14px var(--font-mono) !important; letter-spacing: .04em; text-transform: uppercase; }
-.api-schema-type b { color: var(--amber-500) !important; }
-.api-schema-location code { padding: 0 !important; border: 0 !important; color: var(--text-tertiary) !important; background: transparent !important; font: 500 9px/14px var(--font-mono) !important; letter-spacing: .05em; text-transform: uppercase; }
-.api-schema-description { color: var(--text-secondary) !important; font: 400 12px/18px var(--font-sans); }
+.api-schema-type code, .api-schema-type b { margin-right: 7px; color: var(--text-quaternary) !important; font: 450 10px/14px var(--font-mono) !important; letter-spacing: .04em; text-transform: uppercase; }
+.api-schema-type b { color: var(--color-warning-text) !important; }
+.api-schema-location code { padding: 0 !important; border: 0 !important; color: var(--text-tertiary) !important; background: transparent !important; font: 500 10px/14px var(--font-mono) !important; letter-spacing: .05em; text-transform: uppercase; }
+.api-schema-description { color: var(--text-secondary) !important; font: 400 13px/19px var(--font-sans); }
 .api-schema-description code, .api-section-copy code { padding: 1px 4px; border: 1px solid var(--border-secondary); border-radius: 3px; background: var(--bg-inert); font-family: var(--font-mono); }
 .media-types { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 6px; }
 .media-types code { padding: 3px 7px; border: 1px solid var(--border-primary); border-radius: 3px; color: var(--text-tertiary); background: var(--bg-inert); font-size: 10px; }
@@ -495,7 +515,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .api-try-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .api-try-fields label { min-width: 0; display: flex; flex-direction: column; gap: 6px; }
 .api-try-fields label > span { color: var(--text-secondary); font: 500 11px/16px var(--font-mono); }
-.api-try-fields label > span b, .api-try-fields label > span em, .api-try-fields label > span code { margin-left: 6px; color: var(--amber-500); font: 500 8px/13px var(--font-mono); font-style: normal; letter-spacing: .04em; text-transform: uppercase; }
+.api-try-fields label > span b, .api-try-fields label > span em, .api-try-fields label > span code { margin-left: 6px; color: var(--color-warning-text); font: 500 10px/14px var(--font-mono); font-style: normal; letter-spacing: .04em; text-transform: uppercase; }
 .api-try-fields label > span em { color: var(--text-quaternary); }
 .api-try-fields label > span code { padding: 0; border: 0; color: var(--text-quaternary); background: transparent; }
 .api-try-fields input, .api-try-fields textarea { width: 100%; border: 1px solid var(--border-primary); border-radius: 4px; outline: none; color: var(--text-primary); background: var(--bg-canvas); font: 400 12px/18px var(--font-mono); }
@@ -516,7 +536,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .api-try-result { margin-top: 14px; overflow: hidden; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-canvas); }
 .api-try-result > div { min-height: 34px; padding: 7px 10px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-primary); }
 .api-try-result strong { color: var(--text-secondary); font: 550 11px/16px var(--font-mono); }
-.api-try-result small { margin-left: auto; color: var(--text-quaternary); font: 450 9px/14px var(--font-mono); text-transform: uppercase; }
+.api-try-result small { margin-left: auto; color: var(--text-quaternary); font: 450 10px/14px var(--font-mono); text-transform: uppercase; }
 .api-try-result pre { max-height: 420px; margin: 0 !important; padding: 14px !important; overflow: auto; border: 0 !important; background: transparent !important; color: var(--text-primary) !important; font: 400 12px/20px var(--font-mono) !important; }
 .api-try-result code { padding: 0 !important; border: 0 !important; background: transparent !important; color: inherit !important; font: inherit !important; }
 .api-response { min-height: 43px; padding: 10px 4px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--border-tertiary); }
@@ -543,7 +563,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
   .sidebar { top: 56px; width: min(320px, 88vw); z-index: 70; padding: 16px 16px max(48px, env(safe-area-inset-bottom)) 24px; visibility: hidden; transform: translateX(-105%); transition: transform .2s ease, visibility 0s linear .2s; box-shadow: 12px 0 48px rgba(0,0,0,.35); }
   .sidebar.open { visibility: visible; transform: translateX(0); transition-delay: 0s; }
   .drawer-sections { margin: 0 0 20px; padding-bottom: 16px; display: flex; flex-direction: column; gap: 2px; border-bottom: 1px solid var(--border-primary); }
-  .drawer-sections a { min-height: 44px; padding: 0 10px; display: flex; align-items: center; border-radius: 4px; color: var(--text-tertiary); font: 500 13px/16px var(--font-sans); }
+  .drawer-sections a { min-height: 44px; padding: 0 10px; display: flex; align-items: center; border-radius: 4px; color: var(--text-tertiary); font: 500 14px/18px var(--font-sans); }
   .drawer-sections a:hover { color: var(--text-secondary); background: var(--bg-emph-tertiary); }
   .drawer-sections a.active { color: var(--text-primary); background: var(--bg-emph-secondary); font-weight: 600; }
   .sidebar-link, .nav-nested summary { min-height: 44px; padding-top: 12px; padding-bottom: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -346,7 +346,9 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .anchor-heading { scroll-margin-top: 88px; }
 .anchor-heading > a { display: inline-flex; align-items: baseline; gap: .35em; text-decoration: none !important; }
 .anchor-hash { color: var(--text-quaternary); font-family: var(--font-mono); font-size: .72em; font-weight: 500; opacity: 0; transform: translateX(-3px); transition: opacity .15s ease, transform .15s ease; }
-.anchor-heading:hover .anchor-hash, .anchor-heading:focus-within .anchor-hash { opacity: 1; transform: translateX(0); }
+/* Show the # on hover, or on keyboard focus only (:focus-visible) — a mouse
+   click copies the link without leaving the marker stuck on afterwards. */
+.anchor-heading:hover .anchor-hash, .anchor-heading:has(a:focus-visible) .anchor-hash { opacity: 1; transform: translateX(0); }
 .doc-article .prose a { text-decoration-color: var(--border-strong); text-underline-offset: 3px; }
 .doc-article .prose :where(p, li, td, dd) a:not(.playground-link) { color: var(--text-primary); text-decoration-line: underline; text-decoration-color: var(--text-quaternary); }
 .doc-article .prose :where(p, li, td, dd) a:not(.playground-link):hover { text-decoration-color: var(--color-accent); }

--- a/components/ai-elements/code-block.tsx
+++ b/components/ai-elements/code-block.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { copyToClipboard as writeClipboard } from "@/lib/clipboard";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps, CSSProperties, HTMLAttributes } from "react";
 import {
@@ -468,14 +469,14 @@ export const CodeBlockCopyButton = ({
   const { code } = useContext(CodeBlockContext);
 
   const copyToClipboard = useCallback(async () => {
-    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+    if (typeof window === "undefined") {
       onError?.(new Error("Clipboard API not available"));
       return;
     }
 
     try {
       if (!isCopied) {
-        await navigator.clipboard.writeText(code);
+        if (!(await writeClipboard(code))) throw new Error("Copy failed");
         setIsCopied(true);
         onCopy?.();
         timeoutRef.current = window.setTimeout(

--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -3,6 +3,7 @@
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
 import { captureDocsEvent } from '@/lib/docs-analytics';
+import { copyToClipboard } from '@/lib/clipboard';
 
 export function CopyButton({
   value,
@@ -23,7 +24,7 @@ export function CopyButton({
       type="button"
       aria-label={`${label} to clipboard`}
       onClick={async () => {
-        await navigator.clipboard.writeText(value);
+        if (!(await copyToClipboard(value))) return;
         if (analytics) {
           captureDocsEvent('docs_code_copied', {
             code_kind: analytics.codeKind,

--- a/components/copy-page.tsx
+++ b/components/copy-page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Check, ChevronDown, Copy, FileText, MessageSquare } from 'lucide-react';
 import { toast } from 'sonner';
 import { captureDocsEvent } from '@/lib/docs-analytics';
+import { copyToClipboard } from '@/lib/clipboard';
 import { useDocsSearchController } from '@/components/docs-search-provider';
 
 // Assistant links must reference the production origin: a preview or localhost
@@ -75,7 +76,7 @@ export function CopyPageMenu({ markdownPath }: { markdownPath: string }) {
     try {
       const response = await fetch(markdownPath);
       if (!response.ok) throw new Error(`${response.status}`);
-      await navigator.clipboard.writeText(await response.text());
+      if (!(await copyToClipboard(await response.text()))) throw new Error('copy failed');
       setCopied(true);
       window.clearTimeout(resetTimer.current);
       resetTimer.current = window.setTimeout(() => setCopied(false), 2000);

--- a/components/copy-page.tsx
+++ b/components/copy-page.tsx
@@ -1,24 +1,77 @@
 'use client';
 
-import { useRef, useState } from 'react';
-import { Check, ChevronDown, Copy, ExternalLink, FileText } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Check, ChevronDown, Copy, FileText, MessageSquare } from 'lucide-react';
 import { toast } from 'sonner';
 import { captureDocsEvent } from '@/lib/docs-analytics';
+import { useDocsSearchController } from '@/components/docs-search-provider';
 
 // Assistant links must reference the production origin: a preview or localhost
 // URL is unreachable from the assistant's fetcher.
 const SITE_ORIGIN = 'https://axiom.co';
 
+// Monochrome brand marks (currentColor). Anthropic + OpenAI from simple-icons;
+// Grok from svgl. External AI links open the page as context in that tool.
+function ClaudeIcon() {
+  return (
+    <svg className="copy-page-brand" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    </svg>
+  );
+}
+function ChatGptIcon() {
+  return (
+    <svg className="copy-page-brand" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+function GrokIcon() {
+  return (
+    <svg className="copy-page-brand" viewBox="0 0 1024 1024" fill="currentColor" aria-hidden="true">
+      <path d="M395.479 633.828L735.91 381.105C752.599 368.715 776.454 373.548 784.406 392.792C826.26 494.285 807.561 616.253 724.288 699.996C641.016 783.739 525.151 802.104 419.247 760.277L303.556 814.143C469.49 928.202 670.987 899.995 796.901 773.282C896.776 672.843 927.708 535.937 898.785 412.476L899.047 412.739C857.105 231.37 909.358 158.874 1016.4 10.6326C1018.93 7.11771 1021.47 3.60279 1024 0L883.144 141.651V141.212L395.392 633.916" />
+      <path d="M325.226 695.251C206.128 580.84 226.662 403.776 328.285 301.668C403.431 226.097 526.549 195.254 634.026 240.596L749.454 186.994C728.657 171.88 702.007 155.623 671.424 144.2C533.19 86.9942 367.693 115.465 255.323 228.382C147.234 337.081 113.244 504.215 171.613 646.833C215.216 753.423 143.739 828.818 71.7385 904.916C46.2237 931.893 20.6216 958.87 0 987.429L325.139 695.339" />
+    </svg>
+  );
+}
+
 export function CopyPageMenu({ markdownPath }: { markdownPath: string }) {
   const menu = useRef<HTMLDetailsElement>(null);
   const resetTimer = useRef<number | undefined>(undefined);
   const [copied, setCopied] = useState(false);
+  const { openAssistant } = useDocsSearchController();
 
   const markdownUrl = `${SITE_ORIGIN}${markdownPath}`;
   const assistantPrompt = encodeURIComponent(`Read ${markdownUrl} so I can ask questions about it.`);
 
-  async function copyPage() {
+  function closeMenu() {
     menu.current?.removeAttribute('open');
+  }
+
+  // Native <details> only closes on summary click; dismiss it on an outside
+  // pointer or Escape like a real menu, returning focus to the trigger.
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      const el = menu.current;
+      if (el?.open && !el.contains(event.target as Node)) el.removeAttribute('open');
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      const el = menu.current;
+      if (event.key === 'Escape' && el?.open) {
+        el.removeAttribute('open');
+        el.querySelector<HTMLElement>('summary')?.focus();
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  async function copyPage() {
+    closeMenu();
     try {
       const response = await fetch(markdownPath);
       if (!response.ok) throw new Error(`${response.status}`);
@@ -32,26 +85,51 @@ export function CopyPageMenu({ markdownPath }: { markdownPath: string }) {
     }
   }
 
-  function chooseAction(action: 'view_markdown' | 'open_chatgpt' | 'open_claude' | 'open_perplexity') {
-    menu.current?.removeAttribute('open');
+  function askAiAboutPage() {
+    closeMenu();
+    captureDocsEvent('docs_page_context_action', { action: 'ask_ai' });
+    openAssistant('', 'copy_page_menu');
+  }
+
+  function chooseAction(action: 'view_markdown' | 'open_claude' | 'open_chatgpt' | 'open_grok') {
+    closeMenu();
     captureDocsEvent('docs_page_context_action', { action });
   }
 
   return (
     <div className="copy-page">
       <button type="button" className="copy-page-main" onClick={copyPage}>
-        {copied ? <Check size={13} /> : <Copy size={13} />}
+        {copied ? <Check size={14} /> : <Copy size={14} />}
         <span>{copied ? 'Copied' : 'Copy page'}</span>
       </button>
       <details className="copy-page-menu" ref={menu}>
-        <summary role="button" aria-haspopup="menu" aria-label="More page actions"><ChevronDown size={13} /></summary>
+        <summary role="button" aria-haspopup="menu" aria-label="More page actions"><ChevronDown size={14} /></summary>
         <div className="copy-page-popover" role="menu" aria-label="Page actions">
-          <button type="button" role="menuitem" onClick={copyPage}><Copy size={13} /><span>Copy page as Markdown</span></button>
-          <a role="menuitem" href={markdownPath} target="_blank" rel="noreferrer" onClick={() => chooseAction('view_markdown')}><FileText size={13} /><span>View as Markdown</span></a>
+          <button type="button" role="menuitem" onClick={copyPage}>
+            <Copy size={15} />
+            <span><strong>Copy page</strong><small>Copy this page as Markdown for LLMs</small></span>
+          </button>
+          <a role="menuitem" href={markdownPath} target="_blank" rel="noreferrer" onClick={() => chooseAction('view_markdown')}>
+            <FileText size={15} />
+            <span><strong>View as Markdown</strong><small>Open this page as plain text</small></span>
+          </a>
+          <button type="button" role="menuitem" onClick={askAiAboutPage}>
+            <MessageSquare size={15} />
+            <span><strong>Ask AI about this page</strong><small>Chat with this page as context</small></span>
+          </button>
           <hr />
-          <a role="menuitem" href={`https://chatgpt.com/?hints=search&q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_chatgpt')}><ExternalLink size={13} /><span>Open in ChatGPT</span></a>
-          <a role="menuitem" href={`https://claude.ai/new?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_claude')}><ExternalLink size={13} /><span>Open in Claude</span></a>
-          <a role="menuitem" href={`https://www.perplexity.ai/search?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_perplexity')}><ExternalLink size={13} /><span>Open in Perplexity</span></a>
+          <a role="menuitem" href={`https://claude.ai/new?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_claude')}>
+            <ClaudeIcon />
+            <span><strong>Open in Claude</strong><small>Ask Claude about this page</small></span>
+          </a>
+          <a role="menuitem" href={`https://chatgpt.com/?hints=search&q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_chatgpt')}>
+            <ChatGptIcon />
+            <span><strong>Open in ChatGPT</strong><small>Ask ChatGPT about this page</small></span>
+          </a>
+          <a role="menuitem" href={`https://grok.com/?q=${assistantPrompt}`} target="_blank" rel="noreferrer" onClick={() => chooseAction('open_grok')}>
+            <GrokIcon />
+            <span><strong>Open in Grok</strong><small>Ask Grok about this page</small></span>
+          </a>
         </div>
       </details>
     </div>

--- a/components/heading-anchor.tsx
+++ b/components/heading-anchor.tsx
@@ -10,10 +10,11 @@ export function HeadingAnchor({ as: Heading, children, id, className, ...props }
     event.preventDefault();
     if (!id) return;
 
+    // Copy the deep link and reflect it in the URL bar without scrolling the
+    // page (replaceState does not scroll, unlike assigning location.hash).
     const url = new URL(window.location.href);
     url.hash = id;
     window.history.replaceState(null, '', url);
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
     try {
       await navigator.clipboard.writeText(url.href);

--- a/components/heading-anchor.tsx
+++ b/components/heading-anchor.tsx
@@ -2,6 +2,7 @@
 
 import type { HTMLAttributes, MouseEvent, ReactNode } from 'react';
 import { toast } from 'sonner';
+import { copyToClipboard } from '@/lib/clipboard';
 
 type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
@@ -16,10 +17,9 @@ export function HeadingAnchor({ as: Heading, children, id, className, ...props }
     url.hash = id;
     window.history.replaceState(null, '', url);
 
-    try {
-      await navigator.clipboard.writeText(url.href);
+    if (await copyToClipboard(url.href)) {
       toast.success('Link copied', { description: `#${id}` });
-    } catch {
+    } else {
       toast.error('Couldn’t copy link');
     }
   }

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -2,6 +2,7 @@
 
 import { ZoneLink as Link } from '@/components/zone-link';
 import { usePathname } from 'next/navigation';
+import { withDocsBasePath } from '@/lib/docs-paths';
 import { useTheme } from 'next-themes';
 import { Check, Menu, Monitor, Moon, Search, Sun, X } from 'lucide-react';
 import { useRef, useSyncExternalStore } from 'react';
@@ -23,7 +24,9 @@ function AxiomMark() {
 }
 
 export function DocumentationSections({ className = 'header-tabs', onNavigate }: { className?: string; onNavigate?: () => void }) {
-  const pathname = usePathname();
+  // usePathname() strips the /docs basePath, but the tab matchers below expect
+  // the full /docs-prefixed path — normalize it the same way the sidebar does.
+  const pathname = withDocsBasePath(usePathname());
 
   return (
     <nav className={className} aria-label="Documentation sections">

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -1,0 +1,33 @@
+// navigator.clipboard is only defined in a secure context (HTTPS or localhost).
+// Docs are frequently viewed over http://<hostname> on a LAN/tailnet, where the
+// Clipboard API is undefined and writeText throws. Fall back to a temporary
+// <textarea> + execCommand('copy') so every copy control still works there.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path below
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand('copy');
+    textarea.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/lib/docs-analytics.ts
+++ b/lib/docs-analytics.ts
@@ -9,7 +9,8 @@ export type AssistantEntryPoint =
   | 'mode_tab'
   | 'search_handoff'
   | 'search_empty_state'
-  | 'search_footer';
+  | 'search_footer'
+  | 'copy_page_menu';
 
 type DurationBucket = 'under_250ms' | '250ms_to_1s' | '1s_to_3s' | '3s_to_10s' | 'over_10s';
 type StatusClass = '2xx' | '3xx' | '4xx' | '5xx' | 'unknown';
@@ -57,7 +58,7 @@ type DocsAnalyticsEvents = {
   };
   docs_example_customized: { field_name: ExampleField };
   docs_page_context_action: {
-    action: 'copy_markdown' | 'view_markdown' | 'open_chatgpt' | 'open_claude' | 'open_perplexity';
+    action: 'copy_markdown' | 'view_markdown' | 'ask_ai' | 'open_claude' | 'open_chatgpt' | 'open_grok';
   };
   docs_playground_opened: Record<string, never>;
   docs_console_opened: { placement: 'header' };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -18,6 +18,7 @@
   --gray-200: #e5e5e5;
   --gray-300: #d4d4d4;
   --gray-400: #a3a3a3;
+  --gray-450: #858585;
   --gray-500: #737373;
   --gray-600: #525252;
   --gray-700: #404040;
@@ -106,7 +107,7 @@
   --text-primary:    var(--gray-50);   /* fafafa */
   --text-secondary:  var(--gray-200);
   --text-tertiary:   var(--gray-400);
-  --text-quaternary: var(--gray-500);
+  --text-quaternary: var(--gray-450);  /* >=4.5:1 on canvas/surface (was gray-500, 4.18) */
   --text-on-inverse-primary:    var(--gray-950);
   --text-on-inverse-secondary:  var(--gray-800);
   --text-on-inverse-tertiary:   var(--gray-600);
@@ -134,6 +135,8 @@
   --color-warning:      var(--amber-500);
   --color-info:         var(--blue-500);
   --color-accent:       var(--orange-500);
+  --color-accent-text:  var(--orange-500);   /* accent used as text/fill — 5.23:1 on dark canvas */
+  --color-warning-text: var(--amber-500);    /* amber used as text (REQUIRED markers) — 9.22:1 on dark */
 
   color-scheme: dark;
 }
@@ -157,8 +160,8 @@
 
   --text-primary:    var(--gray-950);
   --text-secondary:  var(--gray-700);
-  --text-tertiary:   var(--gray-500);
-  --text-quaternary: var(--gray-400);
+  --text-tertiary:   var(--gray-600);  /* 7.49:1 (was gray-500, 4.54 borderline) */
+  --text-quaternary: var(--gray-500);  /* 4.54:1 (was gray-400, 2.42 — AA fail) */
   --text-on-inverse-primary:    var(--gray-50);
   --text-on-inverse-secondary:  var(--gray-200);
   --text-on-inverse-tertiary:   var(--gray-400);
@@ -175,6 +178,9 @@
   --icon-secondary:  var(--gray-500);
   --icon-tertiary:   var(--gray-400);
   --icon-quaternary: var(--gray-300);
+
+  --color-accent-text: #b8461d;    /* darkened accent for text/fill on light — 5.12:1 (brand orange is only 3.63) */
+  --color-warning-text: #92400e;   /* darkened amber for text on light — 6.06:1 on inert (amber-500 is only 2.06) */
 
   color-scheme: light;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -89,11 +89,12 @@
 :root,
 :root[data-theme="dark"] {
   /* Background layers */
-  --bg-canvas:   var(--gray-950);   /* page bg */
-  --bg-surface:  var(--gray-900);   /* card / sidebar */
+  --bg-canvas:   var(--gray-950);   /* page bg + reading column */
+  --bg-surface:  var(--gray-900);   /* card / code / contained content */
   --bg-raised:   var(--gray-850);   /* hovered surface / nested card */
   --bg-overlay:  var(--gray-800);   /* popover / dialog */
   --bg-inert:    var(--white-a3);   /* subtle field bg */
+  --bg-sidebar:  var(--black);      /* recessed nav rail — sits below canvas */
 
   /* Emphasis backgrounds (overlay tints) */
   --bg-emph-primary:    var(--white-a6);
@@ -150,6 +151,7 @@
   --bg-raised:   var(--gray-50);
   --bg-overlay:  var(--white);
   --bg-inert:    var(--black-a3);
+  --bg-sidebar:  var(--gray-100);   /* recessed nav rail — sits below canvas */
 
   --bg-emph-primary:    var(--black-a6);
   --bg-emph-secondary:  var(--black-a4);


### PR DESCRIPTION
- Fix WCAG AA contrast failures in the neutral text ramp (quaternary in both themes, light tertiary) and add theme-aware --color-accent-text / --color-warning-text; method badges and REQUIRED markers now clear AA on the light tint.
- Lift the reading column and nav type scale: body 16px, sidebar/header 14px, TOC 13px, code 13px, prose tables 14px; 768px article measure.
- Callouts render as sans prose with a soft radius; table-cell code drops its chip and inherits the cell size.
- Rebuild the Copy page menu (Vercel-style two-line items): native 'Ask AI about this page', plus Claude/ChatGPT/Grok deep links with mono brand marks; Axiom focus rings and outside-click/Escape dismissal.
- Update DESIGN.md to match.