### PR TITLE
Docs polish: readable links, keys, and text selection

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -354,6 +354,10 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
 .doc-article .prose :where(p, li, td, dd) a:not(.playground-link):hover { text-decoration-color: var(--color-accent); }
 .doc-article .prose a:focus-visible { border-radius: 2px; outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .doc-article .prose :not(pre) > code { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 4px; background: var(--bg-inert); font-family: var(--font-mono); font-size: .84em; }
+/* Override Tailwind Typography's default keycap kbd (tiny .875em text, low
+   contrast, heavy 0 3px raised-key shadow that made keys read small and sit
+   below the baseline). Flatter, more legible, vertically centred with the text. */
+.doc-article .prose kbd { padding: 1px 6px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-emph-tertiary); box-shadow: 0 1px 0 var(--border-strong); color: var(--text-secondary); font: 500 12px/18px var(--font-mono); vertical-align: baseline; }
 /* Multi-line code in the reading column tracks the body bump: 12px -> 13px. */
 .doc-article .prose pre, .doc-article .prose pre code { font-size: 13px; line-height: 21px; }
 .doc-article figure[data-rehype-pretty-code-figure], .doc-article figure.shiki, .doc-article .fd-codeblock { border-color: var(--border-primary); border-radius: 4px !important; background: var(--bg-surface); box-shadow: none !important; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -350,7 +350,7 @@ kbd { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 
    click copies the link without leaving the marker stuck on afterwards. */
 .anchor-heading:hover .anchor-hash, .anchor-heading:has(a:focus-visible) .anchor-hash { opacity: 1; transform: translateX(0); }
 .doc-article .prose a { text-decoration-color: var(--border-strong); text-underline-offset: 3px; }
-.doc-article .prose :where(p, li, td, dd) a:not(.playground-link) { color: var(--text-primary); text-decoration-line: underline; text-decoration-color: var(--text-quaternary); }
+.doc-article .prose :where(p, li, td, dd) a:not(.playground-link) { color: var(--text-primary); text-decoration-line: underline; text-decoration-color: color-mix(in oklab, var(--text-primary) 30%, transparent); }
 .doc-article .prose :where(p, li, td, dd) a:not(.playground-link):hover { text-decoration-color: var(--color-accent); }
 .doc-article .prose a:focus-visible { border-radius: 2px; outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .doc-article .prose :not(pre) > code { border: 1px solid var(--border-primary); border-radius: 3px; padding: 1px 4px; background: var(--bg-inert); font-family: var(--font-mono); font-size: .84em; }

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -15,12 +15,20 @@ import { PlaceholderPre as InteractivePlaceholderPre } from './placeholder-code'
 import { HeadingAnchor } from './heading-anchor';
 import { LanguageComparisons } from './language-comparisons';
 
+// play.axiom.co links come in two shapes: runnable APL query links
+// (…/query?initForm=…) that render as the compact "Run in Playground" button
+// beside a code block, and plain prose links to the demo homepage, which should
+// render as ordinary text links rather than a stray mono pill.
+function isPlaygroundQueryLink(href: string): boolean {
+  return href.startsWith('https://play.axiom.co/') && href.includes('/query');
+}
+
 // Content retains root-relative paths from the Mintlify layout. Pages and public assets both live
 // in this app's /docs zone, so normalize them before handing navigation to Next.js.
 function DocsLink({ href = '', children, className, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   const target = withoutDocsBasePath(href);
   if (target.startsWith('/') || target.startsWith('#')) return <ZoneLink href={target} prefetch={false} className={className} {...props}>{children}</ZoneLink>;
-  if (target.startsWith('https://play.axiom.co/')) {
+  if (isPlaygroundQueryLink(target)) {
     return <PlaygroundLink href={target} className={className} {...props}>{children}</PlaygroundLink>;
   }
   return <a href={target} className={className} {...props}>{children}</a>;
@@ -90,7 +98,7 @@ function Tabs({ children }: { children: ReactNode }) {
 function containsPlaygroundLink(node: ReactNode): boolean {
   if (!isValidElement(node)) return false;
   const props = node.props as { children?: ReactNode; href?: string };
-  if (props.href?.startsWith('https://play.axiom.co/')) return true;
+  if (props.href && isPlaygroundQueryLink(props.href)) return true;
   return Children.toArray(props.children).some(containsPlaygroundLink);
 }
 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -355,4 +355,4 @@ a:hover { text-decoration-color: var(--text-primary); }
 
 hr { border: 0; border-top: 1px solid var(--border-primary); margin: var(--space-4) 0; }
 
-::selection { background: color-mix(in oklab, var(--color-accent) 60%, transparent); color: var(--text-primary); }
+::selection { background: color-mix(in oklab, #ff7a2e 88%, transparent); color: var(--text-primary); }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -355,4 +355,4 @@ a:hover { text-decoration-color: var(--text-primary); }
 
 hr { border: 0; border-top: 1px solid var(--border-primary); margin: var(--space-4) 0; }
 
-::selection { background: color-mix(in oklab, var(--color-selected) 50%, transparent); color: var(--text-primary); }
+::selection { background: color-mix(in oklab, var(--color-accent) 60%, transparent); color: var(--text-primary); }


### PR DESCRIPTION
Small readability/polish pass on the docs, driven by review feedback.

## Changes

**Links**
- Soften prose link underlines: they now render at ~30% of the text colour instead of a solid quaternary grey, so they read as a subtle hint rather than a second line of text (hover still shifts to the orange accent).

**Text selection**
- Selection highlight is now a bright `#ff7a2e` orange to match the site theme. The earlier attempt layered the burnt brand accent (`#da5c2b`) over the dark canvas, which only ever read duller as opacity rose — brightness comes from the base colour, not the alpha.

**Keyboard keys (`kbd`)**
- Prose `<kbd>` was inheriting Tailwind Typography's default keycap style: `.875em` text (small, low-contrast) and a double box-shadow with a heavy `0 3px 0` raised-key edge that made keys look tiny and sit below the baseline. Added a `.doc-article .prose kbd` override — 12px legible mono, higher contrast, soft `0 1px 0` shadow, centred with the text. Verified in light and dark.

**Playground links**
- `DocsLink` was turning *every* `play.axiom.co` link into the compact "Run in Playground" mono pill, including plain prose links to the demo homepage (e.g. on the introduction page), which looked like a stray tiny codeblock. Narrowed it so only runnable `…/query?…` links become pills; ordinary demo links are normal text links again. The real APL "Run in Playground" buttons are unaffected.

## Verification
- `pnpm typecheck` and `eslint` pass.
- Selection, kbd, and both link changes checked in light and dark themes via a local dev server.