### PR TITLE
Add MPL guidance for querying summary metrics

### DIFF
--- a/assets/icons/index.tsx
+++ b/assets/icons/index.tsx
@@ -28,6 +28,7 @@ import { ObservabilityIcon } from "./observability";
 import { ProductAnalyticsIcon } from "./product-analytics";
 import { QuickStartIcon } from "./quick-start";
 import {
+  HistogramsSummariesIcon,
   MplFeaturesIcon,
   QueryFeaturesIcon,
   QueryFunctionsIcon,
@@ -72,6 +73,7 @@ export {
   ObservabilityIcon,
   ProductAnalyticsIcon,
   QuickStartIcon,
+  HistogramsSummariesIcon,
   MplFeaturesIcon,
   QueryFeaturesIcon,
   QueryFunctionsIcon,
@@ -146,6 +148,9 @@ export const querySidebarPageIcons: Readonly<
   "/docs/apl/tutorial": sidebarIcon(SampleQueriesIcon),
   "/docs/apl/apl-features": sidebarIcon(QueryFeaturesIcon),
   "/docs/mpl/introduction": sidebarIcon(MplFeaturesIcon),
+  "/docs/mpl/histograms-summaries": sidebarIcon(
+    HistogramsSummariesIcon,
+  ),
   "/docs/mpl/sample-queries": sidebarIcon(SampleQueriesIcon),
   "/docs/mpl/migrate-metrics": sidebarIcon(QueryMigrateIcon),
 };

--- a/assets/icons/query-reference.tsx
+++ b/assets/icons/query-reference.tsx
@@ -3,6 +3,7 @@ import {
   Binary,
   BookMarked,
   BookOpenText,
+  ChartColumn,
   ChartSpline,
   CodeXml,
   ListChecks,
@@ -65,4 +66,10 @@ export function MplFeaturesIcon(
   props: SVGProps<SVGSVGElement>,
 ) {
   return <ChartSpline {...props} strokeWidth={strokeWidth} />;
+}
+
+export function HistogramsSummariesIcon(
+  props: SVGProps<SVGSVGElement>,
+) {
+  return <ChartColumn {...props} strokeWidth={strokeWidth} />;
 }

--- a/content/docs/(documentation)/query-data/metrics.mdx
+++ b/content/docs/(documentation)/query-data/metrics.mdx
@@ -86,6 +86,8 @@ You can query metric data in one of the following ways:
 - **Skills**: Use the [Query metrics skill](/console/intelligence/skills/query-metrics) to give AI agents the ability to query your metrics data via API.
 - **MCP**: Use the [Axiom MCP server](/console/intelligence/mcp-server) to allow an MCP-compatible client to query your metrics data.
 
+Histogram and summary metrics carry several components, so you query them differently from other metric types. For more information, see [Query histogram and summary metrics](/mpl/histograms-summaries).
+
 <Frame>
 <img src="/docs/doc-assets/shots/example-metrics-query.png" alt="Example metrics query" />
 </Frame>

--- a/content/docs/(query-reference)/mpl/histograms-summaries.mdx
+++ b/content/docs/(query-reference)/mpl/histograms-summaries.mdx
@@ -1,0 +1,93 @@
+---
+title: Query histogram and summary metrics
+description: This page explains how to query OpenTelemetry histogram and summary metrics using MPL.
+sidebarTitle: Histograms and summaries
+keywords: ["metrics", "opentelemetry", "otel", "mpl", "metricsdb", "histogram", "summary", "quantile", "percentile"]
+---
+
+Unlike other OpenTelemetry (OTel) metric types, a histogram or summary metric doesn't hold a single measurement. Each one carries several components that mean different things, such as an observation count alongside a distribution. Query these metric types with a function that's aware of that shape, or by selecting the component you want.
+
+## Histogram metrics
+
+Query histogram metrics with `bucket` and an `interpolate_` function: `interpolate_cumulative_histogram` for cumulative temporality, `interpolate_delta_histogram` for delta temporality. Use them when you want the observation count, the average, or an estimated quantile such as the 90th percentile. For the syntax, see [Bucket](/mpl/introduction#bucket). For examples, see [Sample MPL queries](/mpl/sample-queries#histogram).
+
+<Warning>
+Unless you want to sketch which series a metric contains, don't run a plain `align` or `group` over a histogram metric. Its components mean different things, so aggregating them together produces a meaningless result. Use a `bucket` function instead.
+</Warning>
+
+## Summary metrics
+
+<Warning>
+The [OTel data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy) marks summary as a legacy type. It isn't recommended for new applications and exists for compatibility with other formats. If you can choose the instrumentation, a histogram is the better option.
+</Warning>
+
+MPL has no `interpolate_` function for summaries because the producer already computed the quantiles. Instead, select the component you want with the reserved `axiom.summary` and `axiom.quantile` tags, and derive anything else with [compute](/mpl/introduction#compute).
+
+### Count and sum
+
+Filter to the component you want.
+
+```kusto
+`my-metrics`:`service.request.duration`
+| where `service.name` == "checkout"
+| where `axiom.summary` == "count"
+| align to 5m using sum
+```
+
+```kusto
+`my-dataset`:`service.request.duration`
+| where `service.name` == "checkout"
+| where `axiom.summary` == "sum"
+| align to 5m using sum
+```
+
+### Average
+
+Divide the `sum` component by the `count` component with `compute`.
+
+```kusto
+(
+  `my-dataset`:`service.request.duration`
+  | where `service.name` == "checkout"
+  | where `axiom.summary` == "sum"
+  | group using sum,
+  `my-dataset`:`service.request.duration`
+  | where `service.name` == "checkout"
+  | where `axiom.summary` == "count"
+  | group using sum
+)
+| compute average using /
+```
+
+### Minimum and maximum
+
+If the producer emits the `0.0` and `1.0` quantiles, use them as the minimum and the maximum.
+
+```kusto
+// Minimum
+`my-dataset`:`service.request.duration`
+| where `service.name` == "checkout"
+| where `axiom.summary` == "bucket" and `axiom.quantile` == 0.0
+```
+
+```kusto
+// Maximum
+`my-dataset`:`service.request.duration`
+| where `service.name` == "checkout"
+| where `axiom.summary` == "bucket" and `axiom.quantile` == 1.0
+```
+
+### Quantiles
+
+A summary only contains the quantiles the producer computed. You can select one of them, but you can't derive a quantile that isn't there.
+
+```kusto
+// Median, if the producer emits the 0.5 quantile
+`my-dataset`:`service.request.duration`
+| where `service.name` == "checkout"
+| where `axiom.summary` == "bucket" and `axiom.quantile` == 0.5
+```
+
+<Warning>
+As with histograms, avoid a plain `align` or `group` over a summary metric unless you want to sketch which series it contains.
+</Warning>

--- a/content/docs/(query-reference)/mpl/introduction.mdx
+++ b/content/docs/(query-reference)/mpl/introduction.mdx
@@ -318,6 +318,8 @@ Available functions:
 
 <Info>
 `interpolate_cumulative_histogram` works on histogram metrics using cumulative temporality. `interpolate_delta_histogram` works on histogram metrics using delta temporality.
+
+MPL has no equivalent function for summary metrics. For more information, see [Query histogram and summary metrics](/mpl/histograms-summaries).
 </Info>
 
 **Examples:**

--- a/content/docs/(query-reference)/mpl/sample-queries.mdx
+++ b/content/docs/(query-reference)/mpl/sample-queries.mdx
@@ -44,6 +44,19 @@ Calculate the 90th and 99th percentile HTTP request durations by service.
 
 [Run in Playground](https://play.axiom.co/axiom-play-qf1k/query?initForm=%7B%22apl%22%3A%22%60otel-demo-metrics%60%3A%60http.server.request.duration%60%20%7C%20where%20%60http.response.status_code%60%20%3C%20400%20%7C%20bucket%20by%20%60http.request.method%60%2C%20%60http.route%60%20to%205m%20using%20interpolate_cumulative_histogram(rate%2C%200.90%2C%200.99)%22%2C%22metricsDataset%22%3A%22otel-demo-metrics%22%7D)
 
+### Bucket distribution
+
+Show how request durations are distributed across a histogram's buckets. Visualize the result with a [heatmap](/dashboard-elements/heatmap) dashboard element.
+
+```kusto
+`otel-demo-metrics`:`http.server.request.duration`
+| where `axiom.histogram` == "bucket"
+| align to 5m using prom::rate
+| group by `axiom.le` using sum
+```
+
+[Run in Playground](https://play.axiom.co/axiom-play-qf1k/query?initForm=%7B%22apl%22%3A%22%60otel-demo-metrics%60%3A%60http.server.request.duration%60%20%7C%20where%20%60axiom.histogram%60%20%3D%3D%20%5C%22bucket%5C%22%20%7C%20align%20to%205m%20using%20prom%3A%3Arate%20%7C%20group%20by%20%60axiom.le%60%20using%20sum%22%2C%22metricsDataset%22%3A%22otel-demo-metrics%22%7D)
+
 ## Compute
 
 ### Compute error rate

--- a/docs.json
+++ b/docs.json
@@ -783,6 +783,7 @@
             "group": "MPL",
             "pages": [
               "mpl/introduction",
+              "mpl/histograms-summaries",
               "mpl/sample-queries",
               "mpl/migrate-metrics"
             ]

--- a/tests/e2e/docs.spec.ts
+++ b/tests/e2e/docs.spec.ts
@@ -114,7 +114,7 @@ test('shared icon cards match the www treatment with compact docs spacing', asyn
 
   await page.goto('/docs/apps/introduction');
   const extensionCards = page.locator('.app-cards > .icon-card');
-  await expect(extensionCards).toHaveCount(12);
+  await expect(extensionCards).toHaveCount(13);
   await expect(extensionCards.first()).toHaveClass(/app-card/);
   await expect(extensionCards.first()).toHaveCSS('gap', '24px');
   await expect(extensionCards.first()).toHaveAttribute('href', '/docs/apps/lambda');

--- a/tests/e2e/docs.spec.ts
+++ b/tests/e2e/docs.spec.ts
@@ -1364,6 +1364,7 @@ test('query reference sidebar icons stay on top-level options', async ({ page })
     '/docs/apl/tutorial',
     '/docs/apl/apl-features',
     '/docs/mpl/introduction',
+    '/docs/mpl/histograms-summaries',
     '/docs/mpl/sample-queries',
     '/docs/mpl/migrate-metrics',
   ];
@@ -1378,7 +1379,7 @@ test('query reference sidebar icons stay on top-level options', async ({ page })
       .filter({ hasText: new RegExp(`^${title}$`) });
     await expect(row.locator(':scope > [data-slot="sidebar-icon"]')).toHaveCount(1);
   }
-  await expect(querySidebar.locator('[data-slot="sidebar-icon"]')).toHaveCount(11);
+  await expect(querySidebar.locator('[data-slot="sidebar-icon"]')).toHaveCount(12);
   await expect(
     querySidebar.locator('[data-sidebar-child] [data-slot="sidebar-icon"]'),
   ).toHaveCount(0);


### PR DESCRIPTION
summary metrics are rare, legacy but there are users using it, but it doesn't have dedicated bucket function like interpolate_***_histogram (and we don't plan to), so it needs more guidance 

- Add a Query reference page covering both: use a bucket function for histograms, and select components with the reserved axiom tags plus compute for summaries. 

- Also add a bucket distribution sample query (which we use often in metrics dashboard!)