### PR TITLE
Splunk: name the product 'Axiom Portal for Splunk' consistently

### DIFF
--- a/content/docs/(documentation)/splunk/overview.mdx
+++ b/content/docs/(documentation)/splunk/overview.mdx
@@ -1,20 +1,20 @@
 ---
 title: 'Axiom and Splunk'
-description: 'Learn how to work with your Axiom data from Splunk, and how to choose between the Axiom for Splunk app and the Axiom Splunk Portal.'
+description: 'Learn how to work with your Axiom data from Splunk, and how to choose between the Axiom for Splunk app and the Axiom Portal for Splunk.'
 sidebarTitle: Overview
-keywords: ['splunk', 'splunk portal', 'federated search', 'splunk app', 'spl', 'axiom for splunk', 'splunk integration']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search', 'splunk app', 'spl', 'axiom for splunk', 'splunk integration']
 ---
 
 Axiom connects to Splunk in two ways. Both let your team work with Axiom data from the Splunk interface they already know, without moving or duplicating data. The work of filtering and aggregating happens inside Axiom, and Splunk receives compact results it can shape, chart, and alert on.
 
 - The **[Axiom for Splunk app](/splunk/app/setup)** adds a set of `ax` commands to SPL. You query Axiom datasets explicitly from any Splunk search, enrich existing Splunk events with Axiom context, and run raw APL when you need the full Axiom query language. Any Splunk user can install and configure it with an Axiom API token.
-- The **[Axiom Splunk Portal](/splunk/portal/overview)** registers with your Splunk deployment as a federated search provider and makes Axiom datasets appear as ordinary Splunk indexes, addressed as `index=federated:<dataset>` or, in transparent mode, directly by name as `index=<dataset>`. Your team searches them in plain SPL, and existing dashboards, saved searches, and alerts work unchanged. A Splunk admin sets it up once for the whole deployment.
+- The **[Axiom Portal for Splunk](/splunk/portal/overview)** registers with your Splunk deployment as a federated search provider and makes Axiom datasets appear as ordinary Splunk indexes, addressed as `index=federated:<dataset>` or, in transparent mode, directly by name as `index=<dataset>`. Your team searches them in plain SPL, and existing dashboards, saved searches, and alerts work unchanged. A Splunk admin sets it up once for the whole deployment.
 
 ```mermaid
 flowchart LR
     User["Splunk user"] --> SH["Splunk search head"]:::splunk
     SH --> App["Axiom app<br/>axsearch, axstats, axquery, …"]:::axiom
-    SH --> Fed["Splunk Portal<br/>Axiom datasets as Splunk indexes"]:::axiom
+    SH --> Fed["Axiom Portal<br/>Axiom datasets as Splunk indexes"]:::axiom
     App --> Axiom[("Axiom")]
     Fed --> Axiom
 ```
@@ -23,7 +23,7 @@ flowchart LR
 
 The two integrations solve different problems and work well together in the same deployment.
 
-| | Axiom for Splunk app | Axiom Splunk Portal |
+| | Axiom for Splunk app | Axiom Portal for Splunk |
 | --- | --- | --- |
 | Query syntax | New `ax` commands, plus raw APL | Plain SPL: `index=federated:<dataset>`, or `index=<dataset>` in transparent mode |
 | Existing dashboards and saved searches | Adapt them to use `ax` commands | Work unchanged |
@@ -39,7 +39,7 @@ Choose the **app** when:
 - You want to enrich events that are already in Splunk with context from Axiom. The `axlookup` command joins Axiom fields onto Splunk search results in one streaming command, with batching and field normalization handled for you.
 - You want the full power of APL from inside Splunk. The `axquery` command runs any APL query and returns the results as Splunk events.
 
-Choose the **Splunk Portal** when:
+Choose the **Portal** when:
 
 - Your team already has Splunk dashboards, saved searches, and alerts, and you want them to run against Axiom data without edits.
 - End users shouldn’t have to learn anything new. Axiom datasets appear as indexes, and everyone keeps writing the SPL they know.
