### PR TITLE
Mark non-edge Ingest data endpoint as legacy

### DIFF
--- a/content/docs/(api-reference)/restapi/endpoints/ingestIntoDataset.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/ingestIntoDataset.mdx
@@ -1,12 +1,10 @@
 ---
-title: Ingest data
+title: Ingest data (legacy)
 openapi: "v1 post /datasets/{dataset_name}/ingest"
 ---
 
 <Warning>
-Use this endpoint to ingest data into the US East 1 (AWS) edge deployment. For more information, see [Ingest data](/restapi/ingest) and [Edge deployments](/reference/edge-deployments).
+This is a legacy endpoint that ingests data into the US East 1 (AWS) edge deployment. To ingest data, use the [Ingest data to edge deployment](/restapi/endpoints/ingestToDataset) endpoint instead. For more information, see [Ingest data](/restapi/ingest) and [Edge deployments](/reference/edge-deployments).
 
 The base domain for this endpoint is `https://api.axiom.co`, irrespective of your edge deployment.
-
-To ingest data to a specific edge deployment, use the [Ingest data to edge deployment](/restapi/endpoints/ingestToDataset) endpoint.
 </Warning>

--- a/content/docs/(api-reference)/restapi/versions/v1.json
+++ b/content/docs/(api-reference)/restapi/versions/v1.json
@@ -388,7 +388,7 @@
         "tags": [
           "Datasets"
         ],
-        "description": "Ingest",
+        "description": "Ingest (Legacy)",
         "operationId": "ingestIntoDataset",
         "parameters": [
           {


### PR DESCRIPTION
Marks the non-edge ingest endpoint (`POST /v1/datasets/{dataset_name}/ingest`, page `ingestIntoDataset`) as legacy, mirroring how the legacy query endpoint is labelled:

- Page title: **Ingest data** → **Ingest data (legacy)** (also updates the sidebar label)
- Warning callout now leads with the legacy status and points to [Ingest data to edge deployment](https://axiom.co/docs/restapi/endpoints/ingestToDataset) as the endpoint to use
- OpenAPI spec (`v1.json`) operation description: `Ingest` → `Ingest (Legacy)`, matching the existing `Query (Legacy)` description on the legacy query endpoint

Verified with `pnpm typecheck`, `pnpm test`, `pnpm audit:content`, and a full `pnpm build` (prerendered page shows the new title, description, and warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)