### PR TITLE
Add dataset field deletion

### DIFF
--- a/content/docs/(api-reference)/restapi/endpoints/deleteDatasetFields.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/deleteDatasetFields.mdx
@@ -1,0 +1,8 @@
+---
+title: Delete fields
+openapi: "v2 post /datasets/{dataset_id}/delete-fields"
+---
+
+<Note>
+When the endpoint returns the status code 202, it means that the deletion request is queued. The deletion itself might take several hours to complete. For more information, see [Delete fields](/reference/datasets#delete-fields).
+</Note>

--- a/content/docs/(api-reference)/restapi/endpoints/deleteFieldForDataset.mdx
+++ b/content/docs/(api-reference)/restapi/endpoints/deleteFieldForDataset.mdx
@@ -1,0 +1,8 @@
+---
+title: Delete field
+openapi: "v2 delete /datasets/{dataset_id}/fields/{field_id}"
+---
+
+<Note>
+When the endpoint returns the status code 202, it means that the deletion request is queued. The deletion itself might take several hours to complete. For more information, see [Delete fields](/reference/datasets#delete-fields).
+</Note>

--- a/content/docs/(api-reference)/restapi/versions/v2.json
+++ b/content/docs/(api-reference)/restapi/versions/v2.json
@@ -458,11 +458,11 @@
             ]
           }
         ],
-        "description": "Deletes fields from the schema of an event dataset. Deletion is asynchronous: the fields disappear from the dataset once the deletion job finishes, which can take several hours. Ingesting new events with a deleted field recreates the field. You can delete fields from a dataset once every 5 minutes.",
+        "description": "Deletes fields asynchronously. The field disappears from listings once the deletion pipeline finishes. Re-ingesting data with that field recreates it.\n",
         "tags": [
           "datasets"
         ],