@@ -51,12 +51,12 @@ A useful way to remember the difference: the app brings Axiom’s query language
 
 Neither integration copies data into Splunk. Axiom stores and queries your event data, and Splunk receives results.
 
-Both integrations push the expensive work down into Axiom. An aggregation like a count by service over billions of events runs inside Axiom and returns a handful of rows to Splunk. Results are exact, not sampled, at any dataset size. For more information on how work is divided between Axiom and the Splunk search head, see [How the Splunk Portal works](/splunk/portal/overview).
+Both integrations push the expensive work down into Axiom. An aggregation like a count by service over billions of events runs inside Axiom and returns a handful of rows to Splunk. Results are exact, not sampled, at any dataset size. For more information on how work is divided between Axiom and the Splunk search head, see [How the Portal works](/splunk/portal/overview).
 
 Access is controlled with Axiom API tokens. Each integration authenticates with a token that has query permissions on the datasets you choose to expose. Revoke the token, and access is gone. For more information, see [Tokens](/reference/tokens).
 
 ## What’s next
 
 - [Install and configure the Axiom for Splunk app](/splunk/app/setup)
-- [Set up the Splunk Portal](/splunk/portal/set-up-standard)
+- [Set up the Axiom Portal for Splunk](/splunk/portal/set-up-standard)
 - [Translate SPL to APL](/apl/guides/splunk-cheat-sheet)

--- a/content/docs/(documentation)/splunk/portal/examples.mdx
+++ b/content/docs/(documentation)/splunk/portal/examples.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Splunk Portal examples'
-description: 'Copy-paste SPL examples for searching Axiom data from Splunk through the Axiom Splunk Portal, from first searches to lookups and data models.'
+title: 'Axiom Portal for Splunk examples'
+description: 'Copy-paste SPL examples for searching Axiom data from Splunk through the Axiom Portal for Splunk, from first searches to lookups and data models.'
 sidebarTitle: Examples
-keywords: ['splunk', 'splunk portal', 'federated search examples', 'spl examples', 'stats', 'timechart', 'lookup', 'tstats']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search examples', 'spl examples', 'stats', 'timechart', 'lookup', 'tstats']
 ---
 
 These examples use standard mode syntax, `index=federated:<name>`, against a dataset of OpenTelemetry trace data. In transparent mode, drop the `federated:` prefix and use the dataset name directly. Adjust index and field names to your setup.

--- a/content/docs/(documentation)/splunk/portal/observability-cloud.mdx
+++ b/content/docs/(documentation)/splunk/portal/observability-cloud.mdx
@@ -1,13 +1,13 @@
 ---
 title: 'View Axiom logs in Splunk Observability Cloud'
-description: 'Learn how to connect Splunk Observability Cloud Log Observer to a search head backed by the Axiom Splunk Portal, so your logs render in Observability Cloud without ingesting any log data into Splunk.'
+description: 'Learn how to connect Splunk Observability Cloud Log Observer to a search head backed by the Axiom Portal for Splunk, so your logs render in Observability Cloud without ingesting any log data into Splunk.'
 sidebarTitle: Observability Cloud
-keywords: ['splunk', 'splunk portal', 'splunk observability cloud', 'log observer connect', 'logs connections', 'federated search', 'transparent mode', 'opentelemetry']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'splunk observability cloud', 'log observer connect', 'logs connections', 'federated search', 'transparent mode', 'opentelemetry']
 ---
 
 Splunk Observability Cloud doesn't store logs. Its Log Observer feature reads logs from a Splunk platform search head through [Log Observer Connect](https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/introduction-to-splunk-log-observer-connect): Observability Cloud connects to the search head's management port and runs ordinary searches against the indexes you select.
 
