### PR TITLE
fix: use /v1/ingest on edge-domain Elastic ingest URLs

### DIFF
--- a/content/docs/(documentation)/send-data/elastic-beats.mdx
+++ b/content/docs/(documentation)/send-data/elastic-beats.mdx
@@ -56,7 +56,7 @@ filebeat.inputs:
     paths:
       - $PATH_TO_LOG_FILE
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
 ```
@@ -93,7 +93,7 @@ metricbeat.modules:
     - memory
     - network
 output.elasticsearch:
-  hosts: ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+  hosts: ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
   # Specify Axiom API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -123,7 +123,7 @@ metricbeat.modules:
   session_token: '<session_token>'
   # Add other AWS configurations if needed
 output.elasticsearch:
-  hosts: ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+  hosts: ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
 ```
@@ -178,7 +178,7 @@ logging.files:
   path: C:\ProgramData\Winlogbeat\Logs
 logging.level: info
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # token should be an API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -232,7 +232,7 @@ winlogbeat.event_logs:
     ignore_older: 72h
 
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   protocol: "https"
   ssl.verification_mode: "full"
   # token should be an API token
@@ -259,7 +259,7 @@ winlogbeat.event_logs:
   - name: System
 
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # token should be an API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -334,7 +334,7 @@ heartbeat.monitors:
     id: my-http-service
     name: My HTTP Service
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # token should be an API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -382,7 +382,7 @@ auditbeat.modules:
       - /bin
       - /usr/local/sbin
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # token should be an API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -473,7 +473,7 @@ protocols:
   mongodb:
     ports: [27017]
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # api_key should be your API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true
@@ -518,7 +518,7 @@ journalbeat.inputs:
     - "container.image.tag=redis"
     - "process.name=redis"
 output.elasticsearch:
-  hosts: ['https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic']
+  hosts: ['https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic']
   # token should be an API token
   api_key: 'axiom:API_TOKEN'
   allow_older_versions: true

