### PR TITLE
feat(mermaid): compact nodes, orthogonal edge routing, crisp connections

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -318,6 +318,48 @@
   }
 }
 
+/* Step lists (fumadocs Steps/Step). Stock markers are 32px circles centred
+   on a full-height border-line: adjacent one-line steps sit 28px apart, so
+   consecutive circles fused into a pill, and the line poked out above the
+   first badge and below the last. Markers become 24px rounded squares sized
+   under the row height, steps gain breathing room, and the connector is
+   drawn per gap between badges instead of as a container border. Container
+   indent is pinned (stock is breakpoint-dependent) so the badge and line
+   offsets below are deterministic. */
+.fd-steps {
+  border-inline-start: none;
+  margin-inline-start: 16px;
+  padding-inline-start: 28px;
+}
+.fd-step {
+  position: relative;
+}
+.fd-step:not(:first-child) {
+  margin-top: 12px;
+}
+.fd-step::before {
+  width: 24px;
+  height: 24px;
+  /* Vertical position comes from the static position plus margin: the badge
+     tracks its own step's first text line. */
+  margin-top: 2px;
+  inset-inline-start: -39.5px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+}
+/* Connector segment per gap: from just below this badge (2px offset + 24px
+   badge + 4px gap) to just above the next one (12px step gap + 2px offset
+   - 4px gap), so the line never escapes the first or last badge. */
+.fd-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  width: 1px;
+  inset-inline-start: -28px;
+  top: 30px;
+  bottom: -10px;
+  background-color: var(--color-fd-border);
+}
+
 /* ────────────────────────────────────────────────────────────────
  * Typography utilities ported verbatim from www/src/app/globals.css
  * (body-*, mono-*, content-*). Opt-in classes; the docs' own type

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -26,8 +26,14 @@ function axiomThemeVariables(dark: boolean) {
     // Edges and labels. Edges keep one literal grey across themes; it reads as
     // chrome on both canvases and matches the reviewed diagram style.
     lineColor: '#575757',
+    signalColor: '#575757',
     textColor: token('--text-secondary'),
     edgeLabelBackground: token('--bg-canvas'),
+    // Sequence-diagram notes default to mermaid's yellow sticky; keep them on
+    // the same quiet surfaces as everything else.
+    noteBkgColor: token('--bg-inert'),
+    noteBorderColor: token('--border-primary'),
+    noteTextColor: token('--text-secondary'),
     // Secondary/tertiary shapes fall back to quiet surfaces.
     secondaryColor: token('--bg-inert'),
     secondaryBorderColor: token('--border-primary'),
@@ -57,7 +63,9 @@ function themeCss(dark: boolean) {
   .cluster-label span, .cluster-label .nodeLabel, .cluster-label text {
     text-transform: uppercase; font-size: 10px; font-weight: 600; letter-spacing: .09em;
   }
-  .edgePaths path { stroke-width: 1.25px; stroke-linecap: round; }
+  /* Scoped to normal edges so ==> thick links keep their weight. */
+  .edgePaths path { stroke-linecap: round; }
+  .edgePaths path.edge-thickness-normal { stroke-width: 1.25px; }
   .marker { stroke-width: 1px; }
   .node[data-axiom-brand] rect, .node[data-axiom-brand] path,
   .node.axiom rect, .node.axiom path {
@@ -153,18 +161,33 @@ function orthogonalizeEdges(root: SVGSVGElement, radius = 10) {
   const boxes = nodeBoxes(root);
   const nearBox = (p: [number, number], b: Box) =>
     p[0] >= b.x - 4 && p[0] <= b.x + b.w + 4 && p[1] >= b.y - 4 && p[1] <= b.y + b.h + 4;
+  const boxList = [...boxes.values()];
+  type Pt = [number, number];
   type Edge = {
     path: SVGPathElement;
-    s: [number, number];
-    e: [number, number];
+    s: Pt;
+    e: Pt;
     sd: 'h' | 'v';
     ed: 'h' | 'v';
     sdSign: number;
     edSign: number;
     dstBox?: Box;
+    pairKey?: string;
   };
   const edges: Edge[] = [];
-  for (const path of root.querySelectorAll<SVGPathElement>('.edgePaths path')) {
+  const paths = [...root.querySelectorAll<SVGPathElement>('.edgePaths path')];
+  // Where mermaid centred each edge's label, captured before any rewrite so
+  // labels can be re-matched to their edge afterwards. DOM order is not a
+  // reliable pairing between .edgeLabel and path elements.
+  const origMids = paths.map((p): Pt | null => {
+    try {
+      const pt = p.getPointAtLength(p.getTotalLength() / 2);
+      return [pt.x, pt.y];
+    } catch {
+      return null;
+    }
+  });
+  for (const path of paths) {
     const d = path.getAttribute('d') ?? '';
     // Absolute move/line commands only; anything else (curves, relative
     // commands) is not a plain polyline and is left as rendered.
@@ -206,7 +229,27 @@ function orthogonalizeEdges(root: SVGSVGElement, radius = 10) {
           ? [edSign > 0 ? dstBox.x : dstBox.x + dstBox.w, dstBox.y + dstBox.h / 2]
           : [dstBox.x + dstBox.w / 2, edSign > 0 ? dstBox.y : dstBox.y + dstBox.h];
     }
-    edges.push({ path, s, e, sd, ed, sdSign, edSign, dstBox });
+    edges.push({ path, s, e, sd, ed, sdSign, edSign, dstBox, pairKey: ends ? [ends[1], ends[2]].sort().join('|') : undefined });
+  }
+  // Opposite-direction (or duplicate) edges between the same two nodes
+  // collapse onto one line once both are snapped to border centres; shift
+  // each of the pair off-centre so they run parallel instead.
+  const byPair = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    if (edge.pairKey) byPair.set(edge.pairKey, [...(byPair.get(edge.pairKey) ?? []), edge]);
+  }
+  for (const group of byPair.values()) {
+    if (group.length < 2) continue;
+    for (const [i, edge] of group.entries()) {
+      const off = (i - (group.length - 1) / 2) * 18;
+      if (edge.sd === 'h') {
+        edge.s = [edge.s[0], edge.s[1] + off];
+        edge.e = [edge.e[0], edge.e[1] + off];
+      } else {
+        edge.s = [edge.s[0] + off, edge.s[1]];
+        edge.e = [edge.e[0] + off, edge.e[1]];
+      }
+    }
   }
   // Arrowheads: the marker tip extends 4px past the path end (viewBox 10 wide
   // at scale 0.8, ref point at its middle), which buries it inside the target
@@ -247,6 +290,23 @@ function orthogonalizeEdges(root: SVGSVGElement, radius = 10) {
       }
     }
   }