-Because the Axiom Splunk Portal makes Axiom datasets searchable as ordinary indexes in [transparent mode](/splunk/portal/set-up-transparent), this composes: point Log Observer Connect at a search head with a transparent-mode Portal provider, and Observability Cloud renders logs that live only in Axiom. The log list, the time histogram, and the field summaries in the Logs explorer are all served by searches that federate to Axiom.
+Because the Axiom Portal for Splunk makes Axiom datasets searchable as ordinary indexes in [transparent mode](/splunk/portal/set-up-transparent), this composes: point Log Observer Connect at a search head with a transparent-mode Portal provider, and Observability Cloud renders logs that live only in Axiom. The log list, the time histogram, and the field summaries in the Logs explorer are all served by searches that federate to Axiom.
 
 This completes Splunk's own three-signals architecture — metrics and traces flow to Observability Cloud from the OpenTelemetry Collector as usual, and logs are correlated in from the Splunk platform — with Axiom as the log store. You keep the Observability Cloud experience and pay no Splunk log ingest. Spans stored in Axiom as events are searchable through the same connection, so trace-shaped data is browsable in the Logs explorer too.
 

--- a/content/docs/(documentation)/splunk/portal/overview.mdx
+++ b/content/docs/(documentation)/splunk/portal/overview.mdx
@@ -1,15 +1,15 @@
 ---
-title: 'How the Splunk Portal works'
-description: 'Learn how the Axiom Splunk Portal implements Splunk federated search, how work is divided between Axiom and the Splunk search head, and how to choose a mode.'
+title: 'How the Axiom Portal for Splunk works'
+description: 'Learn how the Axiom Portal for Splunk implements Splunk federated search, how work is divided between Axiom and the Splunk search head, and how to choose a mode.'
 sidebarTitle: How it works
-keywords: ['splunk', 'splunk portal', 'federated search', 'federated provider', 'pushdown', 'transparent mode', 'standard mode', 'spl']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search', 'federated provider', 'pushdown', 'transparent mode', 'standard mode', 'spl']
 ---
 
-The Axiom Splunk Portal makes Axiom datasets appear as ordinary Splunk indexes. Anyone who knows SPL, or just knows how to click around Splunk dashboards, can search petabyte-scale Axiom data from their existing Splunk search head, live and with exact results.
+The Axiom Portal for Splunk makes Axiom datasets appear as ordinary Splunk indexes. Anyone who knows SPL, or just knows how to click around Splunk dashboards, can search petabyte-scale Axiom data from their existing Splunk search head, live and with exact results.
 
 The Portal implements the remote side of Splunk’s federated search protocol, the same protocol Splunk uses between its own deployments. Your Splunk search head registers the Portal as a federated provider and treats it like a remote Splunk peer. The Portal translates the dispatched work into Axiom queries, runs them inside Axiom, and streams results back in Splunk’s native result format. No data is copied into Splunk, and nothing is installed on the search head.
 
