### PR TITLE
Update default audit log query window to 30 days

### DIFF
--- a/content/docs/(documentation)/reference/audit-log.mdx
+++ b/content/docs/(documentation)/reference/audit-log.mdx
@@ -20,7 +20,7 @@ The audit log also make it easier to manage your Axiom organization. They allow 
 - Monitor query costs and optimize expensive queries before they impact your budget.
 - Trace queries back to their source (monitors or direct queries) for debugging.
 
-The audit log is available to all organizations. By default, you can query the audit log for the previous three days. You can purchase full access to the audit log as an add-on on the Axiom Cloud plan. For more information, see [Manage add-ons](/reference/usage-billing#manage-add-ons).
+The audit log is available to all organizations. By default, you can query the audit log for the previous 30 days. You can purchase full access to the audit log as an add-on on the Axiom Cloud plan. For more information, see [Manage add-ons](/reference/usage-billing#manage-add-ons).
 
 ## Explore audit log
 


### PR DESCRIPTION
## Overview

The default audit log query window (the range organizations can query without the audit log add-on) is increasing from 3 days to 30 days. This updates the one place in the docs that states the old value.

## Changes

- `reference/audit-log.mdx`: "previous three days" → "previous 30 days".

No other page states the window. `platform-overview/security.mdx` and `reference/usage-billing.mdx` describe the add-on without a number, so they stay as they are.

## Notes

- Opened as a draft until the 30-day window is live for Axiom Cloud organizations. As of 2026-09-09 the seeded plan template on `axiom` main still sets `MaxAuditWindow` to 3 days, so this is expected to land as a plan change rather than a code change.
- Vale reports one pre-existing error on this page (`Google.Units` on `1d` inside a code block) that is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3nBu1MbovXegB9CzSkQuz