+  // Several edges assigned to the same top/bottom border would still fuse
+  // into one arrow; fan them out along the border instead. Side anchors are
+  // left alone: those overlaps are the deliberate merge junctions.
+  const byEntry = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    if (edge.ed !== 'v' || !edge.dstBox) continue;
+    const key = `${edge.e[0].toFixed(0)},${edge.e[1].toFixed(0)}`;
+    byEntry.set(key, [...(byEntry.get(key) ?? []), edge]);
+  }
+  for (const group of byEntry.values()) {
+    if (group.length < 2) continue;
+    group.sort((a, b) => a.s[0] - b.s[0]);
+    const gap = Math.min(14, (group[0].dstBox!.w - 8) / group.length);
+    for (const [i, edge] of group.entries()) {
+      edge.e = [edge.e[0] + (i - (group.length - 1) / 2) * gap, edge.e[1]];
+    }
+  }
   for (const edge of edges) {
     if (edge.path.getAttribute('marker-end')) {
       if (edge.ed === 'h') edge.e = [edge.e[0] - edge.edSign * inset, edge.e[1]];
@@ -257,20 +317,79 @@ function orthogonalizeEdges(root: SVGSVGElement, radius = 10) {
       else edge.s = [edge.s[0], edge.s[1] + edge.sdSign * inset];
     }
   }
-  for (const { path, s, e, sd, ed } of edges) {
-    let route: [number, number][];
-    if (sd === 'h' && ed === 'h') {
-      const mx = (s[0] + e[0]) / 2;
-      route = Math.abs(s[1] - e[1]) < 2 ? [s, e] : [s, [mx, s[1]], [mx, e[1]], e];
-    } else if (sd === 'v' && ed === 'v') {
-      const my = (s[1] + e[1]) / 2;
-      route = Math.abs(s[0] - e[0]) < 2 ? [s, e] : [s, [s[0], my], [e[0], my], e];
-    } else if (sd === 'h') {
-      route = [s, [e[0], s[1]], e];
-    } else {
-      route = [s, [s[0], e[1]], e];
+  // A route is only used if none of its runs cut through a node box (the
+  // endpoints' own boxes excepted: anchors sit on their borders). Candidates
+  // shift the connecting run off-centre before giving up; when every shape
+  // collides, dagre's original routing already avoided the obstacle, so the
+  // edge keeps it.
+  const segHits = (a: Pt, b: Pt, box: Box) =>
+    Math.min(a[0], b[0]) < box.x + box.w + 2 &&
+    Math.max(a[0], b[0]) > box.x - 2 &&
+    Math.min(a[1], b[1]) < box.y + box.h + 2 &&
+    Math.max(a[1], b[1]) > box.y - 2;
+  const isClear = (route: Pt[], skip: Box[]) => {
+    for (let i = 0; i < route.length - 1; i++) {
+      for (const box of boxList) {
+        if (!skip.includes(box) && segHits(route[i], route[i + 1], box)) return false;
+      }
     }
+    return true;
+  };
+  const rewrittenMid = new Map<SVGPathElement, Pt>();
+  for (const { path, s, e, sd, ed } of edges) {
+    const skip = boxList.filter((b) => nearBox(s, b) || nearBox(e, b));
+    const mx = (s[0] + e[0]) / 2;
+    const my = (s[1] + e[1]) / 2;
+    let candidates: Pt[][];
+    if (sd === 'h' && ed === 'h') {
+      const step = e[0] > s[0] ? 24 : -24;
+      candidates =
+        Math.abs(s[1] - e[1]) < 2
+          ? [[s, e]]
+          : [mx, s[0] + step, e[0] - step].map((x): Pt[] => [s, [x, s[1]], [x, e[1]], e]);
+    } else if (sd === 'v' && ed === 'v') {
+      const step = e[1] > s[1] ? 24 : -24;
+      candidates =
+        Math.abs(s[0] - e[0]) < 2
+          ? [[s, e]]
+          : [my, s[1] + step, e[1] - step].map((y): Pt[] => [s, [s[0], y], [e[0], y], e]);
+    } else if (sd === 'h') {
+      candidates = [
+        [s, [e[0], s[1]], e],
+        [s, [mx, s[1]], [mx, my], [e[0], my], e],
+      ];
+    } else {
+      candidates = [
+        [s, [s[0], e[1]], e],
+        [s, [s[0], my], [mx, my], [mx, e[1]], e],
+      ];
+    }
+    const route = candidates.find((r) => isClear(r, skip));
+    if (!route) continue;
     path.setAttribute('d', roundedPathD(route, radius));
+    const mid = path.getPointAtLength(path.getTotalLength() / 2);
+    rewrittenMid.set(path, [mid.x, mid.y]);
+  }
+  // Mermaid centred each label on the original diagonal; re-centre it on the
+  // rewritten route or it floats beside the line it belongs to. Labels match
+  // their edge by proximity to the original label anchor.
+  for (const label of root.querySelectorAll<SVGGElement>('.edgeLabels .edgeLabel')) {
+    if (!label.textContent?.trim()) continue;
+    const t = /translate\(\s*(-?[\d.]+)[ ,]\s*(-?[\d.]+)/.exec(label.getAttribute('transform') ?? '');
+    if (!t) continue;
+    let best = -1;
+    let bestDist = 40;
+    for (const [i, m] of origMids.entries()) {
+      if (!m) continue;
+      const dist = Math.hypot(m[0] - Number(t[1]), m[1] - Number(t[2]));
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = i;
+      }
+    }
+    if (best < 0) continue;
+    const mid = rewrittenMid.get(paths[best]);
+    if (mid) label.setAttribute('transform', `translate(${mid[0]}, ${mid[1]})`);
   }
 }
 

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
 
 // Diagrams are themed from the Axiom semantic tokens rather than mermaid's
@@ -23,8 +23,9 @@ function axiomThemeVariables(dark: boolean) {
     clusterBkg: dark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
     clusterBorder: token('--border-primary'),
     titleColor: token('--text-quaternary'),
-    // Edges and labels.
-    lineColor: token('--text-quaternary'),
+    // Edges and labels. Edges keep one literal grey across themes; it reads as
+    // chrome on both canvases and matches the reviewed diagram style.
+    lineColor: '#575757',
     textColor: token('--text-secondary'),
     edgeLabelBackground: token('--bg-canvas'),
     // Secondary/tertiary shapes fall back to quiet surfaces.
@@ -43,11 +44,20 @@ function themeCss(dark: boolean) {
   const stroke = dark ? '62%' : '80%';
   return `
   .node rect, .cluster rect { rx: 4px; ry: 4px; }
-  .nodeLabel { font-weight: 450; letter-spacing: -.01em; padding: 2px 4px; line-height: 1.35; }
+  /* Horizontal-only: vertical space comes from flowchart.padding alone so the
+     boxes stay shallow. */
+  .nodeLabel { font-weight: 450; letter-spacing: -.01em; padding: 0 7px; line-height: 1.35; }
+  /* Mermaid wraps html labels as span > p inside a line-height 1.5 div. The
+     block p splits the inline span into empty line fragments above and below,
+     so every label measures two extra line boxes tall and the node grows to
+     match. Inlining the p and pinning the wrapper's line-height (inline style,
+     hence !important) removes the phantom height at measure time. */
+  .nodeLabel p, .edgeLabel p, .cluster-label p { display: inline; margin: 0; }
+  foreignObject > div { line-height: 1.35 !important; }
   .cluster-label span, .cluster-label .nodeLabel, .cluster-label text {
     text-transform: uppercase; font-size: 10px; font-weight: 600; letter-spacing: .09em;
   }
-  .edgePaths path { stroke-width: 1.25px; }
+  .edgePaths path { stroke-width: 1.25px; stroke-linecap: round; }
   .marker { stroke-width: 1px; }
   .node[data-axiom-brand] rect, .node[data-axiom-brand] path,
   .node.axiom rect, .node.axiom path {
@@ -88,14 +98,187 @@ function themeCss(dark: boolean) {
 `;
 }
 
+// Emit an M/L/Q path through the points, replacing each bend with a small
+// quadratic arc so corners read as rounded rather than mitred.
+function roundedPathD(pts: [number, number][], radius: number): string {
+  let out = `M${pts[0][0]},${pts[0][1]}`;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const [px, py] = pts[i - 1];
+    const [cx, cy] = pts[i];
+    const [nx, ny] = pts[i + 1];
+    const v1x = px - cx, v1y = py - cy, v2x = nx - cx, v2y = ny - cy;
+    const l1 = Math.hypot(v1x, v1y), l2 = Math.hypot(v2x, v2y);
+    if (!l1 || !l2) continue;
+    // Collinear points add nothing; skip so straight runs stay one segment.
+    if (Math.abs(v1x * v2y - v1y * v2x) / (l1 * l2) < 0.02) continue;
+    const r = Math.min(radius, l1 / 2, l2 / 2);
+    out += `L${cx + (v1x / l1) * r},${cy + (v1y / l1) * r}`;
+    out += `Q${cx},${cy} ${cx + (v2x / l2) * r},${cy + (v2y / l2) * r}`;
+  }
+  return out + `L${pts[pts.length - 1][0]},${pts[pts.length - 1][1]}`;
+}
+
+type Box = { x: number; y: number; w: number; h: number };
+
+// Flowchart node geometry keyed by graph name, read from the mounted SVG.
+// getBBox needs layout, so this (and the rerouting below) runs against the
+// live DOM, not the parsed string.
+function nodeBoxes(root: SVGSVGElement): Map<string, Box> {
+  const boxes = new Map<string, Box>();
+  for (const g of root.querySelectorAll<SVGGElement>('g.node')) {
+    const name = /-flowchart-(.+)-\d+$/.exec(g.id)?.[1];
+    const t = /translate\(\s*(-?[\d.]+)[ ,]\s*(-?[\d.]+)/.exec(g.getAttribute('transform') ?? '');
+    if (!name || !t) continue;
+    try {
+      const bb = g.getBBox();
+      boxes.set(name, { x: bb.x + Number(t[1]), y: bb.y + Number(t[2]), w: bb.width, h: bb.height });
+    } catch {
+      // Not rendered; leave this node's edges on their original endpoints.
+    }
+  }
+  return boxes;
+}
+
+// Dagre routes edges as loose diagonals. Re-route each one orthogonally:
+// horizontal and vertical runs with rounded elbows, anchored on the border
+// midpoints of the actual node boxes. Mermaid's own endpoints were clipped
+// for the diagonal route, which puts them on box corners and cylinder rims;
+// snapping to side centres is what makes the connections read as deliberate.
+// The exit and entry axes come from the original first and last segments, so
+// a side-exit stays a side-exit and a top-entry stays a top-entry. Endpoints
+// far from their node (edges clipped at a cluster border) are kept, so a
+// route never cuts back through the cluster's interior. Paths with non-line
+// commands (cycles, self-loops) are left untouched.
+function orthogonalizeEdges(root: SVGSVGElement, radius = 10) {
+  const boxes = nodeBoxes(root);
+  const nearBox = (p: [number, number], b: Box) =>
+    p[0] >= b.x - 4 && p[0] <= b.x + b.w + 4 && p[1] >= b.y - 4 && p[1] <= b.y + b.h + 4;
+  type Edge = {
+    path: SVGPathElement;
+    s: [number, number];
+    e: [number, number];
+    sd: 'h' | 'v';
+    ed: 'h' | 'v';
+    sdSign: number;
+    edSign: number;
+    dstBox?: Box;
+  };
+  const edges: Edge[] = [];
+  for (const path of root.querySelectorAll<SVGPathElement>('.edgePaths path')) {
+    const d = path.getAttribute('d') ?? '';
+    // Absolute move/line commands only; anything else (curves, relative
+    // commands) is not a plain polyline and is left as rendered.
+    if (/[^ML0-9,.eE\s-]/.test(d)) continue;
+    const nums = d.match(/-?\d*\.?\d+(?:e-?\d+)?/g)?.map(Number) ?? [];
+    if (nums.length < 4 || nums.length % 2 !== 0) continue;
+    const pts: [number, number][] = [];
+    for (let i = 0; i < nums.length; i += 2) {
+      const p: [number, number] = [nums[i], nums[i + 1]];
+      const prev = pts[pts.length - 1];
+      if (!prev || Math.hypot(p[0] - prev[0], p[1] - prev[1]) > 0.5) pts.push(p);
+    }
+    if (pts.length < 2) continue;
+    let s = pts[0];
+    let e = pts[pts.length - 1];
+    const axis = (a: [number, number], b: [number, number]) =>
+      Math.abs(b[0] - a[0]) >= Math.abs(b[1] - a[1]) ? 'h' : 'v';
+    const sgn = (n: number) => (n >= 0 ? 1 : -1);
+    const sd = axis(pts[0], pts[1]);
+    const ed = axis(pts[pts.length - 2], pts[pts.length - 1]);
+    const sdSign = sd === 'h' ? sgn(pts[1][0] - pts[0][0] || e[0] - s[0]) : sgn(pts[1][1] - pts[0][1] || e[1] - s[1]);
+    const edSign =
+      ed === 'h'
+        ? sgn(e[0] - pts[pts.length - 2][0] || e[0] - s[0])
+        : sgn(e[1] - pts[pts.length - 2][1] || e[1] - s[1]);
+    const ends = /-L_([^_]+)_([^_]+)_\d+$/.exec(path.id);
+    const srcBox = ends ? boxes.get(ends[1]) : undefined;
+    const dstBox = ends ? boxes.get(ends[2]) : undefined;
+    if (srcBox && nearBox(s, srcBox)) {
+      s =
+        sd === 'h'
+          ? [sdSign > 0 ? srcBox.x + srcBox.w : srcBox.x, srcBox.y + srcBox.h / 2]
+          : [srcBox.x + srcBox.w / 2, sdSign > 0 ? srcBox.y + srcBox.h : srcBox.y];
+    }
+    if (dstBox && nearBox(e, dstBox)) {
+      // Arriving rightward/downward means entering the left/top border.
+      e =
+        ed === 'h'
+          ? [edSign > 0 ? dstBox.x : dstBox.x + dstBox.w, dstBox.y + dstBox.h / 2]
+          : [dstBox.x + dstBox.w / 2, edSign > 0 ? dstBox.y : dstBox.y + dstBox.h];
+    }
+    edges.push({ path, s, e, sd, ed, sdSign, edSign, dstBox });
+  }
+  // Arrowheads: the marker tip extends 4px past the path end (viewBox 10 wide
+  // at scale 0.8, ref point at its middle), which buries it inside the target
+  // when the path ends on the border. Endpoints get pulled back by this much
+  // so the tip rests just outside.
+  const inset = 5;
+  // Two arrows landing on the same border point melt into one and the second
+  // edge looks unconnected. When a side-centre anchor is contested, an edge
+  // that starts well above the target moves to the top border and one that
+  // starts well below moves to the bottom, the way converging edges are drawn
+  // by hand. Judged from the edge's own exit point, not its node: cluster-
+  // clipped edges start at the cluster border. Near-level edges keep the
+  // shared side anchor: that overlap reads as a deliberate merge junction,
+  // and the vertical run a move would create is shorter than the arrow inset,
+  // which degenerates into a floating arrowhead.
+  const clearance = inset + 2;
+  const byAnchor = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    const key = `${edge.e[0].toFixed(0)},${edge.e[1].toFixed(0)}`;
+    byAnchor.set(key, [...(byAnchor.get(key) ?? []), edge]);
+  }
+  for (const group of byAnchor.values()) {
+    if (group.length < 2) continue;
+    for (const edge of group) {
+      const db = edge.dstBox;
+      if (edge.ed !== 'h' || !db) continue;
+      const dcx = db.x + db.w / 2;
+      // Needs horizontal room to turn; otherwise leave it on the side.
+      if (Math.abs(edge.s[0] - dcx) < radius) continue;
+      if (edge.s[1] < db.y - clearance) {
+        edge.ed = 'v';
+        edge.edSign = 1;
+        edge.e = [dcx, db.y];
+      } else if (edge.s[1] > db.y + db.h + clearance) {
+        edge.ed = 'v';
+        edge.edSign = -1;
+        edge.e = [dcx, db.y + db.h];
+      }
+    }
+  }
+  for (const edge of edges) {
+    if (edge.path.getAttribute('marker-end')) {
+      if (edge.ed === 'h') edge.e = [edge.e[0] - edge.edSign * inset, edge.e[1]];
+      else edge.e = [edge.e[0], edge.e[1] - edge.edSign * inset];
+    }
+    if (edge.path.getAttribute('marker-start')) {
+      if (edge.sd === 'h') edge.s = [edge.s[0] + edge.sdSign * inset, edge.s[1]];
+      else edge.s = [edge.s[0], edge.s[1] + edge.sdSign * inset];
+    }
+  }
+  for (const { path, s, e, sd, ed } of edges) {
+    let route: [number, number][];
+    if (sd === 'h' && ed === 'h') {
+      const mx = (s[0] + e[0]) / 2;
+      route = Math.abs(s[1] - e[1]) < 2 ? [s, e] : [s, [mx, s[1]], [mx, e[1]], e];
+    } else if (sd === 'v' && ed === 'v') {
+      const my = (s[1] + e[1]) / 2;
+      route = Math.abs(s[0] - e[0]) < 2 ? [s, e] : [s, [s[0], my], [e[0], my], e];
+    } else if (sd === 'h') {
+      route = [s, [e[0], s[1]], e];
+    } else {
+      route = [s, [s[0], e[1]], e];
+    }
+    path.setAttribute('d', roundedPathD(route, radius));
+  }
+}
+
 // Nodes labelled exactly "Axiom" are the product in an architecture diagram;
 // pick them out in the brand accent. Sequence-diagram actors have no :::class
 // syntax, so they're tagged by name instead: an actor named after either
 // product gets that product's colour.
-function tagBrandNodes(svg: string): string {
-  const doc = new DOMParser().parseFromString(svg, 'text/html');
-  const root = doc.body.querySelector('svg');
-  if (!root) return svg;
+function tagBrandNodes(root: SVGElement) {
   for (const label of root.querySelectorAll('.nodeLabel')) {
     if (label.textContent?.trim() === 'Axiom') label.closest('.node')?.setAttribute('data-axiom-brand', '');
   }
@@ -104,6 +287,13 @@ function tagBrandNodes(svg: string): string {
     const brand = name.includes('axiom') ? 'axiom' : name.includes('splunk') ? 'splunk' : null;
     if (brand) actor.closest('g')?.setAttribute('data-brand', brand);
   }
+}
+
+function postProcessSvg(svg: string): string {
+  const doc = new DOMParser().parseFromString(svg, 'text/html');
+  const root = doc.body.querySelector('svg');
+  if (!root) return svg;
+  tagBrandNodes(root);
   return root.outerHTML;
 }
 
@@ -114,6 +304,15 @@ export function Mermaid({ chart }: { chart: string }) {
   const [svg, setSvg] = useState('');
   const [failed, setFailed] = useState(false);
   const { resolvedTheme } = useTheme();
+
+  // Re-route edges once the SVG is in the DOM: anchoring needs getBBox, which
+  // only works on rendered elements. Layout effect so the original diagonals
+  // never paint. Rewritten paths contain curve commands, which the rewriter
+  // skips, so re-runs (strict mode) are no-ops.
+  useLayoutEffect(() => {
+    const el = containerRef.current?.querySelector('svg');
+    if (svg && el) orthogonalizeEdges(el);
+  }, [svg]);
 
   useEffect(() => {
     const key = `${resolvedTheme} ${chart}`;
@@ -134,10 +333,16 @@ export function Mermaid({ chart }: { chart: string }) {
           themeVariables: axiomThemeVariables(dark),
           themeCSS: themeCss(dark),
           flowchart: {
-            curve: 'basis',
-            padding: 10,
-            nodeSpacing: 36,
-            rankSpacing: 42,
+            // Plain polylines that orthogonalizeEdges can parse and re-route.
+            curve: 'linear',
+            // Total label-to-border padding, split across both sides; extra
+            // horizontal room comes from the .nodeLabel side padding in
+            // themeCss.
+            padding: 14,
+            nodeSpacing: 40,
+            // Wide rank gap gives the orthogonal runs room to read as
+            // deliberate routing rather than cramped jogs.
+            rankSpacing: 64,
             // Clear the uppercase title off the first node row.
             subGraphTitleMargin: { top: 8, bottom: 16 },
           },
@@ -148,7 +353,7 @@ export function Mermaid({ chart }: { chart: string }) {
         const rendered = await mermaid.render(id, chart.replaceAll('\\n', '\n'));
         if (cancelled) return;
         setFailed(false);
-        setSvg(tagBrandNodes(rendered.svg));
+        setSvg(postProcessSvg(rendered.svg));
         if (containerRef.current) rendered.bindFunctions?.(containerRef.current);
       } catch (error) {
         // Leave the source readable rather than an empty frame when the chart


### PR DESCRIPTION
## Summary

Restyles every mermaid diagram on the site from the shared `components/mermaid.tsx` renderer: compact node boxes, orthogonal (Figma/Whimsical-style) edge routing with rounded corners, and arrowheads that connect cleanly to node borders. Also fixes the fumadocs step-list markers, which fused into pills on adjacent one-line steps.

### Node sizing fix

Mermaid wraps each HTML label as `<span class="nodeLabel"><p>…</p></span>` inside a `line-height: 1.5` wrapper. The block `<p>` splits the inline span into empty line fragments above and below, so every label measured two extra line boxes (~37px) tall and nodes grew to match. Inlining the `<p>` and pinning the wrapper's line-height removes the phantom height; node y-padding is then set deliberately via `flowchart.padding`.

### Orthogonal edge routing

Dagre's routes are loose diagonal splines. A post-render pass rewrites each edge as horizontal/vertical runs with rounded elbows:

- Anchored to border midpoints of the actual node boxes (read via `getBBox` in a layout effect, so the original diagonals never paint).
- Exit/entry axes come from the original path's first/last segments, so side-exits stay side-exits and top-entries stay top-entries.
- When two edges would land on the same anchor (converging into a cylinder), the one starting above enters the top border and the one below enters the bottom; near-level edges share the anchor as a deliberate merge junction.
- Edges clipped at cluster borders keep their endpoints so routes never cut back through a cluster's interior.
- Endpoints are inset 5px because the arrowhead marker tip extends 4px past the path end — previously buried inside translucent nodes.
- Cycles/self-loops and sequence diagrams are left untouched.

### Visual tuning

- Edge colour fixed at `#575757` in both themes (paths and arrowheads).
- Node y-padding doubled; wider rank spacing so orthogonal runs read as deliberate routing.

### Step-list markers (`app/globals.css`)

Stock fumadocs step markers are 32px circles on 28px rows, so consecutive one-line steps fused into a single pill, and the connector line — a full-height container border — poked out above the first badge and below the last:

- Markers shrink to 24px rounded squares (half the previous corner radius), aligned to each step's first text line.
- Steps gain 12px of separation.
- The connector is drawn per gap between badges instead of as a container border, stopping short of each badge.

### Battle-test round

Stress-tested the renderer against a temporary page of 16 complex diagrams (dense meshes, deep fan-ins, labelled edges, bidirectional pairs, all node shapes, nested subgraphs, BT/RL directions, sequence and state diagrams) and fixed what broke:

- Edge labels re-match to their edge by proximity to the original label anchor and re-centre on the rewritten route (DOM-order pairing mislabelled edges).
- Candidate routes are collision-checked against node boxes; blocked routes try shifted runs, then keep dagre's original path instead of tunnelling under nodes.
- Multiple edges assigned to the same top/bottom border fan out along it so converging arrows stay distinct.
- Opposite-direction edges between the same node pair run as parallel offset lines instead of collapsing onto one.
- The stroke-width override is scoped to normal edges so `==>` keeps its weight.
- Sequence-diagram notes and signal lines follow the theme (were stock yellow/white).

## Test plan

- Verified all 6 diagrams (`/splunk/overview`, `/splunk/portal/overview` ×3 incl. sequence diagram, `/send-data/reference-architectures` ×2 incl. subgraphs) via Playwright screenshots in light and dark themes.
- Verified step lists on `/splunk/portal/set-up-standard` in both themes.
- `tsc --noEmit` and `eslint` pass.


