### PR TITLE
Update SLA configuration exclusion

### DIFF
--- a/content/docs/(documentation)/legal/sla.mdx
+++ b/content/docs/(documentation)/legal/sla.mdx
@@ -44,7 +44,7 @@ Axiom measures MUP on a calendar-month basis by taking the total minutes in a ca
   * incidents caused by misuse, negligence, or unapproved modifications of Axiom Services;   
   * Unscheduled Downtime with respect to any Axiom Service made available on a no-fee or trial basis, or for which Customer has not paid to Axiom all of the applicable fees;  
   * Services clearly labelled “Preview”; and  
-  * any issues resulting from changes to a Customer’s configuration of the Axiom Service (e.g., configuration changes related to BYOB or BYOC).
+  * any issues resulting from changes to a Customer’s configuration of the Axiom Service.
 
 **“Incident**” means a failure to meet the applicable MUP due to Unscheduled Downtime.
 


### PR DESCRIPTION
## Summary

Removes outdated deployment model examples from the SLA while retaining the general customer-configuration exclusion.

## Testing

- pnpm audit:content