-        "summary": "Delete fields",
+        "summary": "Delete fields from a dataset",
         "operationId": "deleteDatasetFields",
         "parameters": [
           {
@@ -486,7 +486,7 @@
         },
         "responses": {
           "202": {
-            "description": "Accepted. The deletion is queued.",
+            "description": "DeleteDatasetFieldsResult",
             "content": {
               "application/json": {
                 "schema": {
@@ -505,7 +505,7 @@
             "$ref": "#/components/responses/NotFoundError"
           },
           "429": {
-            "description": "Too many requests. A field deletion started on this dataset in the last 5 minutes.",
+            "description": "TooManyDeleteFieldsRequests",
             "headers": {
               "Retry-After": {
                 "description": "The GMT date/time at which the current rate limit window resets.\n",
@@ -757,11 +757,11 @@
             ]
           }
         ],
-        "description": "Deletes a single field from the schema of an event dataset. Deletion is asynchronous: the field disappears from the dataset once the deletion job finishes, which can take several hours. Ingesting new events with the deleted field recreates the field. You can delete fields from a dataset once every 5 minutes.",
+        "description": "Deletes the field asynchronously. The field disappears from listings once the deletion pipeline finishes. Re-ingesting data with that field recreates it.\n",
         "tags": [
           "datasets"
         ],
-        "summary": "Delete field",
+        "summary": "Delete a field from a dataset",
         "operationId": "deleteFieldForDataset",
         "parameters": [
           {
@@ -783,7 +783,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Accepted. The deletion is queued.",
+            "description": "DeleteDatasetFieldsResult",
             "content": {
               "application/json": {
                 "schema": {
@@ -799,10 +799,10 @@
             "$ref": "#/components/responses/ForbiddenError"
           },
           "404": {
-            "description": "Dataset or field not found."
+            "$ref": "#/components/responses/NotFoundError"
           },
           "429": {
-            "description": "Too many requests. A field deletion started on this dataset in the last 5 minutes.",
+            "description": "TooManyDeleteFieldsRequests",
             "headers": {
               "Retry-After": {
                 "description": "The GMT date/time at which the current rate limit window resets.\n",
@@ -8351,7 +8351,6 @@
         ],
         "properties": {
           "fields": {
-            "description": "Names of the fields to delete.",
             "type": "array",
             "items": {
               "type": "string"
@@ -8360,8 +8359,8 @@
         },
         "example": {
           "fields": [
-            "http.user_agent",
-            "debug.payload"
+            "field1",
+            "field2"
           ]
         }
       },
@@ -8369,17 +8368,17 @@
         "type": "object",
         "properties": {
           "fields": {
-            "description": "Names of the fields queued for deletion, trimmed, de-duplicated, and sorted.",
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-omitempty": false
           }
         },
         "example": {
           "fields": [
-            "debug.payload",
-            "http.user_agent"
+            "field1",
+            "field2"
           ]
         }
       },

--- a/content/docs/(api-reference)/restapi/versions/v2.json
+++ b/content/docs/(api-reference)/restapi/versions/v2.json
@@ -449,6 +449,76 @@
         "x-axiom-preview": true
       }
     },
+    "/datasets/{dataset_id}/delete-fields": {
+      "post": {
+        "security": [
+          {
+            "Auth": [
+              "vacuum|update"
+            ]
+          }
+        ],
+        "description": "Deletes fields from the schema of an event dataset. Deletion is asynchronous: the fields disappear from the dataset once the deletion job finishes, which can take several hours. Ingesting new events with a deleted field recreates the field. You can delete fields from a dataset once every 5 minutes.",
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Delete fields",
+        "operationId": "deleteDatasetFields",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteDatasetFieldsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted. The deletion is queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteDatasetFieldsResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "429": {
+            "description": "Too many requests. A field deletion started on this dataset in the last 5 minutes.",
+            "headers": {
+              "Retry-After": {
+                "description": "The GMT date/time at which the current rate limit window resets.\n",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
+      }
+    },
     "/datasets/{dataset_id}/trim": {
       "post": {
         "security": [
@@ -678,6 +748,72 @@
             }
           }
         }
+      },
+      "delete": {
+        "security": [
+          {
+            "Auth": [
+              "vacuum|update"
+            ]
+          }
+        ],
+        "description": "Deletes a single field from the schema of an event dataset. Deletion is asynchronous: the field disappears from the dataset once the deletion job finishes, which can take several hours. Ingesting new events with the deleted field recreates the field. You can delete fields from a dataset once every 5 minutes.",
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Delete field",
+        "operationId": "deleteFieldForDataset",
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "field_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted. The deletion is queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteDatasetFieldsResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "description": "Dataset or field not found."
+          },
+          "429": {
+            "description": "Too many requests. A field deletion started on this dataset in the last 5 minutes.",
+            "headers": {
+              "Retry-After": {
+                "description": "The GMT date/time at which the current rate limit window resets.\n",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-axiom-preview": true
       }
     },
     "/datasets/{dataset_id}/mapfields": {
@@ -3190,6 +3326,28 @@
       }
     },
     "responses": {
+      "BadRequestError": {
+        "description": "Bad request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "example": {
+                "code": 400,
+                "message": "Bad request"
+              }
+            }
+          }
+        }
+      },
       "ForbiddenError": {
         "description": "Forbidden",
         "content": {
@@ -8185,6 +8343,45 @@
           }
         },
         "additionalProperties": false
+      },
+      "DeleteDatasetFieldsRequest": {
+        "type": "object",
+        "required": [
+          "fields"
+        ],
+        "properties": {
+          "fields": {
+            "description": "Names of the fields to delete.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "example": {
+          "fields": [
+            "http.user_agent",
+            "debug.payload"
+          ]
+        }
+      },
+      "DeleteDatasetFieldsResult": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "Names of the fields queued for deletion, trimmed, de-duplicated, and sorted.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "example": {
+          "fields": [
+            "debug.payload",
+            "http.user_agent"
+          ]
+        }
       },
       "PieChart": {
         "type": "object",

--- a/content/docs/(documentation)/query-data/datasets.mdx
+++ b/content/docs/(documentation)/query-data/datasets.mdx
@@ -68,6 +68,8 @@ To edit a field:
     - Field unit. This is only available for number field types.
     - Hidden. This means that the field is still present in the underlying Axiom database, but it doesn’t appear in the Axiom UI. Use this option if you sent the field to Axiom by mistake or you don’t want to use it anymore in Axiom.
 
+To remove fields from the dataset entirely, delete them. For more information, see [Delete fields](/reference/datasets#delete-fields).
+
 ## Quick charts
 
 Quick charts allow fast charting of fields depending on their field type. For example, for number fields, choose one of the following for easily visualizing the data:

--- a/content/docs/(documentation)/reference/audit-log.mdx
+++ b/content/docs/(documentation)/reference/audit-log.mdx
@@ -174,6 +174,7 @@ The `action` field specifies the type of activity that happened in your Axiom or
 - deleteAPIToken
 - deleteDashboard
 - deleteDataset
+- deleteDatasetFields
 - deleteEndpoint
 - deleteFlowConfiguration
 - deleteFlowDestination

--- a/content/docs/(documentation)/reference/datasets.mdx
+++ b/content/docs/(documentation)/reference/datasets.mdx
@@ -168,7 +168,7 @@ Deleting fields works in the following way:
 - To delete fields, you need the same permissions as for [vacuuming fields](/reference/settings#assign-capabilities-to-roles). Without these permissions, Axiom doesn’t display the menu option below.
 - You can delete fields from a dataset once every 5 minutes. If a field deletion started on the dataset less than 5 minutes ago, wait and try again.
 - You can’t delete fields while the schema of the dataset is locked. [Unlock the schema](#lock-dataset-schema) first, delete the fields, and then lock the schema again.
-- You can’t delete fields from a dataset that another organization has shared with your organization, or from a dataset that you have set up through the [Cloudflare Logpush](/apps/cloudflare-logpush), [Vercel](/apps/vercel), or [Netlify](/apps/netlify) integration.
+- You can’t delete fields from a dataset that another organization has shared with your organization.
 - You can’t delete the fields that Axiom creates automatically, such as `_time`, `_sysTime`, and `_rowId`.
 - You can’t delete a field that’s configured as a [map field](/apl/data-types/map-fields). To delete it, first remove the map field configuration, and then delete the field.
 - Virtual fields don’t store data. To delete a virtual field, see [Virtual fields](/query-data/virtual-fields).

--- a/content/docs/(documentation)/reference/datasets.mdx
+++ b/content/docs/(documentation)/reference/datasets.mdx
@@ -128,7 +128,7 @@ The data schema of your dataset is defined on read. Axiom continuously creates a
 
 In this case, vacuuming fields in a dataset can help you reduce the number of fields associated with a dataset and stay within the allowed limits. Vacuuming fields resets the number of fields associated with a dataset to the fields that occur in events within your retention period. Technically, it wipes the data schema and rebuilds it from the data you currently have in the dataset, which is partly defined by the retention period. For example, you have ingested 500 fields over the last year and 50 fields in the last 95 days, which is your retention period. In this case, before vacuuming, your data schema contains 500 fields. After vacuuming, the dataset only contains 50 fields.
 
-Vacuuming fields doesn’t delete any events from your dataset. To delete events, [trim the dataset](#trim-dataset). Vacuuming only removes fields that no longer occur in any event within your retention period. If you accidentally ingested events with fields you didn’t want to send to Axiom, and these events are within your retention period, vacuuming alone doesn’t solve your problem. In this case, [delete the unintended fields](#delete-fields) instead.
+Vacuuming fields doesn’t delete any events from your dataset. To delete events, [trim the dataset](#trim-dataset). Vacuuming only removes fields that no longer occur in any event within your retention period. If you accidentally ingested events with fields you didn’t want to send to Axiom, and these events are within your retention period, vacuuming alone doesn’t solve your problem. In this case, [delete the unintended fields](#delete-fields) instead. Deleting fields also vacuums the dataset.
 
 You can vacuum the fields of a dataset whose schema is locked. In this case, Axiom vacuums the fields and then regenerates the locked schema so that it matches the vacuumed fields. For more information, see [Lock dataset schema](#lock-dataset-schema).
 
@@ -148,7 +148,7 @@ Deleting fields removes specific fields from the data schema of an event dataset
 
 Deleting fields differs from the other ways of reducing the number of fields:
 
-- [Vacuuming fields](#vacuum-fields) only removes fields that no longer occur in any event within your retention period. Deleting fields removes the fields you select, even if events within your retention period contain them.
+- [Vacuuming fields](#vacuum-fields) only removes fields that no longer occur in any event within your retention period. Deleting fields removes the fields you select, even if events within your retention period contain them. Deleting fields also vacuums the dataset, so fields that vacuuming would remove are removed as well.
 - [Trimming a dataset](#trim-dataset) deletes events. Deleting fields doesn’t delete any events. All other fields of the events remain queryable.
 
 <Warning>
@@ -159,6 +159,7 @@ Deleting fields works in the following way:
 
 - Axiom removes the deleted fields from the schema, the list of fields in the Datasets tab, and query autocomplete. Field descriptions, units, and hidden settings for the deleted fields are removed as well.
 - The values of the deleted fields stay in storage but you can’t access them anymore. Deleting fields doesn’t reduce the storage usage of your dataset.
+- As the last step of the deletion, Axiom vacuums the fields of the dataset. This rebuilds the data schema from the events currently in the dataset, so fields that no longer occur in any event within your retention period disappear together with the fields you selected. For more information, see [Vacuum fields](#vacuum-fields).
 - Saved queries, dashboards, monitors, and virtual fields that reference a deleted field stop returning data for that field. Review these before you delete fields.
 - Deleting fields doesn’t prevent Axiom from adding the fields again. If you ingest events that contain a deleted field after the deletion, Axiom adds the field to the schema again and you can query the newly ingested values. The values you ingested before the deletion remain inaccessible. To stop a field from coming back, fix the data source or [lock the schema](#lock-dataset-schema) after the deletion completes.
 - Field deletion is an asynchronous operation. When you submit a request, Axiom queues the deletion and processes it in the background. The deletion can take several hours to complete, depending on the size of the dataset. During this time, the fields still appear in the Fields panel and in query results. The request appears as `deleteDatasetFields` in the [audit log](/reference/audit-log).

--- a/content/docs/(documentation)/reference/datasets.mdx
+++ b/content/docs/(documentation)/reference/datasets.mdx
@@ -7,7 +7,7 @@ keywords: ['axiom documentation', 'documentation', 'axiom', 'dataset']
 
 import AccessToDatasets from "@/content/snippets/access-to-datasets.mdx"
 
-This reference article explains how to manage datasets in Axiom, including creating new datasets, importing data, and deleting datasets.
+This reference article explains how to manage datasets in Axiom, including creating new datasets, importing data, deleting fields, and deleting datasets.
 
 ## What datasets are
 
@@ -103,7 +103,7 @@ To import data to a dataset, follow these steps:
 
 Trimming permanently deletes data stored in blocks that are older than a date you specify. Note that this action doesn’t delete data that’s older than the specified date but shares a block with newer data.
 
-This can be useful if your dataset contains too many fields or takes up too much storage space, and you want to reduce its size to ensure you stay within the [allowed limits](/reference/limits#pricing-based-limits).
+This can be useful if your dataset takes up too much storage space and you want to reduce its size to ensure you stay within the [allowed limits](/reference/limits#pricing-based-limits). If your dataset contains too many fields, [delete the fields](#delete-fields) you don’t need instead.
 
 <Warning>
 Trimming a dataset deletes all data blocks before the specified date.
@@ -128,7 +128,7 @@ The data schema of your dataset is defined on read. Axiom continuously creates a
 
 In this case, vacuuming fields in a dataset can help you reduce the number of fields associated with a dataset and stay within the allowed limits. Vacuuming fields resets the number of fields associated with a dataset to the fields that occur in events within your retention period. Technically, it wipes the data schema and rebuilds it from the data you currently have in the dataset, which is partly defined by the retention period. For example, you have ingested 500 fields over the last year and 50 fields in the last 95 days, which is your retention period. In this case, before vacuuming, your data schema contains 500 fields. After vacuuming, the dataset only contains 50 fields.
 
-Vacuuming fields doesn’t delete any events from your dataset. To delete events, [trim the dataset](#trim-dataset). You can use trimming and vacuuming in combination. For example, if you accidentally ingested events with fields you didn’t want to send to Axiom, and these events are within your retention period, vacuuming alone doesn’t solve your problem. In this case, first trim the dataset to delete the events with the unintended fields, and then vacuum the fields to rebuild the data schema.
+Vacuuming fields doesn’t delete any events from your dataset. To delete events, [trim the dataset](#trim-dataset). Vacuuming only removes fields that no longer occur in any event within your retention period. If you accidentally ingested events with fields you didn’t want to send to Axiom, and these events are within your retention period, vacuuming alone doesn’t solve your problem. In this case, [delete the unintended fields](#delete-fields) instead.
 
 You can vacuum the fields of a dataset whose schema is locked. In this case, Axiom vacuums the fields and then regenerates the locked schema so that it matches the vacuumed fields. For more information, see [Lock dataset schema](#lock-dataset-schema).
 
@@ -141,6 +141,52 @@ To vacuum fields, follow these steps:
 1. Click <Icon icon="gear" iconType="solid"/> **Settings > Datasets and views**.
 1. In the list, find the dataset where you want to vacuum fields, and then click <img src="/docs/doc-assets/icons/vacuum.svg" className="my-0 mx-0.5 inline-block size-4 align-text-bottom object-contain dark:invert" alt="Vacuum fields icon" /> **Vacuum fields** on the right.
 1. Select the checkbox, and then click **Vacuum**.
+
+## Delete fields
+
+Deleting fields removes specific fields from the data schema of an event dataset. This is useful if you accidentally ingested fields you don’t want in Axiom, or if the number of fields in the dataset approaches the [allowed limits](/reference/limits#pricing-based-limits) and you want to remove the fields you don’t need.
+
+Deleting fields differs from the other ways of reducing the number of fields:
+
+- [Vacuuming fields](#vacuum-fields) only removes fields that no longer occur in any event within your retention period. Deleting fields removes the fields you select, even if events within your retention period contain them.
+- [Trimming a dataset](#trim-dataset) deletes events. Deleting fields doesn’t delete any events. All other fields of the events remain queryable.
+
+<Warning>
+Deleting fields can’t be undone. After deletion, you can’t query the values of the deleted fields in events you ingested before the deletion.
+</Warning>
+
+Deleting fields works in the following way:
+
+- Axiom removes the deleted fields from the schema, the list of fields in the Datasets tab, and query autocomplete. Field descriptions, units, and hidden settings for the deleted fields are removed as well.
+- The values of the deleted fields stay in storage but you can’t access them anymore. Deleting fields doesn’t reduce the storage usage of your dataset.
+- Saved queries, dashboards, monitors, and virtual fields that reference a deleted field stop returning data for that field. Review these before you delete fields.
+- Deleting fields doesn’t prevent Axiom from adding the fields again. If you ingest events that contain a deleted field after the deletion, Axiom adds the field to the schema again and you can query the newly ingested values. The values you ingested before the deletion remain inaccessible. To stop a field from coming back, fix the data source or [lock the schema](#lock-dataset-schema) after the deletion completes.
+- Field deletion is an asynchronous operation. When you submit a request, Axiom queues the deletion and processes it in the background. The deletion can take several hours to complete, depending on the size of the dataset. During this time, the fields still appear in the Fields panel and in query results. The request appears as `deleteDatasetFields` in the [audit log](/reference/audit-log).
+
+<Note>
+- You can delete fields from event datasets only. Metrics datasets don’t support deleting fields.
+- To delete fields, you need the same permissions as for [vacuuming fields](/reference/settings#assign-capabilities-to-roles). Without these permissions, Axiom doesn’t display the menu option below.
+- You can delete fields from a dataset once every 5 minutes. If a field deletion started on the dataset less than 5 minutes ago, wait and try again.
+- You can’t delete fields while the schema of the dataset is locked. [Unlock the schema](#lock-dataset-schema) first, delete the fields, and then lock the schema again.
+- You can’t delete fields from a dataset that another organization has shared with your organization, or from a dataset that you have set up through the [Cloudflare Logpush](/apps/cloudflare-logpush), [Vercel](/apps/vercel), or [Netlify](/apps/netlify) integration.
+- You can’t delete the fields that Axiom creates automatically, such as `_time`, `_sysTime`, and `_rowId`.
+- You can’t delete a field that’s configured as a [map field](/apl/data-types/map-fields). To delete it, first remove the map field configuration, and then delete the field.
+- Virtual fields don’t store data. To delete a virtual field, see [Virtual fields](/query-data/virtual-fields).
+</Note>
+
+To delete fields, follow these steps:
+
+1. Go to the Datasets tab.
+1. In the list, select the dataset from which you want to delete fields.
+1. In the **Fields** panel, click <Icon icon="ellipsis-vertical" iconType="solid"/> **More > Delete fields**.
+1. Enter a pattern that matches the names of the fields you want to delete, and then click **Find fields**. Axiom lists all fields whose name contains the pattern. The pattern is case-insensitive. Leave the pattern empty to list all fields.
+1. Axiom selects all matching fields by default. Clear the checkbox next to the fields you want to keep. Use **Check all** and **Uncheck all** to change the selection of all matching fields. Fields you can’t delete appear greyed out with an explanation.
+1. Click **Delete fields**.
+1. Review the list of fields, and then click **Delete**.
+
+Axiom displays a message that the deletion started. The deleted fields disappear from the Fields panel when the deletion completes.
+
+To delete fields using the Axiom API, send a POST request to the [delete fields endpoint](/restapi/endpoints/deleteDatasetFields) with the list of field names in the request body. To delete a single field, send a DELETE request to the [delete field endpoint](/restapi/endpoints/deleteFieldForDataset). Both endpoints return the status code 202 when the deletion is queued, and the status code 429 with a `Retry-After` header if a field deletion started on the dataset in the last 5 minutes.
 
 ## Lock dataset schema
 
@@ -172,7 +218,7 @@ Axiom still ingests the events themselves and only drops the fields that don’t
 
 Axiom calculates ingest usage based on the data as it arrives. Fields that Axiom discards because the schema is locked still count towards your ingest usage.
 
-Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, ensure that fields have consistent types, or keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [vacuum its fields](#vacuum-fields).
+Locking the schema can be useful if you want to protect a dataset with a well-defined schema from unexpected fields, ensure that fields have consistent types, or keep the number of fields within the [allowed limits](/reference/limits#pricing-based-limits). To reduce the number of fields already associated with a dataset, [delete fields](#delete-fields) or [vacuum its fields](#vacuum-fields).
 
 Locking and unlocking the schema take effect immediately and don’t change the data stored in the dataset. When you unlock the schema, Axiom restores the default behavior and adds new fields to the schema during the data ingestion process. Unlocking doesn’t restore fields or values that Axiom discarded while the schema was locked.
 

--- a/content/docs/(documentation)/reference/limits.mdx
+++ b/content/docs/(documentation)/reference/limits.mdx
@@ -44,7 +44,8 @@ Axiom restricts the number of datasets and the number of fields in your datasets
 If you ingest a new event that would exceed the allowed number of fields in a dataset, Axiom returns an error and rejects the event. To prevent this error, ensure that the number of fields in your events are within the allowed limits.
 
 To reduce the number of fields in a dataset, use one of the following approaches:
-- [Trim the dataset](/reference/datasets#trim-dataset) and [vacuum its fields](/reference/datasets#vacuum-fields).
+- [Delete the fields](/reference/datasets#delete-fields) you don’t need.
+- [Vacuum the fields](/reference/datasets#vacuum-fields) to remove fields that no longer occur in events within your retention period. If necessary, [trim the dataset](/reference/datasets#trim-dataset) first.
 - Use [map fields](/apl/data-types/map-fields).
 
 To prevent new fields from being added to an event dataset, [lock its schema](/reference/datasets#lock-dataset-schema).

--- a/content/docs/(documentation)/reference/settings.mdx
+++ b/content/docs/(documentation)/reference/settings.mdx
@@ -116,7 +116,7 @@ The table below describes these dataset-level capabilities:
 | Share | User can share datasets. | User can access the list of shared datasets in their organization. | User can modify an existing shared dataset in their organization.      | — |
 | Saved queries | User can create a saved query for datasets. | User can access the list of saved queries in their organization. | User can modify an existing saved query in their organization.      | User can delete a saved query from a dataset. |
 | Trim          | —                                                         | —              | User can trim datasets.                                                                     | —                                            |
-| Vacuum          | —                                                         | —              | User can vacuum datasets.                                                                     | —                                            |
+| Vacuum          | —                                                         | —              | User can vacuum datasets and delete fields from datasets.                                     | —                                            |
 | Virtual fields | User can create a new virtual field. | User can see the list of virtual fields. | User can modify the definition of a virtual field. | User can delete a virtual field. |
 
 <AccessToDatasets />

--- a/content/docs/(query-reference)/apl/data-types/map-fields.mdx
+++ b/content/docs/(query-reference)/apl/data-types/map-fields.mdx
@@ -83,7 +83,7 @@ To view map fields:
 
 - **MAPPED** means that the field was previously an ordinary field but at some point its parent was changed to a map field. Axiom adds new events to the field as an attribute of the parent map field. Events you ingested before the change retain the ordinary structure.
 - **UNUSED** means that the field is configured as a map field but you haven’t yet ingested data into it. Once ingested, data within this field won’t count toward your field limit.
-- **REMOVED** means that the field was configured as a map field but at some point it was changed to an ordinary field. Axiom adds new events to the field as usual. Events you ingested before the change retain the map structure. To fully remove this field, first [trim your dataset](/reference/datasets#trim-dataset) to remove the time period when map data was ingested, and then [vacuum the fields](/reference/datasets#vacuum-fields).
+- **REMOVED** means that the field was configured as a map field but at some point it was changed to an ordinary field. Axiom adds new events to the field as usual. Events you ingested before the change retain the map structure. To fully remove this field, [delete the field](/reference/datasets#delete-fields). Alternatively, [trim your dataset](/reference/datasets#trim-dataset) to remove the time period when map data was ingested, and then [vacuum the fields](/reference/datasets#vacuum-fields).
 
 ## Access properties of nested maps
 

--- a/docs.json
+++ b/docs.json
@@ -849,6 +849,8 @@
               "restapi/endpoints/updateDataset",
               "restapi/endpoints/updateFieldForDataset",
               "restapi/endpoints/vacuumDataset",
+              "restapi/endpoints/deleteDatasetFields",
+              "restapi/endpoints/deleteFieldForDataset",
               "restapi/endpoints/deleteDataset"
             ]
           },


### PR DESCRIPTION
Documents dataset field deletion (axiomhq/axiom#18706, console in axiomhq/ctrl#8872): a new **Delete fields** section on `/reference/datasets`, two v2 endpoint pages, and cross-links from limits, RBAC, audit log, Datasets tab, and map fields.

The `v2.json` entries are the output of `make v2-api-docs` on axiom main (261f108cdd), spliced in as-is. A full regeneration also brings ~1,650 lines of unrelated dashboards-schema drift, left for a separate PR.

Prod queue wiring merged today (axiomhq/axiom#18799); the console UI is in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LDRV5HBHxevjnpdsCkPq1
