### PR TITLE
fix: clip mobile overlay shadows so they don't bleed onto the header

### DIFF
--- a/components/docs-assistant-sidebar.tsx
+++ b/components/docs-assistant-sidebar.tsx
@@ -99,6 +99,9 @@ export function DocsAssistantSidebar() {
         // own the width and the divider line there.
         'docs-assistant-sidebar ph-no-capture h-full w-full flex-col bg-background',
         'max-xl:fixed max-xl:top-14 max-xl:right-0 max-xl:bottom-0 max-xl:z-[65] max-xl:h-auto max-xl:w-[min(400px,92vw)] max-xl:border-l max-xl:border-border/50 max-xl:shadow-[-12px_0_48px_rgba(0,0,0,.35)]',
+        // Stacks above the header (z-65 vs z-50), so clip the shadow blur
+        // from bleeding upward onto it; only the leftward reach may escape.
+        'max-xl:[clip-path:inset(0_0_0_-64px)]',
         // Phones: the overlay owns the whole viewport width.
         'max-sm:left-0 max-sm:w-auto max-sm:border-l-0 max-sm:shadow-none',
         assistantOpen ? 'flex' : 'hidden',

--- a/components/docs-shell.tsx
+++ b/components/docs-shell.tsx
@@ -362,6 +362,10 @@ export function DocsShell({
           ref={drawerRef}
           className={cn(
             "sidebar sticky top-14 z-30 flex h-[calc(100svh-3.5rem)] w-68 flex-none flex-col select-none bg-background text-sidebar-foreground max-xl:fixed max-xl:bottom-0 max-xl:left-0 max-xl:z-[70] max-xl:h-auto max-xl:w-[min(300px,86vw)] max-xl:shadow-[12px_0_48px_rgba(0,0,0,.35)] motion-reduce:[transition:none]!",
+            // The drawer stacks above the header (z-70 vs z-50), so without
+            // this clip its shadow blur would paint upward onto the header;
+            // only the rightward reach (12px offset + 48px blur) may escape.
+            "max-xl:[clip-path:inset(0_-64px_0_0)]",
             drawerOpen
               ? "open max-xl:visible max-xl:[transform:translateX(0)] max-xl:[transition:transform_.2s_ease,visibility_0s_linear_0s]"
               : "max-xl:invisible max-xl:[transform:translateX(-105%)] max-xl:[transition:transform_.2s_ease,visibility_0s_linear_.2s]",


### PR DESCRIPTION
## Problem

With the mobile nav drawer open, a dark smudge appeared over the site header:

The drawer (`z-[70]`) and the Ask AI sidebar (`z-[65]`) both start at `top-14` but stack above the header (`z-50`). Their `48px` box-shadow blur therefore painted upward past their top edge, onto the header.

## Fix

Clip each overlay's own painting with `clip-path: inset(...)` at `max-xl`, allowing overflow only on the side that faces the backdrop:

- Nav drawer: `inset(0 -64px 0 0)` — shadow may escape rightward (12px offset + 48px blur = 60px max reach), never upward onto the header.
- Ask AI sidebar: `inset(0 0 0 -64px)` — mirrored, shadow escapes leftward only.

Raising the header's z-index instead was rejected: the search dialog is also `z-50` and only wins over the header by DOM order, so a higher header would sit above the search overlay.

## Verification

- `pnpm lint`, `pnpm typecheck`
- Focused e2e: `search and mobile navigation are keyboard and touch accessible` — passed on desktop-chromium and mobile-chromium (against a fresh production build)
- Visual check at 390px and 768px in light and dark: header is clean with the drawer/Ask AI open; the outward shadow over the backdrop is unchanged