### PR TITLE
Remove references to Enterprise plans

### DIFF
--- a/content/docs/(documentation)/console/intelligence/query-cost-limits.mdx
+++ b/content/docs/(documentation)/console/intelligence/query-cost-limits.mdx
@@ -10,8 +10,6 @@ Connecting an AI agent to Axiom is one of the most valuable things you can do wi
 With a capped token, you can let an agent work autonomously against your data and know your worst case in advance: an agent with a $1 hourly and $10 daily limit can never spend more than $10 per day on queries, no matter what it does.
 
 <Note>
-Query cost limits are available on the Axiom Cloud and Enterprise plans.
-
 Query cost limits are separate from your organization’s [monthly spending limit](/reference/usage-billing#spending-limit). The spending limit caps your whole organization’s bill; query cost limits cap the query costs of individual tokens and members.
 </Note>
 

--- a/content/docs/(documentation)/reference/tokens.mdx
+++ b/content/docs/(documentation)/reference/tokens.mdx
@@ -59,7 +59,7 @@ After creating an API token, you can’t change the privileges assigned to that 
 
 ### Limit query costs of an API token
 
-On the Axiom Cloud and Enterprise plans, you can cap the hourly and daily query costs of an API token, in dollars. When the token exceeds a limit, its query requests fail with HTTP status code `429` until the window resets. Ingest and other operations are unaffected. This is particularly useful for tokens you give to AI agents.
+You can cap the hourly and daily query costs of an API token, in dollars. When the token exceeds a limit, its query requests fail with HTTP status code `429` until the window resets. Ingest and other operations are unaffected. This is particularly useful for tokens you give to AI agents.
 
 To set limits when you create a token, enter an hourly limit, a daily limit, or both in **Query cost limits**. To add or change limits on an existing token, click <Icon icon="gear" iconType="solid"/> **Settings > API tokens**, select the token, and then edit **Query cost limits**. The token page shows the token’s current usage against each limit.
 

--- a/content/snippets/ai-setting.mdx
+++ b/content/snippets/ai-setting.mdx
@@ -4,7 +4,7 @@ Features powered by Axiom AI allow you to get insights from your data faster. Th
 
 AI features are available for all organizations. They comply with the Health Insurance Portability and Accountability Act (HIPAA) regulations. This means that you can use them even if your organization has a Business Associate Agreements (BAAs) with Axiom.
 
-AI features are turned on by default for most customers. If your organization is on the Enterprise plan, AI features are turned off by default. You can turn AI features on or off anytime for the whole organization,for example, for regulatory and compliance reasons.
+AI features are turned on by default. You can turn AI features on or off anytime for the whole organization,for example, for regulatory and compliance reasons.
 
 To turn Axiom AI on or off:
 

--- a/content/snippets/ai-setting.mdx
+++ b/content/snippets/ai-setting.mdx
@@ -4,7 +4,7 @@ Features powered by Axiom AI allow you to get insights from your data faster. Th
 
 AI features are available for all organizations. They comply with the Health Insurance Portability and Accountability Act (HIPAA) regulations. This means that you can use them even if your organization has a Business Associate Agreements (BAAs) with Axiom.
 
-AI features are turned on by default. You can turn AI features on or off anytime for the whole organization,for example, for regulatory and compliance reasons.
+AI features are turned on by default. You can turn AI features on or off anytime for the whole organization, for example, for regulatory and compliance reasons.
 
 To turn Axiom AI on or off:
 


### PR DESCRIPTION
Removes references to Axiom Enterprise plans from the docs. The default assumption is that the reader is on Axiom Cloud, so there's no need to call out which plans a feature is available on.

- **Query cost limits** (`console/intelligence/query-cost-limits.mdx`): drops the "available on the Axiom Cloud and Enterprise plans" line from the availability Note. The rest of the Note (spending limit vs query cost limits) stays.
- **API tokens reference** (`reference/tokens.mdx`): drops the "On the Axiom Cloud and Enterprise plans" qualifier from the query cost limits section.
- **AI setting snippet** (`snippets/ai-setting.mdx`): drops the sentence about AI features being off by default on the Enterprise plan; the text now just says AI features are on by default and can be toggled per organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
