### PR TITLE
docs: document the Splunk HEC edge ingest API

### DIFF
--- a/content/docs/(api-reference)/restapi/endpoints/getHecHealth.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/getHecHealth.mdx
@@ -1,0 +1,14 @@
+---
+title: Check Splunk HEC health
+openapi: "v1-edge-hec get /services/collector/health"
+---
+
+import BaseDomains from "@/content/snippets/base-domains.mdx"
+
+<Warning>
+Use this endpoint to check whether the Splunk HTTP Event Collector (HEC) compatible API is available. No authentication is required. For more information, see [Send data using the Splunk HEC API](/send-data/splunk-hec).
+
+The base domain for this endpoint is `hec.` prefixed to the base domain of your edge deployment. For example, if your edge deployment’s base domain is `us-east-1.aws.edge.axiom.co`, the HEC endpoint is `https://hec.us-east-1.aws.edge.axiom.co`.
+
+<BaseDomains />
+</Warning>

--- a/content/docs/(api-reference)/restapi/endpoints/ingestHecEvent.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/ingestHecEvent.mdx
@@ -1,0 +1,16 @@
+---
+title: Ingest Splunk HEC events
+openapi: "v1-edge-hec post /services/collector/event"
+---
+
+import BaseDomains from "@/content/snippets/base-domains.mdx"
+
+<Warning>
+Use this endpoint to ingest events through the Splunk HTTP Event Collector (HEC) compatible API. For a walkthrough, see [Send data using the Splunk HEC API](/send-data/splunk-hec).
+
+The base domain for this endpoint is `hec.` prefixed to the base domain of your edge deployment. For example, if your edge deployment’s base domain is `us-east-1.aws.edge.axiom.co`, the HEC endpoint is `https://hec.us-east-1.aws.edge.axiom.co`.
+
+<BaseDomains />
+
+This endpoint only supports API tokens. Personal access tokens (PATs) aren't supported. For more information, see [Tokens](/reference/tokens).
+</Warning>

--- a/content/docs/(api-reference)/restapi/endpoints/ingestHecRaw.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/ingestHecRaw.mdx
@@ -1,0 +1,16 @@
+---
+title: Ingest raw Splunk HEC events
+openapi: "v1-edge-hec post /services/collector/raw"
+---
+
+import BaseDomains from "@/content/snippets/base-domains.mdx"
+
+<Warning>
+Use this endpoint to ingest raw payloads through the Splunk HTTP Event Collector (HEC) compatible API. For a walkthrough, see [Send data using the Splunk HEC API](/send-data/splunk-hec).
+
+The base domain for this endpoint is `hec.` prefixed to the base domain of your edge deployment. For example, if your edge deployment’s base domain is `us-east-1.aws.edge.axiom.co`, the HEC endpoint is `https://hec.us-east-1.aws.edge.axiom.co`.
+
+<BaseDomains />
+
+This endpoint only supports API tokens. Personal access tokens (PATs) aren't supported. For more information, see [Tokens](/reference/tokens).
+</Warning>

