### PR TITLE
docs: remove otel.metric.unit tag, document unit display on Datasets tab

### DIFF
--- a/content/docs/(documentation)/query-data/datasets.mdx
+++ b/content/docs/(documentation)/query-data/datasets.mdx
@@ -56,8 +56,6 @@ Axiom displays the unit of a metric in one of the following ways:
 - Units in curly braces are values that Axiom doesn’t translate. These are UCUM annotations like `{requests}` or unit values that aren’t valid UCUM units. Axiom displays the value inside braces as it was ingested.
 - Empty braces (`{}`) mean that unit information isn’t available for the metric. This happens when the metric was ingested without a unit or when the unit of the metric isn’t consistent within the selected time range.
 
-To display the unit value exactly as it was ingested, hold the pointer over the unit.
-
 ### Edit field
 
 To edit a field:

--- a/content/docs/(documentation)/query-data/datasets.mdx
+++ b/content/docs/(documentation)/query-data/datasets.mdx
@@ -46,6 +46,18 @@ On the right, you see the following:
 - [Saved queries](#saved-queries)
 - [Query history](#query-history)
 
+### Explore metrics datasets
+
+When you select a metrics dataset, Axiom displays the list of metrics in the dataset instead of a list of fields. Each row displays the type, the name, and the unit of the metric.
+
+Axiom displays the unit of a metric in one of the following ways:
+
+- Units without braces are standard [UCUM](https://ucum.org/) units that Axiom recognizes and displays as readable labels. For example, a metric ingested with the unit `By` appears as `bytes`, and a metric ingested with the unit `ms` appears as `milliseconds`. The dimensionless unit `1` appears as `dimensionless`.
+- Units in curly braces are values that Axiom doesn’t translate. These are UCUM annotations like `{requests}` or unit values that aren’t valid UCUM units. Axiom displays the value inside braces as it was ingested.
+- Empty braces (`{}`) mean that unit information isn’t available for the metric. This happens when the metric was ingested without a unit or when the unit of the metric isn’t consistent within the selected time range.
+
+To display the unit value exactly as it was ingested, hold the pointer over the unit.
+
 ### Edit field
 
 To edit a field:

--- a/content/docs/(documentation)/query-data/metrics.mdx
+++ b/content/docs/(documentation)/query-data/metrics.mdx
@@ -138,7 +138,6 @@ MetricsDB applies the following transformations to improve query performance and
 
 - **Timestamp precision**: Truncate nanosecond timestamps to second precision. MetricsDB is built for use cases where second-level granularity is sufficient, and this optimization significantly improves compression ratios and query speed.
 - **Unified tag namespace**: Flatten resource, scope, and metric tags into a single namespace. This simplification makes queries more straightforward and enables faster dimensional filtering. You don’t need to remember which tags came from which scope.
-- **Unit metadata**: Store the `unit` attribute of each metric as metadata instead of as a tag. To inspect the unit of a metric, use the Datasets tab. For more information, see [Explore metrics datasets](/query-data/datasets#explore-metrics-datasets).
 - **Histogram handling**: Assume equal-width histograms and don’t preserve histogram metadata. This trade-off supports the most common histogram analysis patterns (percentiles, distribution visualization) while reducing storage requirements.
 
 These design choices reflect real-world metrics usage patterns. If your use case requires capabilities not currently supported, [contact Axiom](https://axiom.co/contact) to discuss your requirements. Your feedback helps shape MetricsDB’s evolution.

--- a/content/docs/(documentation)/query-data/metrics.mdx
+++ b/content/docs/(documentation)/query-data/metrics.mdx
@@ -138,7 +138,7 @@ MetricsDB applies the following transformations to improve query performance and
 
 - **Timestamp precision**: Truncate nanosecond timestamps to second precision. MetricsDB is built for use cases where second-level granularity is sufficient, and this optimization significantly improves compression ratios and query speed.
 - **Unified tag namespace**: Flatten resource, scope, and metric tags into a single namespace. This simplification makes queries more straightforward and enables faster dimensional filtering. You don’t need to remember which tags came from which scope.
-- **Unit normalization**: Convert the `unit` attribute to `otel.metric.unit` for consistent handling across all metric types.
+- **Unit metadata**: Store the `unit` attribute of each metric as metadata instead of as a tag. To inspect the unit of a metric, use the Datasets tab. For more information, see [Explore metrics datasets](/query-data/datasets#explore-metrics-datasets).
 - **Histogram handling**: Assume equal-width histograms and don’t preserve histogram metadata. This trade-off supports the most common histogram analysis patterns (percentiles, distribution visualization) while reducing storage requirements.
 
 These design choices reflect real-world metrics usage patterns. If your use case requires capabilities not currently supported, [contact Axiom](https://axiom.co/contact) to discuss your requirements. Your feedback helps shape MetricsDB’s evolution.


### PR DESCRIPTION
## Overview

MetricsDB is stopping returning the synthetic `otel.metric.unit` tag, so this deletes the only mention of it in the docs — the **Unit normalization** bullet in the metrics data-model section.

It also adds an **Explore metrics datasets** section to the Datasets overview page (which previously only covered event datasets), documenting how the Datasets tab displays each metric's unit:

- No braces — recognized UCUM units, shown as readable labels (`By` → `bytes`, `ms` → `milliseconds`, `1` → `dimensionless`)
- Curly braces — UCUM annotations (`{requests}`) and non-UCUM text, shown as ingested
- Empty braces `{}` — no unit information (not ingested, or inconsistent within the selected time range)


## Testing

- `pnpm audit:content` passes: no unresolved links or missing assets
- The `browser` e2e job failure is pre-existing on `main` (red since #691, CSS-assertion tests not updated for the readability polish) and unrelated to this content-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