--- a/content/docs/(documentation)/send-data/elasticsearch-bulk-api.mdx
+++ b/content/docs/(documentation)/send-data/elasticsearch-bulk-api.mdx
@@ -63,7 +63,7 @@ func main() {
 `)
 
 	// Create a new request using http
-	req, err := http.NewRequest("POST", "https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic/_bulk", bytes.NewBuffer(data))
+	req, err := http.NewRequest("POST", "https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic/_bulk", bytes.NewBuffer(data))
 	if err != nil {
 		log.Fatalf("Error creating request: %v", err)
 	}
@@ -131,7 +131,7 @@ dataset = "DATASET_NAME"
 api_token = "API_TOKEN"
 
 # The URL for the bulk API
-url = f'https://AXIOM_DOMAIN:443/v1/datasets/{dataset}/elastic/_bulk'
+url = f'https://AXIOM_DOMAIN:443/v1/ingest/{dataset}/elastic/_bulk'
 
 try:
     response = requests.post(
@@ -187,7 +187,7 @@ Obtain an Axiom [API token](/reference/tokens) for the Authorization header, and
 const axios = require('axios');
 
 // Axiom elastic API URL
-const AxiomApiUrl = 'https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic/_bulk';
+const AxiomApiUrl = 'https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic/_bulk';
 
 // Your Axiom API token
 const AxiomToken = 'API_TOKEN';
@@ -249,7 +249,7 @@ require 'vendor/autoload.php';
 use GuzzleHttp\Client;
 
 $client = new Client([
-    'base_uri' => 'https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic/_bulk',  // Update with your Axiom host
+    'base_uri' => 'https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic/_bulk',  // Update with your Axiom host
     'timeout'  => 2.0,
 ]);
 

--- a/content/docs/(documentation)/send-data/fluentd.mdx
+++ b/content/docs/(documentation)/send-data/fluentd.mdx
@@ -93,7 +93,7 @@ The example below shows a Fluentd configuration that sends data to Axiom using t
   include_timestamp true
   host "#{ENV['FLUENT_OPENSEARCH_HOST']  || 'AXIOM_DOMAIN'}"
   port "#{ENV['FLUENT_OPENSEARCH_PORT'] || '443'}"
-  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/datasets/DATASET_NAME/elastic'}"
+  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/ingest/DATASET_NAME/elastic'}"
   scheme "#{ENV['FLUENT_OPENSEARCH_SCHEME'] || 'https'}"
   ssl_verify "#{ENV['FLUENT_OPENSEARCH_SSL_VERIFY'] || 'true'}"
   ssl_version "#{ENV['FLUENT_OPENSEARCH_SSL_VERSION'] || 'TLSv1_2'}"
@@ -157,7 +157,7 @@ The example below shows a Fluentd configuration to hold logs in memory with spec
   include_timestamp true
   host "#{ENV['FLUENT_OPENSEARCH_HOST']  || 'AXIOM_DOMAIN'}"
   port "#{ENV['FLUENT_OPENSEARCH_PORT'] || '443'}"
-  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/datasets/DATASET_NAME/elastic'}"
+  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/ingest/DATASET_NAME/elastic'}"
   scheme "#{ENV['FLUENT_OPENSEARCH_SCHEME'] || 'https'}"
   ssl_verify "#{ENV['FLUENT_OPENSEARCH_SSL_VERIFY'] || 'true'}"
   ssl_version "#{ENV['FLUENT_OPENSEARCH_SSL_VERSION'] || 'TLSv1_2'}"
@@ -210,7 +210,7 @@ The example below shows a Fluentd configuration that sends PHP data to Axiom.
   include_timestamp true
   host "#{ENV['FLUENT_OPENSEARCH_HOST']  || 'AXIOM_DOMAIN'}"
   port "#{ENV['FLUENT_OPENSEARCH_PORT'] || '443'}"
-  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/datasets/DATASET_NAME/elastic'}"
+  path "#{ENV['FLUENT_OPENSEARCH_PATH']|| '/v1/ingest/DATASET_NAME/elastic'}"
   scheme "#{ENV['FLUENT_OPENSEARCH_SCHEME'] || 'https'}"
   ssl_verify "#{ENV['FLUENT_OPENSEARCH_SSL_VERIFY'] || 'true'}"
   ssl_version "#{ENV['FLUENT_OPENSEARCH_SSL_VERSION'] || 'TLSv1_2'}"
@@ -308,7 +308,7 @@ The example below shows a Fluentd configuration that sends data from your virtua
   @type http
   @id out_http_axiom
   @log_level info
-  endpoint "#{ENV['AXIOM_URL'] || 'https://api.axiom.co'}"
+  endpoint "#{ENV['AXIOM_URL'] || 'https://AXIOM_DOMAIN'}"
   path "/v1/ingest/DATASET_NAME"
   ssl_verify "#{ENV['AXIOM_SSL_VERIFY'] || 'true'}"
   <headers>
@@ -329,6 +329,7 @@ The example below shows a Fluentd configuration that sends data from your virtua
 ```
 
 <Info>
+<ReplaceDomain />
 <ReplaceDatasetToken />
 </Info>
 
@@ -359,7 +360,7 @@ The example below shows a Fluentd configuration that sends data from your virtua
   @type http
   @id out_http_axiom
   @log_level info
-  endpoint "#{ENV['AXIOM_URL'] || 'https://api.axiom.co'}"
+  endpoint "#{ENV['AXIOM_URL'] || 'https://AXIOM_DOMAIN'}"
   path "/v1/ingest/DATASET_NAME"
   ssl_verify "#{ENV['AXIOM_SSL_VERIFY'] || 'true'}"
   <headers>
@@ -380,5 +381,6 @@ The example below shows a Fluentd configuration that sends data from your virtua
 ```
 
 <Info>
+<ReplaceDomain />
 <ReplaceDatasetToken />
 </Info>

--- a/content/docs/(documentation)/send-data/kubernetes.mdx
+++ b/content/docs/(documentation)/send-data/kubernetes.mdx
@@ -78,7 +78,7 @@ data:
     processors:
       - add_cloud_metadata:
     output.elasticsearch:
-      hosts: ['${AXIOM_HOST}/v1/datasets/${AXIOM_DATASET}/elastic']
+      hosts: ['${AXIOM_HOST}/v1/ingest/${AXIOM_DATASET}/elastic']
       api_key: 'axiom:${AXIOM_TOKEN}'
     setup.ilm.enabled: false
 kind: ConfigMap

--- a/content/docs/(documentation)/send-data/logstash.mdx
+++ b/content/docs/(documentation)/send-data/logstash.mdx
@@ -51,7 +51,7 @@ input{
 }
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }
@@ -100,7 +100,7 @@ filter {
 
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }
@@ -139,7 +139,7 @@ filter {
 
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }
@@ -175,7 +175,7 @@ filter {
 
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }
@@ -211,7 +211,7 @@ filter {
 
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }
@@ -247,7 +247,7 @@ filter {
 
 output{
   opensearch{
-    hosts => ["https://AXIOM_DOMAIN:443/v1/datasets/DATASET_NAME/elastic"]
+    hosts => ["https://AXIOM_DOMAIN:443/v1/ingest/DATASET_NAME/elastic"]
     user => "axiom"
     password => "API_TOKEN"
   }


### PR DESCRIPTION
## Summary
- Point Elastic Beats, Logstash, Elasticsearch Bulk API, Fluentd, and Kubernetes Filebeat examples at `/v1/ingest` when using edge domains (`AXIOM_DOMAIN`).
- Leave legacy `api.axiom.co` `/v1/datasets` ingest paths unchanged.
- Align Fluentd VM HTTP examples that mixed `api.axiom.co` with the edge `/v1/ingest` path.

## Test plan
- [x] Spot-check Elastic Beats, Logstash, and Elasticsearch Bulk API examples for `AXIOM_DOMAIN` + `/v1/ingest/.../elastic`.
- [ ] Confirm Heroku Log Drains still documents `api.axiom.co/v1/datasets/.../ingest`.
- [ ] Confirm Fluentd HTTP examples use `AXIOM_DOMAIN` and include the domain replacement note.


Made with [Cursor](https://cursor.com)