-A Portal is an Axiom integration that speaks another tool’s own remote-data protocol, so Axiom appears natively inside that tool. The Splunk Portal is the first of the family.
+A Portal is an Axiom integration that speaks another tool’s own remote-data protocol, so Axiom appears natively inside that tool. The Portal for Splunk is the first of the family.
 
 ```mermaid
 sequenceDiagram
@@ -25,7 +25,7 @@ sequenceDiagram
 
 ## Where the work happens
 
-The defining feature of the Splunk Portal is **pushdown**: the expensive parts of a search run inside Axiom, next to the data.
+The defining feature of the Portal is **pushdown**: the expensive parts of a search run inside Axiom, next to the data.
 
 - **Pushed down to Axiom.** Filters, projections, and aggregations are translated and computed inside Axiom. A `stats count` over a billion events scans the data in Axiom and returns a handful of rows to Splunk. Pushed-down aggregations are exact at any dataset size, not sampled, and include `stats`, `timechart`, `chart`, `top`, `rare`, and `tstats`.
 - **Run on the search head.** Streaming and transforming commands like `eval`, `rex`, `dedup`, and `transaction` run on the Splunk search head over the events Axiom returns, identical to how Splunk works with its own remote peers. Everything behaves like native SPL because it is native SPL.
@@ -73,7 +73,7 @@ Use one mode per Splunk deployment. Registering both a standard and a transparen
 
 ## Supported Splunk versions
 
-Axiom verifies the Splunk Portal against Splunk Enterprise 9.0 through 10.4 in both modes. Splunk Enterprise 9.0 or later is recommended.
+Axiom verifies the Portal against Splunk Enterprise 9.0 through 10.4 in both modes. Splunk Enterprise 9.0 or later is recommended.
 
 The Portal supports Splunk Cloud Platform on the Victoria Experience, which all new Splunk Cloud instances use, in both modes. To check which experience your environment uses, see [Determine your Splunk Cloud Platform Experience](https://help.splunk.com/en/splunk-cloud-platform/administer/admin-manual/10.5.2605/get-started-managing-splunk-cloud-platform/determine-your-splunk-cloud-platform-experience) in the Splunk documentation.
 

--- a/content/docs/(documentation)/splunk/portal/set-up-standard.mdx
+++ b/content/docs/(documentation)/splunk/portal/set-up-standard.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'Set up the Splunk Portal in standard mode'
-description: 'Learn how to register the Axiom Splunk Portal as a federated provider in standard mode and map Axiom datasets as federated indexes.'
+title: 'Set up the Axiom Portal for Splunk in standard mode'
+description: 'Learn how to register the Axiom Portal for Splunk as a federated provider in standard mode and map Axiom datasets as federated indexes.'
 sidebarTitle: Set up standard mode
-keywords: ['splunk', 'splunk portal', 'federated search', 'federated provider', 'federated index', 'standard mode', 'setup']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search', 'federated provider', 'federated index', 'standard mode', 'setup']
 ---
 
-In standard mode, each Axiom dataset you expose is mapped to a Splunk federated index, and users search it as `index=federated:<name>`. Standard mode is explicit, simple to reason about, and the recommended starting point. For how the modes differ, see [How the Splunk Portal works](/splunk/portal/overview).
+In standard mode, each Axiom dataset you expose is mapped to a Splunk federated index, and users search it as `index=federated:<name>`. Standard mode is explicit, simple to reason about, and the recommended starting point. For how the modes differ, see [How the Portal works](/splunk/portal/overview).
 
 <Note>
 If you use Splunk Enterprise Security, [set up transparent mode](/splunk/portal/set-up-transparent) instead. Splunk doesn’t support federated search in standard mode with Enterprise Security.

--- a/content/docs/(documentation)/splunk/portal/set-up-transparent.mdx
+++ b/content/docs/(documentation)/splunk/portal/set-up-transparent.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Set up the Splunk Portal in transparent mode'
-description: 'Learn how to register the Axiom Splunk Portal as a federated provider in transparent mode so datasets are searchable by name and your knowledge objects work against Axiom data.'
+title: 'Set up the Axiom Portal for Splunk in transparent mode'
+description: 'Learn how to register the Axiom Portal for Splunk as a federated provider in transparent mode so datasets are searchable by name and your knowledge objects work against Axiom data.'
 sidebarTitle: Set up transparent mode
-keywords: ['splunk', 'splunk portal', 'federated search', 'transparent mode', 'knowledge objects', 'lookups', 'data models', 'tstats']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search', 'transparent mode', 'knowledge objects', 'lookups', 'data models', 'tstats']
 ---
 
 In transparent mode, Axiom datasets are directly addressable by their own names, as `index=<name>`, with no per-dataset mapping. Splunk also replicates the search head’s knowledge bundle to Axiom, so your existing knowledge objects work against Axiom data:
@@ -11,7 +11,7 @@ In transparent mode, Axiom datasets are directly addressable by their own names,
 - **Data models**, including `tstats` queries and `pivot`.
 - **Tags and event types**, which the search head expands before dispatch.
 
-Transparent mode works from a Splunk Enterprise search head or Splunk Cloud Platform on the Victoria Experience. For how the modes differ, see [How the Splunk Portal works](/splunk/portal/overview).
+Transparent mode works from a Splunk Enterprise search head or Splunk Cloud Platform on the Victoria Experience. For how the modes differ, see [How the Portal works](/splunk/portal/overview).
 
 If you use Splunk Enterprise Security, transparent mode is the mode to use: Splunk doesn’t support standard mode federated search with Enterprise Security.
 

--- a/content/docs/(documentation)/splunk/portal/spl-support.mdx
+++ b/content/docs/(documentation)/splunk/portal/spl-support.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'SPL command support in the Splunk Portal'
+title: 'SPL command support in the Axiom Portal for Splunk'
 description: 'Reference for which SPL commands are pushed down into Axiom, which run on the Splunk search head, and the limits that apply.'
 sidebarTitle: SPL command support
-keywords: ['splunk', 'splunk portal', 'spl', 'federated search', 'pushdown', 'stats', 'timechart', 'tstats', 'command support', 'limits', 'mltk', 'machine learning toolkit', 'fit', 'apply', 'custom search commands']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'spl', 'federated search', 'pushdown', 'stats', 'timechart', 'tstats', 'command support', 'limits', 'mltk', 'machine learning toolkit', 'fit', 'apply', 'custom search commands']
 ---
 
-Every SPL command falls into one of three states when it runs against Axiom data through the Splunk Portal. This is the same model Splunk uses between its own deployments.
+Every SPL command falls into one of three states when it runs against Axiom data through the Axiom Portal for Splunk. This is the same model Splunk uses between its own deployments.
 
 - **Pushed down.** The command is computed inside Axiom. Results are exact at any dataset size, and only compact results cross the wire.
 - **Search head.** Axiom returns the matching events, and the Splunk search head runs the command itself. This is exact whenever the matching events fit the response budget. Beyond that, a WARN banner reports that the command ran over a sample.

--- a/content/docs/(documentation)/splunk/portal/troubleshoot.mdx
+++ b/content/docs/(documentation)/splunk/portal/troubleshoot.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'Monitor and troubleshoot the Splunk Portal'
+title: 'Monitor and troubleshoot the Axiom Portal for Splunk'
 description: 'Learn how to read Axiom metrics in the Splunk Job Inspector, what each search banner means, and how to resolve common issues.'
 sidebarTitle: Monitor and troubleshoot
-keywords: ['splunk', 'splunk portal', 'federated search', 'troubleshooting', 'job inspector', 'banners', 'authentication', 'test connection']
+keywords: ['splunk', 'splunk portal', 'axiom portal for splunk', 'federated search', 'troubleshooting', 'job inspector', 'banners', 'authentication', 'test connection']
 ---
 
-The Splunk Portal never degrades silently. Every degraded path surfaces a visible banner on the search job, and every search reports Axiom-side metrics in Splunk’s Job Inspector. Start there.
+The Axiom Portal for Splunk never degrades silently. Every degraded path surfaces a visible banner on the search job, and every search reports Axiom-side metrics in Splunk’s Job Inspector. Start there.
 
 ## Inspect a search
 

--- a/docs.json
+++ b/docs.json
@@ -225,7 +225,7 @@
                     ]
                   },
                   {
-                    "group": "Splunk Portal",
+                    "group": "Portal",
                     "pages": [
                       "splunk/portal/overview",
                       "splunk/portal/set-up-standard",


### PR DESCRIPTION
The published Splunk pages drifted into calling the product **"the Splunk Portal"** and **"the Axiom Splunk Portal"**. Both read as a Splunk-owned (Cisco) product — the first is outright confusing use of the mark, the second is arguably worse ("an Axiom-flavored Splunk product"). The safe, standard pattern is the nominative one Splunkbase itself uses: **"Axiom Portal for Splunk"** — which is already the product's name in the `splunk-portal` repo README.

Naming policy applied:

- **Product name** = *Axiom Portal for Splunk*: page titles, descriptions, and the first mention in each page's body.
- **Subsequent references** = *the Portal* (generic descriptor, no mark attached).
- Nav group under Splunk: `Splunk Portal` → `Portal` (renders as Splunk → Portal, less redundant too).
- `'splunk portal'` is kept in `keywords` frontmatter on every page — it's what users will type into search, and keywords are metadata, not naming.

9 files, +36/−36, pure renames — no content changes. `grep -r "Splunk Portal"` (case-sensitive) over the repo now returns zero hits.
