### PR TITLE
Splunk Portal: Splunk Cloud Victoria supports transparent mode

### DIFF
--- a/content/docs/(documentation)/splunk/portal/overview.mdx
+++ b/content/docs/(documentation)/splunk/portal/overview.mdx
@@ -45,7 +45,7 @@ flowchart LR
     S1["index=federated:http-logs"]:::splunk --> S2["Federated index<br/>mapped once in Splunk"]:::splunk --> S3[("Axiom dataset<br/>http-logs")]:::axiom
 ```
 
-**Transparent mode** makes Axiom datasets directly addressable by their own names, as `index=<name>`, with zero per-dataset mapping. Splunk also replicates the search head’s knowledge bundle to Axiom, so your existing CSV lookups, automatic lookups, and data models work against Axiom data. Transparent mode requires Splunk Enterprise.
+**Transparent mode** makes Axiom datasets directly addressable by their own names, as `index=<name>`, with zero per-dataset mapping. Splunk also replicates the search head’s knowledge bundle to Axiom, so your existing CSV lookups, automatic lookups, and data models work against Axiom data. Transparent mode works from Splunk Enterprise and Splunk Cloud Platform on the Victoria Experience.
 
 ```mermaid
 flowchart LR
@@ -60,7 +60,7 @@ flowchart LR
 | Splunk lookups over Axiom data | No | Yes, CSV and automatic lookups |
 | Data models and `tstats` | Limited | Yes |
 | Splunk Enterprise Security | Not supported by Splunk | Supported |
-| Splunk editions | Splunk Enterprise and Splunk Cloud Platform | Splunk Enterprise |
+| Splunk editions | Splunk Enterprise and Splunk Cloud Platform | Splunk Enterprise and Splunk Cloud Platform (Victoria Experience) |
 
 <Note>
 If you use Splunk Enterprise Security, choose transparent mode. Splunk doesn’t support federated search in standard mode with Enterprise Security. For more information, see [Use federated searches in transparent mode with Splunk Enterprise Security](https://help.splunk.com/en/splunk-enterprise-security-8/user-guide/8.5/introduction/use-federated-searches-in-transparent-mode-with-splunk-enterprise-security) in the Splunk documentation.
@@ -74,7 +74,7 @@ Use one mode per Splunk deployment. Registering both a standard and a transparen
 
 Axiom verifies the Splunk Portal against Splunk Enterprise 9.0 through 10.4 in both modes. Splunk Enterprise 9.0 or later is recommended.
 
-The Portal supports Splunk Cloud Platform in standard mode on the Victoria Experience, which all new Splunk Cloud instances use. To check which experience your environment uses, see [Determine your Splunk Cloud Platform Experience](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/10.5.2605/get-started-managing-splunk-cloud-platform/determine-your-splunk-cloud-platform-experience) in the Splunk documentation.
+The Portal supports Splunk Cloud Platform on the Victoria Experience, which all new Splunk Cloud instances use, in both modes. To check which experience your environment uses, see [Determine your Splunk Cloud Platform Experience](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/10.5.2605/get-started-managing-splunk-cloud-platform/determine-your-splunk-cloud-platform-experience) in the Splunk documentation.
 
 ## Security model
 

--- a/content/docs/(documentation)/splunk/portal/set-up-transparent.mdx
+++ b/content/docs/(documentation)/splunk/portal/set-up-transparent.mdx
@@ -11,7 +11,7 @@ In transparent mode, Axiom datasets are directly addressable by their own names,
 - **Data models**, including `tstats` queries and `pivot`.
 - **Tags and event types**, which the search head expands before dispatch.
 
-Transparent mode requires a Splunk Enterprise search head. Splunk doesn’t support transparent mode from Splunk Cloud Platform to a remote provider, so on Splunk Cloud use [standard mode](/splunk/portal/set-up-standard) instead. For how the modes differ, see [How the Splunk Portal works](/splunk/portal/overview).
+Transparent mode works from a Splunk Enterprise search head or Splunk Cloud Platform on the Victoria Experience. For how the modes differ, see [How the Splunk Portal works](/splunk/portal/overview).
 
 If you use Splunk Enterprise Security, transparent mode is the mode to use: Splunk doesn’t support standard mode federated search with Enterprise Security.
 
@@ -23,7 +23,7 @@ Use one mode per Splunk deployment. If you already registered a standard mode pr
 
 - [Create an advanced API token in Axiom](/reference/tokens#create-advanced-api-token) with query permissions on the datasets you want to expose. The token needs no other permissions.
 - [Determine your Axiom organization ID](/reference/tokens#determine-organization-id).
-- A Splunk Enterprise 9.0 or later search head, and a Splunk role with permissions to manage federated search. The search head must be able to reach `splunk.portal.axiom.co` on port 443 over HTTPS.
+- A Splunk Enterprise 9.0 or later search head, or Splunk Cloud Platform on the Victoria Experience, and a Splunk role with permissions to manage federated search. The search head must be able to reach `splunk.portal.axiom.co` on port 443 over HTTPS. If your Splunk Cloud environment restricts outbound traffic, allow egress to this host and port first.
 
 ## Register the Portal as a transparent mode provider
 


### PR DESCRIPTION
The Splunk Portal docs currently say transparent mode requires Splunk Enterprise and that Splunk Cloud is standard-mode only. Both claims are outdated:

- **Confirmed working in the field**: the Portal was registered as a transparent-mode federated provider from a real Splunk Cloud **Victoria** customer stack (2026-08-03, Ian Tinney) — Axiom dataset searched with bare `index=` syntax, events rendered in the SC search UI.
- **Splunk's own docs agree**: the current Cloud Platform federated-search docs (10.5.2605) state transparent mode is supported from Splunk Cloud as the local deployment (8.2.2107+).

Changes:
- `overview.mdx` — mode-comparison prose + editions table row now list Splunk Cloud (Victoria Experience) for transparent mode; supported-versions section says both modes on Victoria.
- `set-up-transparent.mdx` — removed the 'requires Splunk Enterprise / not supported from Splunk Cloud' paragraph; prerequisites now mirror the standard-mode page (incl. the outbound-443 egress note).

Engineering evidence lives in the portal repo: `docs/RESEARCH.md` ('Confirmed: Victoria + transparent mode') and `docs/SUPPORT-MATRIX.md` (updated in axiomhq/splunk-portal@cde39d6).