### PR TITLE
Fix breadcrumb and Copy page alignment

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -90,7 +90,7 @@ export default async function DocumentationPage({ params }: PageProps) {
       <div className="article-layout relative min-h-[calc(100vh_-_56px)] pt-14 pb-24 px-[clamp(32px,6vw,96px)] max-md:px-9 max-sm:pt-9 max-sm:pb-18 max-sm:px-5">
         <article className={querySyntaxTitle ? `${DOC_ARTICLE_CLASS} query-syntax-article` : DOC_ARTICLE_CLASS}>
           <div className="doc-topline mt-0 mx-0 mb-5 flex items-start justify-between gap-x-4 gap-y-2">
-            <nav className="doc-breadcrumbs m-0 flex flex-wrap gap-x-2 gap-y-1 text-(--color-accent-text) font-mono text-[12px] leading-4 font-[450]" aria-label="Breadcrumb">
+            <nav className="doc-breadcrumbs m-0 min-h-[30px] flex flex-wrap items-center gap-x-2 gap-y-1 text-(--color-accent-text) font-mono text-[12px] leading-4 font-[550] max-sm:min-h-0" aria-label="Breadcrumb">
               {visibleBreadcrumbs.map((item, index) => {
                 const last = index === visibleBreadcrumbs.length - 1;
                 return (

--- a/tests/e2e/docs.spec.ts
+++ b/tests/e2e/docs.spec.ts
@@ -450,6 +450,19 @@ test('deep documentation pages cap the breadcrumb at the first two ancestors', a
   await expect(breadcrumbs.getByRole('link')).toHaveCount(2);
 });
 
+test('breadcrumbs align with the copy page control', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/docs/dashboard-elements/pie-chart');
+
+  const breadcrumbs = page.getByRole('navigation', { name: 'Breadcrumb' });
+  const breadcrumbTextBox = await breadcrumbs.locator('.doc-breadcrumb').first().boundingBox();
+  const copyPageBox = await page.locator('.copy-page').boundingBox();
+  expect(breadcrumbTextBox).not.toBeNull();
+  expect(copyPageBox).not.toBeNull();
+  expect(Math.abs(breadcrumbTextBox!.y + breadcrumbTextBox!.height / 2 - (copyPageBox!.y + copyPageBox!.height / 2))).toBeLessThanOrEqual(1);
+  await expect(breadcrumbs).toHaveCSS('font-weight', '550');
+});
+
 test('the copy page menu offers the Markdown surface and assistant links', async ({ page, context }) => {
   await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   await page.setViewportSize({ width: 1440, height: 900 });


### PR DESCRIPTION
## Summary

- center breadcrumb text within the same 30px alignment row as the **Copy page** control
- increase breadcrumb weight from 450 to 550 while preserving compact mobile spacing
- add browser coverage for alignment and font weight

## Why

The topline previously aligned the breadcrumb’s 16px line box and the 30px action control by their top edges. That left their visual centers 7px apart and made the breadcrumb hierarchy feel too light.

## Impact

Breadcrumbs now align with the page action on desktop and tablet layouts without shifting the article title, changing the sidebar alignment, or adding mobile whitespace.

## Validation

- `pnpm check`
- full Playwright suite: 37 passed; the unrelated desktop API-reference test flaked during the parallel run and passed immediately on an isolated rerun
- live geometry checks at 1440px, 1024px, and 390px
- `git diff --check`