--- a/content/docs/(api-reference)/restapi/versions/v1-edge-hec.json
+++ b/content/docs/(api-reference)/restapi/versions/v1-edge-hec.json
@@ -1,0 +1,365 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Splunk HTTP Event Collector (HEC) compatible ingest API, served from the edge deployment.",
+    "title": "Axiom HEC",
+    "termsOfService": "http://axiom.co/terms",
+    "contact": {
+      "name": "Axiom support team",
+      "url": "https://axiom.co",
+      "email": "hello@axiom.co"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://hec.{axiom-domain}/"
+    }
+  ],
+  "paths": {
+    "/services/collector/event": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "ingest|create"
+            ]
+          }
+        ],
+        "tags": [
+          "hec"
+        ],
+        "operationId": "ingestHecEvent",
+        "summary": "Ingest Splunk HEC events",
+        "description": "Ingest one or more Splunk HEC event envelopes. Bodies may contain multiple envelopes, concatenated or newline-delimited. The target dataset is resolved from the `index` query parameter, then the `index` field of the first event, then the dataset the token is scoped to when it grants ingest access to exactly one dataset.",
+        "parameters": [
+          {
+            "description": "The dataset (Splunk index) to ingest into. Overrides the `index` field in the event envelope.",
+            "name": "index",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HecEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The events were accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request could not be processed. The `code` field identifies the Splunk error: `5` (no data), `6` (invalid data format), or `7` (incorrect index).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-limit-requests": true,
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/services/collector": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "ingest|create"
+            ]
+          }
+        ],
+        "tags": [
+          "hec"
+        ],
+        "operationId": "ingestHecCollector",
+        "summary": "Ingest Splunk HEC events (alias)",
+        "description": "Alias of `/services/collector/event`. Accepts the same event envelopes and parameters.",
+        "parameters": [
+          {
+            "description": "The dataset (Splunk index) to ingest into. Overrides the `index` field in the event envelope.",
+            "name": "index",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HecEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The events were accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request could not be processed. The `code` field identifies the Splunk error: `5` (no data), `6` (invalid data format), or `7` (incorrect index).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-limit-requests": true,
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/services/collector/raw": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "ingest|create"
+            ]
+          }
+        ],
+        "tags": [
+          "hec"
+        ],
+        "operationId": "ingestHecRaw",
+        "summary": "Ingest raw Splunk HEC events",
+        "description": "Ingest a raw payload. Each line of a `text/plain` body becomes an event; JSON bodies are also accepted. Event metadata is supplied through query parameters rather than an envelope.",
+        "parameters": [
+          {
+            "description": "The dataset (Splunk index) to ingest into.",
+            "name": "index",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The sourcetype to attach to every event in the request.",
+            "name": "sourcetype",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The source to attach to every event in the request.",
+            "name": "source",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The host to attach to every event in the request.",
+            "name": "host",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "description": "Raw event data. Each line becomes a separate event.",
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "description": "A JSON payload to ingest as a single event.",
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The events were accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request could not be processed. The `code` field identifies the Splunk error: `5` (no data), `6` (invalid data format), or `7` (incorrect index).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-limit-requests": true,
+        "x-axiom-not-suspended": true
+      }
+    },
+    "/services/collector/health": {
+      "get": {
+        "security": [],
+        "tags": [
+          "hec"
+        ],
+        "operationId": "getHecHealth",
+        "summary": "Check HEC health",
+        "description": "Report whether the collector is available and accepting data. No authentication is required. A healthy collector responds with HEC code `17`.",
+        "responses": {
+          "200": {
+            "description": "The collector is healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/services/collector/health/1.0": {
+      "get": {
+        "security": [],
+        "tags": [
+          "hec"
+        ],
+        "operationId": "getHecHealthVersioned",
+        "summary": "Check HEC health (versioned)",
+        "description": "Versioned alias of `/services/collector/health`. No authentication is required.",
+        "responses": {
+          "200": {
+            "description": "The collector is healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HecStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "Auth": {
+        "description": "Authenticate using an API token with ingest permission. HEC clients typically send the token in the Splunk scheme: `Authorization: Splunk <token>`. The Bearer scheme (`Authorization: Bearer <token>`) and HTTP Basic (`x:<token>`) are also accepted. For more information, see [Tokens](/reference/tokens).",
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+            "scopes": {}
+          }
+        }
+      }
+    },
+    "schemas": {
+      "HecEvent": {
+        "description": "A Splunk HEC event envelope.",
+        "type": "object",
+        "properties": {
+          "event": {
+            "description": "The event payload. When an object, its keys become top-level fields of the Axiom event. When a string, it is stored in the `_raw` field.",
+            "example": {
+              "message": "hello from HEC",
+              "severity": "INFO"
+            }
+          },
+          "fields": {
+            "description": "Additional fields merged into the event.",
+            "type": "object"
+          },
+          "time": {
+            "description": "The event timestamp, as epoch seconds, epoch milliseconds, or an RFC 3339 string. When omitted, Axiom assigns the ingest time.",
+            "example": "2024-01-07T12:00:00Z"
+          },
+          "index": {
+            "description": "The dataset (Splunk index) to ingest into. The `index` query parameter takes precedence.",
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "sourcetype": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "event": {
+            "message": "hello from HEC",
+            "severity": "INFO"
+          },
+          "sourcetype": "httpevent"
+        }
+      },
+      "HecStatus": {
+        "description": "The Splunk HEC status envelope.",
+        "type": "object",
+        "required": [
+          "text",
+          "code"
+        ],
+        "properties": {
+          "text": {
+            "description": "A human-readable status message.",
+            "type": "string",
+            "example": "Success"
+          },
+          "code": {
+            "description": "The Splunk status code. `0` indicates success, `17` indicates a healthy collector, and `5`, `6`, and `7` indicate no data, invalid data format, and incorrect index respectively.",
+            "type": "integer",
+            "example": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/content/docs/(documentation)/send-data/methods.mdx
+++ b/content/docs/(documentation)/send-data/methods.mdx
@@ -68,6 +68,7 @@ To send events continuously, Axiom supports a wide range of standard tools, libr
 | [Secure Syslog](/send-data/secure-syslog) | TLS-encrypted syslog forwarding |
 | [Serverless](/send-data/serverless) | Best practices for serverless environments |
 | [Splunk](/endpoints/splunk) | Compatible endpoint for Splunk forwarders |
+| [Splunk HEC](/send-data/splunk-hec) | HTTP Event Collector compatible API on your edge deployment |
 | [StatsD](/send-data/statsd) | Send StatsD metrics through the OpenTelemetry Collector |
 | [Syslog Proxy](/send-data/syslog-proxy) | Forward syslog data with transformation |
 | [Traefik](/send-data/traefik) | Scrape Traefik metrics with the OpenTelemetry Collector |

--- a/content/docs/(documentation)/send-data/splunk-hec.mdx
+++ b/content/docs/(documentation)/send-data/splunk-hec.mdx
@@ -1,0 +1,122 @@
+---
+title: 'Send data to Axiom using the Splunk HEC API'
+description: 'This page explains how to send data to Axiom through the Splunk HTTP Event Collector (HEC) compatible API.'
+overview: 'Splunk-compatible HTTP Event Collector endpoint for ingesting events'
+sidebarTitle: Splunk HEC
+keywords: ['splunk', 'hec', 'http event collector', 'axiom documentation', 'documentation', 'axiom', 'logs', 'ingest']
+---
+
+import Prerequisites from "@/content/snippets/standard-prerequisites.mdx"
+import ReplaceDomain from "@/content/snippets/replace-domain.mdx"
+
+Axiom offers a Splunk [HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) compatible API so you can send events from Splunk forwarders, the OpenTelemetry `splunk_hec` exporter, and any other HEC client without changing your existing tooling.
+
+The HEC API is served from a dedicated host on your edge deployment: `hec.AXIOM_DOMAIN`. For example, if your edge deployment’s base domain is `us-east-1.aws.edge.axiom.co`, the HEC endpoint is `https://hec.us-east-1.aws.edge.axiom.co`.
+
+<Prerequisites />
+
+<Info>
+<ReplaceDomain />
+The HEC endpoints are hosted at `hec.AXIOM_DOMAIN`, a dedicated subdomain of your edge deployment’s base domain.
+</Info>
+
+## Authentication
+
+Authenticate every request with an Axiom [API token](/reference/tokens) that has permission to ingest into the target dataset. The HEC API accepts the token in any of the following schemes:
+
+| Scheme | Header |
+| :--- | :--- |
+| Splunk (default HEC clients) | `Authorization: Splunk API_TOKEN` |
+| Bearer | `Authorization: Bearer API_TOKEN` |
+| Basic | `Authorization: Basic <base64 of x:API_TOKEN>` (for example, `curl -u x:API_TOKEN`) |
+
+Requests without a valid token are rejected with `401 Unauthorized` (missing token) or `403 Forbidden` (token not permitted for the dataset).
+
+## Choose the target dataset
+
+In Splunk, events are routed by `index`. Axiom maps the HEC `index` to an Axiom [dataset](/reference/datasets) and resolves it in the following order:
+
+1. The `index` query parameter, for example `?index=DATASET_NAME`.
+2. The `index` field inside the event envelope.
+3. The dataset the API token is scoped to, when the token grants ingest access to exactly one dataset.
+
+If none of these resolve to a dataset, the request is rejected with HEC code `7` (Incorrect index).
+
+## Send events
+
+Send JSON events to `/services/collector/event`. The bare `/services/collector` path is an alias of the event endpoint. Each request body is one or more HEC event envelopes, which may be concatenated (newline-delimited or back-to-back).
+
+```shell wrap
+curl -X POST 'https://hec.AXIOM_DOMAIN/services/collector/event?index=DATASET_NAME' \
+    -H 'Authorization: Splunk API_TOKEN' \
+    -H 'Content-Type: application/json' \
+    -d '{"event": {"message": "hello from HEC", "severity": "INFO"}, "sourcetype": "httpevent"}'
+```
+
+A successful ingest returns `200 OK` with the Splunk status body:
+
+```json
+{"text": "Success", "code": 0}
+```
+
+### Event envelope fields
+
+Axiom interprets the standard HEC envelope fields as follows:
+
+| Field | Behavior |
+| :--- | :--- |
+| `event` | When an object, its keys become top-level fields of the Axiom event. When a string, it is stored in the `_raw` field. |
+| `fields` | Merged into the event as top-level fields. |
+| `time` | Parsed as the event timestamp (`_time`). Accepts epoch seconds, epoch milliseconds, or an RFC 3339 string. When omitted, Axiom assigns the ingest time. |
+| `index` | Selects the target dataset (see [Choose the target dataset](#choose-the-target-dataset)) and is also retained as a field. |
+| `host`, `source`, `sourcetype` | Retained as fields on the event. |
+
+## Send raw events
+
+Send arbitrary payloads to `/services/collector/raw`. Metadata is supplied through query parameters rather than an envelope. Each line of a `text/plain` body becomes an event; JSON bodies are also accepted.
+
+```shell wrap
+curl -X POST 'https://hec.AXIOM_DOMAIN/services/collector/raw?index=DATASET_NAME&sourcetype=mysourcetype&source=mysource&host=myhost' \
+    -H 'Authorization: Splunk API_TOKEN' \
+    -H 'Content-Type: text/plain' \
+    --data-binary 'a raw log line
+another raw log line'
+```
+
+## Compressed payloads
+
+The HEC API accepts gzip-compressed request bodies. Set `Content-Encoding: gzip` and send the gzipped payload:
+
+```shell wrap
+curl -X POST 'https://hec.AXIOM_DOMAIN/services/collector/event?index=DATASET_NAME' \
+    -H 'Authorization: Splunk API_TOKEN' \
+    -H 'Content-Type: application/json' \
+    -H 'Content-Encoding: gzip' \
+    --data-binary @events.json.gz
+```
+
+## Check service health
+
+`GET /services/collector/health` (and the versioned `/services/collector/health/1.0`) report whether the collector is accepting data. No authentication is required.
+
+```shell wrap
+curl 'https://hec.AXIOM_DOMAIN/services/collector/health'
+```
+
+```json
+{"text": "HEC is healthy", "code": 17}
+```
+
+## Response codes
+
+Responses follow the Splunk HEC convention: an HTTP status code plus a JSON body carrying a Splunk `code`.
+
+| HTTP status | HEC code | Meaning |
+| :--- | :--- | :--- |
+| `200` | `0` | Success. |
+| `200` | `17` | The collector is healthy (health endpoints only). |
+| `400` | `5` | No data. The request body was empty. |
+| `400` | `6` | Invalid data format. The body could not be parsed. |
+| `400` | `7` | Incorrect index. The target dataset could not be resolved. |
+| `401` | — | Missing or unsupported authentication. |
+| `403` | — | The token is not permitted to ingest into the dataset. |

--- a/docs.json
+++ b/docs.json
@@ -825,6 +825,9 @@
             "group": "Edge endpoints",
             "pages": [
               "restapi/endpoints/ingestToDataset",
+              "restapi/endpoints/ingestHecEvent",
+              "restapi/endpoints/ingestHecRaw",
+              "restapi/endpoints/getHecHealth",
               "restapi/endpoints/queryEdge",
               "restapi/endpoints/queryBatch",
               "restapi/endpoints/queryMetrics",

--- a/lib/openapi.ts
+++ b/lib/openapi.ts
@@ -2,6 +2,7 @@ import v1 from '@/content/docs/(api-reference)/restapi/versions/v1.json';
 import v2 from '@/content/docs/(api-reference)/restapi/versions/v2.json';
 import edgeIngest from '@/content/docs/(api-reference)/restapi/versions/v1-edge-ingest.json';
 import edgeQuery from '@/content/docs/(api-reference)/restapi/versions/v1-edge-query.json';
+import edgeHec from '@/content/docs/(api-reference)/restapi/versions/v1-edge-hec.json';
 
 // OpenAPI documents are heterogeneous recursive JSON objects.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,6 +13,7 @@ const documents: Record<string, JsonObject> = {
   v2,
   'v1-edge-ingest': edgeIngest,
   'v1-edge-query': edgeQuery,
+  'v1-edge-hec': edgeHec,
 };
 
 export type ApiOperationData = {

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -16,6 +16,16 @@ describe('OpenAPI migration', () => {
     expect(schemaExample(endpoint.document, schema)).toMatchObject({ ingested: 2, failed: 0 });
   });
 
+  it('resolves the edge HEC endpoint reference and status schema', () => {
+    const endpoint = getApiOperation('v1-edge-hec post /services/collector/event');
+    expect(endpoint?.method).toBe('post');
+    expect(endpoint?.displayPath).toBe('/services/collector/event');
+    expect(endpoint?.operation.operationId).toBe('ingestHecEvent');
+
+    const schema = endpoint!.operation.responses['200'].content['application/json'].schema;
+    expect(schemaExample(endpoint!.document, schema)).toMatchObject({ text: 'Success', code: 0 });
+  });
+
   it('unwraps array responses and chained schema references', () => {
     const endpoint = getApiOperation('v2 get /dashboards')!;
     const responseSchema = endpoint.operation.responses['200'].content['application/json'].schema;


### PR DESCRIPTION
Add a Send data guide for the Splunk HTTP Event Collector (HEC) compatible API served from the edge (hec.AXIOM_DOMAIN): the event, raw and health endpoints, the Splunk/Bearer/Basic auth schemes, index → dataset resolution, event-envelope field mapping, gzip payloads, and the Splunk response-code table. Link it from the send-data methods hub.

Distinct from the existing /endpoints/splunk page, which documents the generated *.ingress.axiom.co Splunk-compatible endpoint rather than the native edge HEC service.