### PR TITLE
Add self-hosted EventDB deployment docs

### DIFF
--- a/content/docs/(documentation)/self-hosted/backup-restore.mdx
+++ b/content/docs/(documentation)/self-hosted/backup-restore.mdx
@@ -1,0 +1,119 @@
+---
+title: 'Back up and restore PostgreSQL'
+sidebarTitle: Back up and restore
+description: 'Enable continuous WAL archiving and scheduled base backups for the PostgreSQL cluster in a self-hosted EventDB deployment, and restore to a point in time with CloudNativePG.'
+keywords: ['self-hosted', 'eventdb', 'backup', 'restore', 'postgresql', 'cloudnativepg', 'barman', 'point-in-time recovery', 'wal archiving']
+---
+
+PostgreSQL holds EventDB's dataset metadata and Atom's management state: organizations, users, API tokens, and the mapping from dataset names to the blocks in object storage. Everything else in a self-hosted deployment is either rebuilt from object storage or is the object store itself. PostgreSQL is what needs a backup.
+
+Replication is not one. The three instances survive losing a node; they do not survive a migration that drops the wrong table, because the standbys replay it as faithfully as everything else, and they do not survive losing the storage they all sit on.
+
+## How backups work
+
+`postgresql.backups` turns on CloudNativePG's built-in Barman Cloud support: continuous WAL archiving plus a scheduled base backup to an S3-compatible bucket. Together they give point-in-time recovery to any moment inside the retention window.
+
+- **WAL segments** are archived as they close, and at least every five minutes, so the recovery point is at most that far behind.
+- **A base backup** runs daily at 02:00 UTC by default, from a standby so the primary is not read end to end. The first runs at install.
+- **Retention** prunes base backups older than `retentionPolicy`, with the WAL segments only they needed.
+
+<Warning>
+Put the bucket outside the cluster. The chart-managed RGW runs on the same Ceph the PostgreSQL volumes are likely to, and a backup that dies with the thing it protects is not one. Use a second site, a cloud bucket, or a separate object store.
+</Warning>
+
+## Enable backups
+
+Create the credentials Secret. Its key names are the upstream chart's and differ from `eventdb-s3-credentials` on purpose: these are different credentials to a different bucket, and they need list, read, write, and delete on it, because retention prunes.
+
+```bash
+kubectl -n axiom-system create secret generic axiom-postgresql-backup \
+  --from-literal=ACCESS_KEY_ID="$BACKUP_KEY" \
+  --from-literal=ACCESS_SECRET_KEY="$BACKUP_SECRET"
+```
+
+Then add the backup configuration to the values file and upgrade:
+
+```yaml
+postgresql:
+  backups:
+    enabled: true
+    # Full URL with scheme. Leave empty on AWS to derive it from s3.region.
+    endpointURL: https://s3.backup.example.internal
+    s3:
+      region: us-east-1
+      bucket: axiom-postgresql-backups
+    secret:
+      name: axiom-postgresql-backup
+    retentionPolicy: "30d"
+```
+
+Barman creates the bucket on first use when the credentials allow it; otherwise create it first. Everything lands under `<bucket>/<s3.path>/postgresql/`, the cluster name, so one bucket can serve several releases as long as their cluster names differ.
+
+For a privately signed endpoint certificate, hand the CA bundle to the operator through `postgresql.backups.endpointCA`. Leave `wal.encryption` and `data.encryption` empty unless your store is configured for the explicit `AES256` header; Ceph RGW and MinIO reject it otherwise.
+
+## Check on it
+
+```bash
+kubectl -n axiom-system get scheduledbackups,backups
+kubectl -n axiom-system get cluster postgresql \
+  -o jsonpath='{.status.firstRecoverabilityPoint}{"\n"}'
+```
+
+An empty first recoverability point means no base backup has completed yet. A `Backup` in phase `failed` carries the reason in its status, and a WAL archiving failure surfaces as the cluster's `ContinuousArchiving` condition:
+
+```bash
+kubectl -n axiom-system get cluster postgresql \
+  -o jsonpath='{.status.conditions[?(@.type=="ContinuousArchiving")]}'
+```
+
+Barman runs inside the PostgreSQL image. The default `ghcr.io/cloudnative-pg/postgresql:17` ships it; the `-minimal` and `-standard` flavours do not, and a cluster on one of those archives nothing and says so in that condition.
+
+## Restore
+
+A restore is a new cluster bootstrapped from the archive, not an operation on the running one. Install a new release, or the same release once the original cluster is gone, with the upstream chart's recovery mode:
+
+```yaml
+postgresql:
+  mode: recovery
+  recovery:
+    method: object_store
+    clusterName: postgresql          # the archive's server name
+    database: eventdb
+    owner: eventdb
+    endpointURL: https://s3.backup.example.internal
+    s3:
+      region: us-east-1
+      bucket: axiom-postgresql-backups
+    secret:
+      create: false
+      name: axiom-postgresql-backup
+    pitrTarget:
+      time: "2026-09-07T01:30:00Z"   # omit to replay every archived WAL
+  backups:
+    # As before, but archiving somewhere new: see below.
+    enabled: true
+    s3:
+      path: /restored-2026-09-07/
+```
+
+The operator replays the newest base backup before the target and the WAL segments up to it. Three things to know before you need them:
+
+- **Bootstrap is read once.** `mode: recovery` stays in the values from then on. Changing it back would rewrite an immutable field and the upgrade fails.
+- **The application password is reset.** The upstream chart does not pass a Secret to the recovery bootstrap, so the operator mints a `postgresql-app` Secret and sets the `eventdb` role's password from it, while the workloads keep reading `axiom-postgresql-app`. Make the two agree once the cluster is up, from the one the workloads use:
+
+  ```bash
+  kubectl -n axiom-system patch secret postgresql-app --type merge \
+    -p "{\"data\":{\"password\":\"$(kubectl -n axiom-system get secret axiom-postgresql-app -o jsonpath='{.data.password}')\"}}"
+  ```
+
+  Atom's role is declared under `postgresql.cluster.roles` with its own `passwordSecret`, so the operator re-applies it from `axiom-postgresql-atom` unprompted.
+- **Archive somewhere new.** The restored cluster is a new timeline. Barman refuses to archive into a WAL archive that already holds one for the same server name, so the restored cluster's own `backups` need a different `s3.path` or bucket, or it comes up with archiving failed.
+
+Then run the EventDB and Atom migrate Jobs as any upgrade does; they are idempotent.
+
+## What is not backed up here
+
+- **Event data** lives in object storage and is not part of this backup. Protect the bucket with your object store's own replication or snapshots, and never with lifecycle rules.
+- **The shared WAL** holds only unflushed events. A graceful ingest restart flushes it.
+- **The `axiom-atom` Secret**, in particular `token-hash-secret`, is not in PostgreSQL. Without it every API token in a restored database is unusable. Back it up with your other Secrets.
+- **Valkey** is a cache and needs no backup.

--- a/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
+++ b/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
@@ -721,6 +721,7 @@ aws --endpoint-url http://127.0.0.1:18333 s3 ls s3://eventdb/blocks/connectivity
 
 - **Publish Atom.** See [Operate](/self-hosted/operate#expose-atom) to enable the Ingress with TLS and, optionally, OIDC single sign-on for the console.
 - **Send data.** Point the Axiom SDKs, the CLI, or an OpenTelemetry Collector at Atom's URL with an `xaat-` token, exactly as you would at Axiom Cloud. See [Send data](/send-data/methods).
+- **Plan upgrades.** See [Upgrade](/self-hosted/upgrade) before the first new release lands: it covers the pre-flight checks and the operator ordering.
 - **Back up PostgreSQL.** See [Back up and restore](/self-hosted/backup-restore) to turn on continuous WAL archiving to a bucket outside the cluster.
 - **Monitor.** See [Operate](/self-hosted/operate#monitor-with-prometheus) to scrape EventDB, Atom, and Ceph with Prometheus Operator.
 - **Splunk.** Enable the [Axiom Portal for Splunk](/splunk/portal/overview) with `splunkPortal.enabled` and point it at Atom so that federated searches are authenticated.

--- a/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
+++ b/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
@@ -1,0 +1,727 @@
+---
+title: 'Deploy EventDB on bare metal'
+sidebarTitle: Deploy on bare metal
+description: 'Step-by-step tutorial for deploying self-hosted Axiom EventDB with the axiom-eventdb Helm chart on a bare-metal or on-premises Kubernetes cluster, with Rook/Ceph object storage, a CephFS write-ahead log, and Atom.'
+keywords: ['self-hosted', 'eventdb', 'helm', 'bare metal', 'on-premises', 'kubernetes', 'rook', 'ceph', 'cephfs', 'atom', 'install', 'tutorial']
+---
+
+This tutorial deploys self-hosted EventDB on a bare-metal or on-premises Kubernetes cluster. When you finish, you have a running EventDB with Rook-managed Ceph object storage, a CephFS-backed write-ahead log, a three-instance PostgreSQL cluster, Valkey, and Atom publishing an authenticated, Axiom-compatible API and console.
+
+The guide works with any conformant Kubernetes distribution that satisfies [Requirements](/self-hosted/requirements), such as kubeadm, RKE2, or k3s. Host-level factors outside Kubernetes, such as restrictive SELinux policies or a kernel without the `cephfs` module, can still affect a given environment.
+
+For what the chart deploys and why, see [Overview](/self-hosted/overview). For the full list of values, read the chart's `values.yaml`: every key is documented in place.
+
+## Prerequisites
+
+Ensure you have the following tools installed:
+
+- **kubectl**, compatible with your target Kubernetes version
+- **Helm** 3.18 or later
+- **skopeo**, for copying container images between registries
+- **curl** and **jq**, for verification
+
+You also need:
+
+- A **Kubernetes cluster** that meets the requirements in Step 1.
+- A **private, OCI-compatible container registry** reachable from every node.
+- **Access to Axiom's release registry.** Registry credentials, the EventDB release tag, the Atom tag, and the chart version are provided by Axiom during onboarding.
+- A **licence configuration** for EventDB, also provided during onboarding.
+
+The commands below use these variables. Set them once in your shell:
+
+```bash
+# your private registry (host, or host and project path)
+REGISTRY_HOST=registry.internal:5000
+
+# provided by Axiom during onboarding
+AXIOM_REGISTRY=<axiom-release-registry>
+EVENTDB_TAG=<eventdb-release-tag>
+ATOM_TAG=<atom-commit-tag>
+CHART_VERSION=0.0.1-alpha.<sha>
+
+# release namespace
+NAMESPACE=axiom-system
+```
+
+## Step 1: Prepare the Kubernetes cluster
+
+### Cluster
+
+| Requirement | Details |
+| :--- | :--- |
+| Kubernetes version | 1.28 or later. |
+| CNI | Any CNI providing standard IPv4 pod networking, such as Cilium, Calico, or Canal. |
+| Container runtime | Any CRI-compatible runtime, such as containerd. |
+| DNS | A working in-cluster DNS. |
+| Kernel | The `cephfs` and `rbd` kernel modules on every node that runs EventDB pods, so the CephFS write-ahead log can mount. Load them with `modprobe cephfs rbd` and persist the change in `/etc/modules-load.d/`. |
+
+### Node roles
+
+Dedicate nodes to Ceph storage and keep at least three more for the EventDB workloads and their datastores. Label the nodes so that the values file can place Ceph on the storage nodes and everything else away from them.
+
+| Role | Count | Node label | Taint |
+| :--- | :--- | :--- | :--- |
+| Storage | 3 or more | `axiom.co/role=storage` | `axiom.co/storage=true:NoSchedule` |
+| EventDB | 3 or more | `axiom.co/role=eventdb` | none |
+| Control plane and add-ons | 1 or more | none required | none |
+
+Apply the labels and taints with `kubectl`:
+
+```bash
+# storage nodes: one per failure domain, each with dedicated raw disks
+for node in <storage-node-1> <storage-node-2> <storage-node-3>; do
+  kubectl label node "$node" axiom.co/role=storage --overwrite
+  kubectl taint node "$node" axiom.co/storage=true:NoSchedule --overwrite
+done
+
+# EventDB nodes
+for node in <eventdb-node-1> <eventdb-node-2> <eventdb-node-3>; do
+  kubectl label node "$node" axiom.co/role=eventdb --overwrite
+done
+```
+
+The Ceph daemons tolerate the storage taint through the `placement` blocks in Step 6. The EventDB workloads never carry that toleration, so they cannot land on a storage node.
+
+### Failure domains
+
+Ceph's pools are replicated three ways with `failureDomain: host`, and its three monitors refuse to share a node, so three storage nodes is the minimum. Put them on separate power feeds or racks so that losing one domain loses one replica.
+
+PostgreSQL's three instances spread across nodes with pod anti-affinity, which the operator enforces by default, so the EventDB nodes need to be at least three as well.
+
+<Note>
+**Sizing.** Storage nodes need one core and about 4 GiB of memory per OSD, plus 2 GiB each for a monitor and a manager. Size the EventDB nodes for the workload; the chart's multi-mode defaults request about 15 cores and 21 GiB for EventDB, plus roughly 4 cores and 8 GiB for PostgreSQL, Valkey, and Atom. See [Sizing](/self-hosted/requirements#sizing) for scaling beyond that.
+</Note>
+
+## Step 2: Mirror container images
+
+Copy the Axiom images from the release registry into your private registry with `skopeo`. The `--all` flag preserves every architecture in a multi-arch image.
+
+```bash
+# log into the Axiom release registry with the credentials from onboarding
+skopeo login $AXIOM_REGISTRY
+
+# log into your private registry (the method may differ for your registry)
+skopeo login $REGISTRY_HOST
+
+# EventDB: all three images share the release tag
+for image in eventdb-db eventdb-query-worker eventdb-admin; do
+  skopeo copy --all \
+    docker://$AXIOM_REGISTRY/$image:$EVENTDB_TAG \
+    docker://$REGISTRY_HOST/$image:$EVENTDB_TAG
+done
+
+# Atom is tagged with its own repository's commit, not the EventDB tag
+skopeo copy --all \
+  docker://$AXIOM_REGISTRY/atom:$ATOM_TAG \
+  docker://$REGISTRY_HOST/atom:$ATOM_TAG
+```
+
+The dependency subcharts pull their own upstream images: Rook, Ceph, the Ceph CSI plugins, CloudNativePG, PostgreSQL, Valkey, and the `busybox` and `amazon/aws-cli` images the bootstrap Jobs run. In a disconnected environment, render the chart with your values file once you have written it in Step 6 and mirror every image it references:
+
+```bash
+helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $CHART_VERSION --namespace $NAMESPACE --values values.yaml \
+  | grep -E '^\s+image: ' | sort -u
+```
+
+Images that the Rook operator launches at runtime, such as the Ceph daemons and CSI sidecars, come from `rookCephCluster.cephImage` and the `rookCephOperator.csi` image settings rather than from rendered pod specs. Set both to your registry and mirror the tags they name.
+
+If your registry requires authentication for pulls, create the release namespace and a pull secret now, then attach it to the default service account so every pod in the namespace, including those the operators create, can pull:
+
+```bash
+kubectl create namespace $NAMESPACE
+
+kubectl create secret docker-registry registry-credentials \
+  --docker-server=$REGISTRY_HOST \
+  --docker-username=<username> \
+  --docker-password=<password> \
+  -n $NAMESPACE
+
+kubectl patch serviceaccount default -n $NAMESPACE \
+  -p '{"imagePullSecrets":[{"name":"registry-credentials"}]}'
+```
+
+The chart creates a dedicated `axiom-eventdb` service account for the EventDB pods. Patch it the same way after the first install, or set `eventdb.serviceAccount.create: false` and create the account with the pull secret attached beforehand.
+
+## Step 3: Provision local storage
+
+Three kinds of storage are needed, and they are provisioned differently:
+
+- **Raw disks for Ceph OSDs** on the storage nodes. Rook claims them whole; they hold every EventDB block and the CephFS write-ahead log.
+- **A block StorageClass** for PostgreSQL, Valkey, and their write-ahead logs. These are ReadWriteOnce volumes.
+- **A ReadWriteMany StorageClass** for the shared EventDB write-ahead log. This guide gets it from a CephFS on the same Rook cluster, so nothing external is required.
+
+<Note>
+**Durability.** EventDB's source of truth is object storage. The shared WAL holds only what has not yet been flushed into a block, and the delta cache is rebuilt from it. PostgreSQL holds dataset metadata and Atom's management state and is the one datastore that needs [backups](/self-hosted/backup-restore).
+</Note>
+
+### Prepare the Ceph devices
+
+On each storage node, identify the disks Ceph will own and confirm they are empty. Rook refuses a device that carries a filesystem, partition table, or LVM signature, and it never touches a disk that is not in its inventory.
+
+```bash
+# list block devices and their stable by-id paths
+lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT
+ls -l /dev/disk/by-id/ | grep -v part
+
+# wipe a disk that was used before (destroys its contents)
+sudo sgdisk --zap-all /dev/nvme1n1
+sudo wipefs --all /dev/nvme1n1
+sudo dd if=/dev/zero of=/dev/nvme1n1 bs=1M count=100 oflag=direct
+```
+
+Record each device's `/dev/disk/by-id/` path and the node name it belongs to. Step 6 lists them explicitly; the chart never lets Rook claim "all devices".
+
+<Warning>
+Never list an OS or root disk. Rook creates an OSD on every device in the inventory and the data on it is gone.
+</Warning>
+
+### Provide a block StorageClass
+
+PostgreSQL, its WAL volume, and Valkey claim ReadWriteOnce volumes from a class you name in the values. Any performant provisioner works. On bare metal that is commonly:
+
+- **A local-path provisioner** on the EventDB nodes' NVMe, for the best latency. PostgreSQL and Valkey replicate across nodes, so node-bound volumes are acceptable.
+- **A Ceph RBD class** from the same Rook cluster. Declare it under `rookCephCluster.cephBlockPools` with `storageClass.enabled: true`; it becomes available after the Ceph cluster is healthy, which the bootstrap pass in Step 7 accounts for.
+
+PostgreSQL's WAL volume defaults to 30 GiB and its data volume to 50 GiB per instance. Confirm the class has that capacity on three nodes.
+
+### Provide a ReadWriteMany class for the shared WAL
+
+Six EventDB workloads mount one write-ahead-log volume, and the chart insists it is `ReadWriteMany`: a ReadWriteOnce volume binds to a node, and the first node replacement strands ingest behind a `Multi-Attach` error that only deleting the claim clears.
+
+This guide sets `eventdb.wal.provider: cephfs`. The chart then declares a `CephFilesystem` on the Rook cluster, creates its StorageClass, and renders the CephFS CSI driver that Rook 1.20 otherwise leaves for you to create. Nothing outside the release is needed. If your cluster already has an RWX class (NFS, a vendor filer), use `provider: existing` and name it in `eventdb.wal.storageClass` instead.
+
+## Step 4: Choose object storage
+
+EventDB stores every block in S3-compatible object storage. On bare metal you have two options.
+
+### Chart-managed Rook/Ceph RGW (this guide)
+
+With `objectStorage.provider: rook`, the chart's Rook subcharts run a Ceph cluster on the devices from Step 3 and expose its RGW S3 gateway inside the cluster. The chart creates the RGW user bound to your credentials Secret and a Job that creates the bucket. This is the self-contained path and the one validated on bare metal.
+
+The RGW serves plain HTTP on its Service name, and EventDB only speaks plain HTTP to a hostname ending in `.localhost`. Step 7 bridges that with a per-pod host alias, so no cluster-wide DNS change is needed.
+
+### An external S3-compatible store
+
+With `objectStorage.provider: external`, EventDB talks to a store you already run: MinIO, SeaweedFS, another Ceph, or AWS S3. Provide:
+
+| Value | Notes |
+| :--- | :--- |
+| `objectStorage.endpoint` | The S3 API URL. Must be HTTPS with a certificate the pods trust, unless the hostname ends in `.localhost`. |
+| `objectStorage.bucket`, `objectStorage.region` | One bucket per release, or a shared bucket with a distinct `objectStorage.prefix`. |
+| `eventdb-s3-credentials` Secret | A static access key pair with read, write, list, and delete on the bucket. |
+| `objectStorage.createBucket` | `true` lets the in-cluster Job create the bucket; `false` assumes it exists. |
+
+Set `rookCephOperator.enabled` and `rookCephCluster.enabled` to `false`, and pick a different WAL provider, since there is no Ceph to put a CephFS on. The chart ships this as an overlay, `values-external-s3.example.yaml`.
+
+<Warning>
+Do not create lifecycle or expiration rules on the bucket, and leave object versioning off. EventDB manages retention per dataset and deletes its own blocks. A lifecycle rule deletes objects EventDB still depends on, which is **data loss**. To manage retention, set it per dataset through Atom.
+</Warning>
+
+## Step 5: Create the namespace and Secrets
+
+Production installs set `credentials.create: false` and read every credential from Secrets you create before installing. Values are embedded into connection URLs, so keep them URL-safe: letters, digits, `-`, `_`, and `.`.
+
+```bash
+kubectl create namespace $NAMESPACE 2>/dev/null || true
+
+gen() { openssl rand -hex 24; }
+
+# EventDB's PostgreSQL role; CloudNativePG creates the database owner from it
+kubectl create secret generic axiom-postgresql-app -n $NAMESPACE \
+  --from-literal=username=eventdb \
+  --from-literal=password="$(gen)"
+
+# Valkey's ACL user
+kubectl create secret generic axiom-valkey-auth -n $NAMESPACE \
+  --from-literal=default="$(gen)"
+
+# object-storage access keys; with the rook provider these seed the RGW user
+kubectl create secret generic eventdb-s3-credentials -n $NAMESPACE \
+  --from-literal=access-key="$(gen)" \
+  --from-literal=secret-key="$(gen)"
+
+# Atom's PostgreSQL role, in the basic-auth shape the operator reads
+kubectl create secret generic axiom-postgresql-atom -n $NAMESPACE \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=atom \
+  --from-literal=password="$(gen)"
+
+# Atom: the token-signing secret and the first-boot owner password
+kubectl create secret generic axiom-atom -n $NAMESPACE \
+  --from-literal=token-hash-secret="$(openssl rand -hex 32)" \
+  --from-literal=admin-password="$(gen)"
+```
+
+<Warning>
+`token-hash-secret` HMACs every API token Atom issues. **It must never change.** Rotating it invalidates every token ever issued. Back it up with the rest of your secrets.
+</Warning>
+
+If you enable [PostgreSQL backups](/self-hosted/backup-restore), also create `axiom-postgresql-backup` with the credentials for the backup bucket. Keep that bucket outside the cluster: a backup that dies with the Ceph it protects is not one.
+
+## Step 6: Write the values file
+
+The chart's base values enable nothing. The file below is a complete production profile for the topology in this guide: multi mode, Rook-managed object storage and CephFS WAL on the labeled storage nodes, PostgreSQL as the job queue, and Atom enabled. Replace every `<...>` placeholder.
+
+```yaml
+# values.yaml
+mode: multi
+
+credentials:
+  create: false
+
+objectStorage:
+  provider: rook
+  bucket: eventdb
+  # A *.localhost name is the one hostname EventDB accepts over plain HTTP.
+  # Step 7 aliases it to the in-cluster RGW Service for this release's pods.
+  endpoint: http://ceph-rgw.eventdb.localhost:80
+
+eventdb:
+  enabled: true
+  environment: prod
+  image:
+    db:
+      repository: <registry-host>/eventdb-db
+      tag: <eventdb-release-tag>
+    queryWorker:
+      repository: <registry-host>/eventdb-query-worker
+      tag: <eventdb-release-tag>
+    admin:
+      repository: <registry-host>/eventdb-admin
+      tag: <eventdb-release-tag>
+  config:
+    # Production must run with the licence configuration from onboarding.
+    useDebugLicence: "0"
+    extra: {}
+  queues:
+    backend: postgres
+  # Keep every EventDB pod off the Ceph storage nodes.
+  scheduling:
+    nodeSelector:
+      axiom.co/role: eventdb
+  wal:
+    provider: cephfs
+    storageClass: ""     # derived from the CephFilesystem below
+    size: 100Gi
+  # The four hot-path components scale on CPU from the tested floor.
+  # Needs metrics-server; decide at install time (see Operate).
+  ingest:
+    autoscaling:
+      enabled: true
+  deltaCache:
+    autoscaling:
+      enabled: true
+  queryRunner:
+    autoscaling:
+      enabled: true
+  queryWorker:
+    autoscaling:
+      enabled: true
+
+atom:
+  enabled: true
+  image:
+    repository: <registry-host>/atom
+    tag: <atom-commit-tag>
+  admin:
+    email: <owner@example.com>
+  autoscaling:
+    enabled: true
+  # Publishing is a separate step once the release is healthy; see Operate.
+  ingress:
+    enabled: false
+
+rookCephOperator:
+  enabled: true
+
+rookCephCluster:
+  enabled: true
+  operatorNamespace: axiom-system
+  cephImage:
+    repository: <registry-host>/ceph/ceph
+    tag: v20.2.2
+  cephClusterSpec:
+    placement:
+      all:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: axiom.co/role
+                    operator: In
+                    values: [storage]
+        tolerations:
+          - key: axiom.co/storage
+            operator: Exists
+            effect: NoSchedule
+    storage:
+      useAllNodes: false
+      useAllDevices: false
+      # The explicit inventory from Step 3. Stable by-id paths only.
+      nodes:
+        - name: <storage-node-1>
+          devices:
+            - name: /dev/disk/by-id/<nvme-serial-1>
+        - name: <storage-node-2>
+          devices:
+            - name: /dev/disk/by-id/<nvme-serial-2>
+        - name: <storage-node-3>
+          devices:
+            - name: /dev/disk/by-id/<nvme-serial-3>
+  # The RGW S3 gateway. Lists replace rather than merge in Helm, so the
+  # chart's default store is repeated here with placement added.
+  cephObjectStores:
+    - name: eventdb-store
+      spec:
+        metadataPool:
+          failureDomain: host
+          replicated:
+            size: 3
+        dataPool:
+          failureDomain: host
+          replicated:
+            size: 3
+        preservePoolsOnDelete: true
+        gateway:
+          port: 80
+          instances: 2
+          placement:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: axiom.co/role
+                        operator: In
+                        values: [storage]
+            tolerations:
+              - key: axiom.co/storage
+                operator: Exists
+                effect: NoSchedule
+      storageClass:
+        enabled: false
+      ingress:
+        enabled: false
+  # The CephFS that backs the shared WAL. Its StorageClass name is what
+  # eventdb.wal.storageClass resolves to.
+  cephFileSystems:
+    - name: eventdb-fs
+      spec:
+        metadataPool:
+          failureDomain: host
+          replicated:
+            size: 3
+        dataPools:
+          - name: data0
+            failureDomain: host
+            replicated:
+              size: 3
+        metadataServer:
+          activeCount: 1
+          activeStandby: true
+          placement:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: axiom.co/role
+                        operator: In
+                        values: [storage]
+            tolerations:
+              - key: axiom.co/storage
+                operator: Exists
+                effect: NoSchedule
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              memory: 4Gi
+      storageClass:
+        enabled: true
+        name: eventdb-fs
+        pool: data0
+        reclaimPolicy: Retain
+        allowVolumeExpansion: true
+        volumeBindingMode: Immediate
+        parameters:
+          csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+          csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+          csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+
+postgresqlOperator:
+  enabled: true
+
+postgresql:
+  enabled: true
+  cluster:
+    storage:
+      storageClass: <block-storage-class>
+    walStorage:
+      storageClass: <block-storage-class>
+    # Atom's role; the password is the axiom-postgresql-atom Secret.
+    roles:
+      - name: atom
+        ensure: present
+        login: true
+        passwordSecret:
+          name: axiom-postgresql-atom
+  databases:
+    - name: atom
+      owner: atom
+  # Turn on once you have a bucket outside the cluster; see Back up and restore.
+  backups:
+    enabled: false
+
+valkey:
+  enabled: true
+  replica:
+    persistence:
+      storageClass: <block-storage-class>
+
+# Jobs queue on PostgreSQL, so no NATS cluster is needed.
+nats:
+  enabled: false
+```
+
+A few of these choices deserve a word:
+
+- **`eventdb.wal.storageClass: ""`** is deliberate. An explicit class always wins over derivation, so the value must be empty for the chart to hand the name to the CephFS it creates.
+- **`queues.backend: postgres`** puts EventDB's background jobs on the PostgreSQL cluster it already runs. There is no extra datastore, no JetStream stream to replicate, and no bootstrap Job. The render refuses `postgres` with `nats.enabled: true`.
+- **Autoscaling is decided at install time.** Turning it on for a running release resets each component's count to one for about fifteen seconds. See [Operate](/self-hosted/operate#scale-and-autoscale).
+- **Nodes without the `cephfs` kernel module** need `mounter: fuse` under the StorageClass `parameters`, or nothing mounts.
+- **Pin digests.** Each image accepts `digest: sha256:...`, which takes precedence over `tag` and cannot be repointed.
+
+The chart validates this file against its schema on every `lint`, `template`, and `install`: an unknown key or a missing storage class fails immediately with a message rather than leaving a claim `Pending`. Check it before touching the cluster:
+
+```bash
+helm registry login ghcr.io   # while the package is private
+helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $CHART_VERSION --namespace $NAMESPACE --values values.yaml >/dev/null \
+  && echo "values render"
+```
+
+<Note>
+**Installing from a checkout instead.** Clone `axiomhq/helm-charts`, run `make deps` to register the upstream repositories and fetch the pinned dependencies, and pass `charts/axiom-eventdb` in place of the OCI reference in every command below.
+</Note>
+
+## Step 7: Install the chart
+
+The install is two passes of the same release. The first installs the operators, the Ceph cluster, and the datastores while EventDB and Atom stay off; the second enables everything. Two things force the split: Helm cannot validate custom resources against CRDs introduced in the same transaction on a cluster that has never seen them, and the RGW Service's ClusterIP, which the host alias needs, does not exist until Ceph is up.
+
+<Warning>
+The bootstrap pass sets `eventdb.enabled=false` and `atom.enabled=false` on the command line. **Never run it against a healthy existing release.** Disabling a data-plane section on an upgrade deletes the live workloads, and disabling `rookCephCluster` or `postgresql` on an upgrade deletes the Ceph and PostgreSQL clusters with their data. The bootstrap pass is an install-time step only.
+</Warning>
+
+### Bootstrap: operators, Ceph, and datastores
+
+```bash
+helm upgrade --install axiom-eventdb \
+  oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $CHART_VERSION \
+  --namespace $NAMESPACE --create-namespace \
+  --values values.yaml \
+  --set eventdb.enabled=false \
+  --set atom.enabled=false \
+  --timeout 15m
+```
+
+Wait for the Ceph cluster to converge. OSD preparation runs one Job per storage node and takes several minutes on first boot:
+
+```bash
+kubectl -n $NAMESPACE get cephcluster eventdb-ceph -w
+# wait for PHASE Ready and HEALTH HEALTH_OK
+```
+
+Then confirm the object store, the filesystem, and the RGW user are ready, and that PostgreSQL and Valkey are up:
+
+```bash
+kubectl -n $NAMESPACE get cephobjectstore,cephfilesystem,cephobjectstoreuser
+kubectl -n $NAMESPACE rollout status deployment/rook-ceph-rgw-eventdb-store-a --timeout=600s
+kubectl -n $NAMESPACE wait --for=condition=Ready cluster/postgresql --timeout=600s
+kubectl -n $NAMESPACE rollout status statefulset/valkey --timeout=300s
+```
+
+If a storage node shows no OSD after ten minutes, see [Troubleshoot](/self-hosted/troubleshoot#no-osd-is-created-on-a-storage-node).
+
+### Resolve the RGW endpoint
+
+Read the ClusterIP of the RGW Service that Rook created. It is stable for the life of the Service:
+
+```bash
+RGW_IP=$(kubectl -n $NAMESPACE get service rook-ceph-rgw-eventdb-store \
+  -o jsonpath='{.spec.clusterIP}')
+echo "$RGW_IP"
+```
+
+### Full install: EventDB and Atom
+
+Re-run the same release with the complete profile, adding the host alias that maps the `.localhost` endpoint onto the RGW Service for this release's pods:
+
+```bash
+helm upgrade --install axiom-eventdb \
+  oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $CHART_VERSION \
+  --namespace $NAMESPACE \
+  --values values.yaml \
+  --set "eventdb.hostAliases[0].ip=$RGW_IP" \
+  --set "eventdb.hostAliases[0].hostnames[0]=ceph-rgw.eventdb.localhost" \
+  --timeout 15m
+```
+
+Add the alias to `values.yaml` under `eventdb.hostAliases` afterwards, so future upgrades carry it without the `--set` flags.
+
+<Tip>
+**Chart values reference.** This install sets only the values a bare-metal deployment needs. For the full list of configurable values and their defaults, read `values.yaml` in the chart, where every key is documented in place.
+</Tip>
+
+### Wait for the bootstrap Jobs and rollouts
+
+The chart runs revision-suffixed Jobs on every install and upgrade: bucket creation and the EventDB and Atom schema migrations. They are idempotent. Wait for them in order, then for the workloads:
+
+```bash
+wait_job() {
+  job=$(kubectl -n $NAMESPACE get job -l "app=$1" \
+    --sort-by=.metadata.creationTimestamp -o name | tail -n1)
+  kubectl -n $NAMESPACE wait --for=condition=complete "$job" --timeout=600s
+}
+
+wait_job eventdb-bucket-setup
+wait_job eventdb-migrate
+wait_job axiom-atom-migrate
+
+kubectl -n $NAMESPACE rollout status statefulset/eventdb-ingest-prod --timeout=600s
+for w in eventdb-delta-cache eventdb-query-runner eventdb-query-worker \
+         eventdb-dataset-manager eventdb-queue-worker eventdb-admin axiom-atom; do
+  kubectl -n $NAMESPACE rollout status deployment/$w --timeout=600s
+done
+```
+
+Atom's Deployment restarts a few times until `axiom-atom-migrate` completes, then recovers on its own; the EventDB workloads behave the same way behind `eventdb-migrate`. Ingest pods come up one at a time.
+
+Monitor the rollout as a whole with:
+
+```bash
+kubectl get pods -n $NAMESPACE -w
+```
+
+## Step 8: Verify the installation
+
+### Run the chart's smoke tests
+
+`helm test` runs two hook Pods against the live release: one probes every first-party Service the way its readiness probe does, including Atom's `/healthz`, which only passes when Atom can reach both PostgreSQL and EventDB; the other proves PostgreSQL and Valkey are reachable at the addresses the workloads were configured with.
+
+```bash
+helm test axiom-eventdb -n $NAMESPACE --logs
+```
+
+### Sign in to the Atom console
+
+Forward Atom's port and open the console. The owner account is the email from `atom.admin.email`, and its password is the `admin-password` key of the `axiom-atom` Secret:
+
+```bash
+kubectl -n $NAMESPACE port-forward service/axiom-atom 8080:8080 &
+
+kubectl -n $NAMESPACE get secret axiom-atom \
+  -o jsonpath='{.data.admin-password}' | base64 -d; echo
+```
+
+Open [http://localhost:8080/ui/](http://localhost:8080/ui/) and sign in.
+
+### Create a dataset and an API token
+
+From the console, create a dataset named `connectivity-check` and an API token with ingest and query capabilities on it. Or do the same through the API with the console session:
+
+```bash
+ATOM=http://localhost:8080
+EMAIL=<owner@example.com>
+PASSWORD=$(kubectl -n $NAMESPACE get secret axiom-atom -o jsonpath='{.data.admin-password}' | base64 -d)
+
+# sign in; the response carries the CSRF token the session needs
+LOGIN=$(curl -sS --cookie-jar cookies.txt --json \
+  "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" \
+  "$ATOM/api/internal/atom/auth/login")
+CSRF=$(echo "$LOGIN" | jq -r .csrfToken)
+
+# create a dataset
+curl -sS --cookie cookies.txt -H "X-Atom-CSRF: $CSRF" --json \
+  '{"name":"connectivity-check","description":"install verification"}' \
+  "$ATOM/v2/datasets" | jq .
+
+# mint an API token scoped to it
+TOKEN=$(curl -sS --cookie cookies.txt -H "X-Atom-CSRF: $CSRF" --json '{
+    "name": "connectivity-check",
+    "datasetCapabilities": {"connectivity-check": {"ingest": ["create"], "query": ["read"]}},
+    "orgCapabilities": {},
+    "viewCapabilities": {}
+  }' "$ATOM/v2/tokens" | jq -r .token)
+echo "$TOKEN"   # starts with xaat-
+rm cookies.txt
+```
+
+### Ingest and query
+
+Ingest through Atom's Axiom-compatible endpoint, then query it back with APL:
+
+```bash
+# ingest 1,000 events
+for i in $(seq 1 1000); do
+  printf '{"_time":"%s","n":%d,"message":"hello from bare metal"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$i"
+done | curl -sS -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/x-ndjson' --data-binary @- \
+  "$ATOM/v1/ingest/connectivity-check" | jq .
+```
+
+Expected output:
+
+```json
+{
+  "ingested": 1000,
+  "failed": 0,
+  "failures": [],
+  ...
+}
+```
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" --json \
+  '{"apl": "[\"connectivity-check\"] | summarize count(), min(n), max(n)", "startTime": "now-1h", "endTime": "now"}' \
+  "$ATOM/v1/datasets/_apl?format=tabular" | jq '.tables[0].columns'
+```
+
+A count of 1,000 with `min` 1 and `max` 1,000 proves the ingest path, the WAL, the delta cache, and the query path.
+
+### Confirm data reaches object storage
+
+The query above may have been served from the delta cache. Because the object store is something you provide, verify that blocks land in it and can be read back cold. A graceful restart of ingest flushes its WAL into blocks; restarting the query path discards anything cached in process:
+
+```bash
+kubectl -n $NAMESPACE rollout restart statefulset/eventdb-ingest-prod
+kubectl -n $NAMESPACE rollout status statefulset/eventdb-ingest-prod --timeout=600s
+
+kubectl -n $NAMESPACE rollout restart deployment/eventdb-delta-cache deployment/eventdb-query-runner deployment/eventdb-query-worker
+kubectl -n $NAMESPACE rollout status deployment/eventdb-query-runner --timeout=300s
+```
+
+Re-run the query. The same count after the restart confirms the full write-then-read path through object storage. You can also list the objects under `blocks/connectivitycheck/` in the bucket with the AWS CLI against a port-forward of the RGW Service, using the keys in `eventdb-s3-credentials`:
+
+```bash
+kubectl -n $NAMESPACE port-forward service/rook-ceph-rgw-eventdb-store 18333:80 &
+AWS_ACCESS_KEY_ID=$(kubectl -n $NAMESPACE get secret eventdb-s3-credentials -o jsonpath='{.data.access-key}' | base64 -d) \
+AWS_SECRET_ACCESS_KEY=$(kubectl -n $NAMESPACE get secret eventdb-s3-credentials -o jsonpath='{.data.secret-key}' | base64 -d) \
+AWS_DEFAULT_REGION=us-east-1 \
+aws --endpoint-url http://127.0.0.1:18333 s3 ls s3://eventdb/blocks/connectivitycheck/ --recursive
+```
+
+## Next steps
+
+- **Publish Atom.** See [Operate](/self-hosted/operate#expose-atom) to enable the Ingress with TLS and, optionally, OIDC single sign-on for the console.
+- **Send data.** Point the Axiom SDKs, the CLI, or an OpenTelemetry Collector at Atom's URL with an `xaat-` token, exactly as you would at Axiom Cloud. See [Send data](/send-data/methods).
+- **Back up PostgreSQL.** See [Back up and restore](/self-hosted/backup-restore) to turn on continuous WAL archiving to a bucket outside the cluster.
+- **Monitor.** See [Operate](/self-hosted/operate#monitor-with-prometheus) to scrape EventDB, Atom, and Ceph with Prometheus Operator.
+- **Splunk.** Enable the [Axiom Portal for Splunk](/splunk/portal/overview) with `splunkPortal.enabled` and point it at Atom so that federated searches are authenticated.
+- **Troubleshoot.** See [Troubleshoot](/self-hosted/troubleshoot) for the failure modes seen on real deployments.

--- a/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
+++ b/content/docs/(documentation)/self-hosted/deploy-bare-metal.mdx
@@ -126,7 +126,33 @@ helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
 
 Images that the Rook operator launches at runtime, such as the Ceph daemons and CSI sidecars, come from `rookCephCluster.cephImage` and the `rookCephOperator.csi` image settings rather than from rendered pod specs. Set both to your registry and mirror the tags they name.
 
-If your registry requires authentication for pulls, create the release namespace and a pull secret now, then attach it to the default service account so every pod in the namespace, including those the operators create, can pull:
+If your registry requires authentication for pulls, create the release namespace and a pull secret now. A pull secret reaches a pod through the service account the pod runs as, so it is attached in two places.
+
+The dependency subcharts each take an `imagePullSecrets` list and pass it to every service account they create. Add these to the values file you write in Step 6:
+
+```yaml
+rookCephOperator:
+  imagePullSecrets:
+    - name: registry-credentials
+rookCephCluster:
+  imagePullSecrets:
+    - name: registry-credentials
+cephCsiOperator:
+  imagePullSecrets:
+    - name: registry-credentials
+postgresqlOperator:
+  imagePullSecrets:
+    - name: registry-credentials
+postgresql:
+  cluster:
+    imagePullSecrets:
+      - name: registry-credentials
+valkey:
+  imagePullSecrets:
+    - name: registry-credentials
+```
+
+The first-party pods, including the bootstrap Jobs and CronJobs, run as the `axiom-eventdb` service account. The chart creates that account without pull secrets, so create it yourself with the secret attached and point the chart at it:
 
 ```bash
 kubectl create namespace $NAMESPACE
@@ -137,11 +163,26 @@ kubectl create secret docker-registry registry-credentials \
   --docker-password=<password> \
   -n $NAMESPACE
 
-kubectl patch serviceaccount default -n $NAMESPACE \
-  -p '{"imagePullSecrets":[{"name":"registry-credentials"}]}'
+kubectl apply -n $NAMESPACE -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: axiom-eventdb
+automountServiceAccountToken: false
+imagePullSecrets:
+  - name: registry-credentials
+EOF
 ```
 
-The chart creates a dedicated `axiom-eventdb` service account for the EventDB pods. Patch it the same way after the first install, or set `eventdb.serviceAccount.create: false` and create the account with the pull secret attached beforehand.
+```yaml
+# values.yaml
+eventdb:
+  serviceAccount:
+    create: false
+    name: axiom-eventdb
+```
+
+The CephFS CSI plugin pods run as the `cephfs-ctrlplugin-sa` and `cephfs-nodeplugin-sa` accounts the chart renders, which carry no pull secrets. If the CSI images sit behind authentication too, patch those two accounts after the install and restart the plugin pods.
 
 ## Step 3: Provision local storage
 
@@ -181,7 +222,7 @@ Never list an OS or root disk. Rook creates an OSD on every device in the invent
 PostgreSQL, its WAL volume, and Valkey claim ReadWriteOnce volumes from a class you name in the values. Any performant provisioner works. On bare metal that is commonly:
 
 - **A local-path provisioner** on the EventDB nodes' NVMe, for the best latency. PostgreSQL and Valkey replicate across nodes, so node-bound volumes are acceptable.
-- **A Ceph RBD class** from the same Rook cluster. Declare it under `rookCephCluster.cephBlockPools` with `storageClass.enabled: true`; it becomes available after the Ceph cluster is healthy, which the bootstrap pass in Step 7 accounts for.
+- **A Ceph RBD class** from the same Rook cluster. Declare it under `rookCephCluster.cephBlockPools` with `storageClass.enabled: true`. Claims on it stay `Pending` until the Ceph cluster is healthy and then bind on their own; PostgreSQL and Valkey wait for them.
 
 PostgreSQL's WAL volume defaults to 30 GiB and its data volume to 50 GiB per instance. Confirm the class has that capacity on three nodes.
 
@@ -274,8 +315,16 @@ objectStorage:
   provider: rook
   bucket: eventdb
   # A *.localhost name is the one hostname EventDB accepts over plain HTTP.
-  # Step 7 aliases it to the in-cluster RGW Service for this release's pods.
+  # Step 7 maps it onto the in-cluster RGW Service.
   endpoint: http://ceph-rgw.eventdb.localhost:80
+
+# On k3s only: let the chart map the name above onto the RGW Service through
+# a CoreDNS rewrite, so Step 7 has nothing to bridge by hand. k3s imports the
+# kube-system/coredns-custom ConfigMap the chart writes; other distributions
+# do not, and use eventdb.hostAliases instead (see Step 7).
+# localDns:
+#   enabled: true
+#   hostname: ceph-rgw.eventdb.localhost
 
 eventdb:
   enabled: true
@@ -510,13 +559,7 @@ helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
 
 ## Step 7: Install the chart
 
-The install is two passes of the same release. The first installs the operators, the Ceph cluster, and the datastores while EventDB and Atom stay off; the second enables everything. Two things force the split: Helm cannot validate custom resources against CRDs introduced in the same transaction on a cluster that has never seen them, and the RGW Service's ClusterIP, which the host alias needs, does not exist until Ceph is up.
-
-<Warning>
-The bootstrap pass sets `eventdb.enabled=false` and `atom.enabled=false` on the command line. **Never run it against a healthy existing release.** Disabling a data-plane section on an upgrade deletes the live workloads, and disabling `rookCephCluster` or `postgresql` on an upgrade deletes the Ceph and PostgreSQL clusters with their data. The bootstrap pass is an install-time step only.
-</Warning>
-
-### Bootstrap: operators, Ceph, and datastores
+The install is one Helm transaction. The operators' CRDs ship in companion subcharts under `crds/`, which Helm registers before it renders anything else, so the same release creates the Ceph cluster, the CephFS, the PostgreSQL cluster, and the EventDB workloads together. Nothing has to be installed first and nothing has to be turned off.
 
 ```bash
 helm upgrade --install axiom-eventdb \
@@ -524,19 +567,25 @@ helm upgrade --install axiom-eventdb \
   --version $CHART_VERSION \
   --namespace $NAMESPACE --create-namespace \
   --values values.yaml \
-  --set eventdb.enabled=false \
-  --set atom.enabled=false \
   --timeout 15m
 ```
 
-Wait for the Ceph cluster to converge. OSD preparation runs one Job per storage node and takes several minutes on first boot:
+Helm returns once the resources exist. What follows takes longer: Rook prepares one OSD per device, the operators bring up their data planes, and the EventDB workloads wait behind the bootstrap Jobs.
+
+<Tip>
+**Chart values reference.** This install sets only the values a bare-metal deployment needs. For the full list of configurable values and their defaults, read `values.yaml` in the chart, where every key is documented in place.
+</Tip>
+
+### Wait for Ceph and the datastores
+
+OSD preparation runs one Job per storage node and takes several minutes on first boot:
 
 ```bash
 kubectl -n $NAMESPACE get cephcluster eventdb-ceph -w
 # wait for PHASE Ready and HEALTH HEALTH_OK
 ```
 
-Then confirm the object store, the filesystem, and the RGW user are ready, and that PostgreSQL and Valkey are up:
+Then confirm the object store, the filesystem, and the RGW user are ready, and that the datastores are up:
 
 ```bash
 kubectl -n $NAMESPACE get cephobjectstore,cephfilesystem,cephobjectstoreuser
@@ -545,11 +594,14 @@ kubectl -n $NAMESPACE wait --for=condition=Ready cluster/postgresql --timeout=60
 kubectl -n $NAMESPACE rollout status statefulset/valkey --timeout=300s
 ```
 
-If a storage node shows no OSD after ten minutes, see [Troubleshoot](/self-hosted/troubleshoot#no-osd-is-created-on-a-storage-node).
+The `eventdb-wal` claim binds on its own once the filesystem's metadata server is up. If a storage node shows no OSD after ten minutes, see [Troubleshoot](/self-hosted/troubleshoot#no-osd-is-created-on-a-storage-node).
 
-### Resolve the RGW endpoint
+### Bridge the object-storage endpoint
 
-Read the ClusterIP of the RGW Service that Rook created. It is stable for the life of the Service:
+`objectStorage.endpoint` names the RGW as `ceph-rgw.eventdb.localhost`, because EventDB only speaks plain HTTP to a `*.localhost` name, and Rook publishes the RGW under its Service name. Something has to map one onto the other. Until it does, the EventDB pods restart while they cannot resolve the endpoint; that is expected and clears on its own once the mapping exists. The bucket-setup Job is unaffected: with the Rook provider it targets the Service name directly.
+
+- **On k3s**, with `localDns` enabled in Step 6, there is nothing to do. The chart wrote a CoreDNS rewrite for the name, k3s imports it, and the pods resolve it within a minute or two. Skip to the next section.
+- **On any other distribution**, the mapping is a per-pod `/etc/hosts` entry pointing at the RGW Service's ClusterIP, which exists now that Ceph is up and is stable for the life of the Service. Read it, add it to the values file, and upgrade:
 
 ```bash
 RGW_IP=$(kubectl -n $NAMESPACE get service rook-ceph-rgw-eventdb-store \
@@ -557,26 +609,25 @@ RGW_IP=$(kubectl -n $NAMESPACE get service rook-ceph-rgw-eventdb-store \
 echo "$RGW_IP"
 ```
 
-### Full install: EventDB and Atom
-
-Re-run the same release with the complete profile, adding the host alias that maps the `.localhost` endpoint onto the RGW Service for this release's pods:
+```yaml
+# values.yaml
+eventdb:
+  hostAliases:
+    - ip: <RGW_IP>
+      hostnames:
+        - ceph-rgw.eventdb.localhost
+```
 
 ```bash
-helm upgrade --install axiom-eventdb \
+helm upgrade axiom-eventdb \
   oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
   --version $CHART_VERSION \
   --namespace $NAMESPACE \
   --values values.yaml \
-  --set "eventdb.hostAliases[0].ip=$RGW_IP" \
-  --set "eventdb.hostAliases[0].hostnames[0]=ceph-rgw.eventdb.localhost" \
   --timeout 15m
 ```
 
-Add the alias to `values.yaml` under `eventdb.hostAliases` afterwards, so future upgrades carry it without the `--set` flags.
-
-<Tip>
-**Chart values reference.** This install sets only the values a bare-metal deployment needs. For the full list of configurable values and their defaults, read `values.yaml` in the chart, where every key is documented in place.
-</Tip>
+This is a values change like any other: nothing is disabled, and the upgrade rolls only the EventDB pods, which come back with the alias.
 
 ### Wait for the bootstrap Jobs and rollouts
 

--- a/content/docs/(documentation)/self-hosted/operate.mdx
+++ b/content/docs/(documentation)/self-hosted/operate.mdx
@@ -1,0 +1,215 @@
+---
+title: 'Operate self-hosted EventDB'
+sidebarTitle: Operate
+description: 'Day-two operations for the axiom-eventdb Helm chart: publish Atom with an Ingress and OIDC, upgrade safely, scale and autoscale the hot-path components, monitor with Prometheus Operator, and enable the Splunk and Grafana portals.'
+keywords: ['self-hosted', 'eventdb', 'operate', 'upgrade', 'autoscaling', 'ingress', 'oidc', 'prometheus', 'servicemonitor', 'helm upgrade']
+---
+
+This page covers what comes after [Deploy on bare metal](/self-hosted/deploy-bare-metal): publishing Atom, upgrading, scaling, and monitoring. Every change below is a `helm upgrade` with an edited values file. Keep the values file under version control; it is the whole definition of the release.
+
+## Expose Atom
+
+Atom is the authenticating layer. Every API call needs an `xaat-` token it issued and the console needs a session, so it is the one workload in the chart meant to be reachable from outside the cluster. The EventDB Services and the portals stay `ClusterIP`.
+
+Publishing is `atom.ingress`, which routes each host whole to the Atom Service through the cluster's ingress controller. TLS terminates at the controller; Atom reads `X-Forwarded-Proto` from it, so session cookies come out `Secure` and OIDC callbacks come out `https` with nothing more configured.
+
+```yaml
+atom:
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      # An ingest batch can be many megabytes; the NGINX controller allows 1m.
+      nginx.ingress.kubernetes.io/proxy-body-size: 64m
+      # A query may run for minutes.
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    hosts:
+      - host: atom.example.com
+    tls:
+      - secretName: atom-tls
+        hosts:
+          - atom.example.com
+```
+
+The two annotations are the ones that matter and are not every controller's default. Translate them for your controller. `hosts` takes the Kubernetes shape, with `paths` defaulting to one `Prefix` match on `/` per host, so the API and the `/ui/` console share the host.
+
+Once published, clients use Atom exactly as they use Axiom Cloud, with `https://atom.example.com` as the base URL and an API token from the console:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" https://atom.example.com/v2/datasets
+```
+
+<Note>
+If you expose the Service directly through an L4 load balancer instead of an Ingress, set `atom.service.externalTrafficPolicy: Local`. With Kubernetes' default, the load balancer's health check passes on every node whether or not it has a ready Atom pod, and the resulting extra hop is a real source of intermittent timeouts.
+</Note>
+
+### Console single sign-on
+
+Setting `atom.oidc.issuer` switches the console to OIDC. The client ID goes in the values and the client secret in the `oidc-client-secret` key of the `axiom-atom` Secret:
+
+```yaml
+atom:
+  oidc:
+    issuer: https://login.example.com/realms/axiom
+    clientId: atom
+    # Only needed when a proxy in front of the Ingress does not forward the scheme.
+    redirectUrl: ""
+```
+
+```bash
+kubectl -n axiom-system patch secret axiom-atom --type merge \
+  -p "{\"stringData\":{\"oidc-client-secret\":\"$OIDC_CLIENT_SECRET\"}}"
+```
+
+Atom requests the `openid`, `profile`, and `email` scopes. The first-boot owner account keeps working alongside OIDC.
+
+## Upgrade
+
+### Chart upgrades
+
+Chart releases are OCI artifacts at `oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb`. Prereleases are versioned `0.0.1-alpha.<sha>`; Helm hides prereleases from version resolution, so always pass the exact `--version`. Upgrade with the same values file and the same command as the full install:
+
+```bash
+helm upgrade axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $NEW_CHART_VERSION \
+  --namespace axiom-system \
+  --values values.yaml \
+  --timeout 15m
+```
+
+Every upgrade re-runs the revision-suffixed bootstrap Jobs, which are idempotent, and rolls any workload whose configuration changed. Wait for the Jobs and rollouts as in [Step 7](/self-hosted/deploy-bare-metal#wait-for-the-bootstrap-jobs-and-rollouts).
+
+<Warning>
+**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data. Those toggles are install-time decisions. The bootstrap pass in the deployment guide is the only time they are turned off, and only on a cluster with no release yet.
+</Warning>
+
+### EventDB image upgrades
+
+A new EventDB release is a new tag for the three `eventdb.image.*` entries, mirrored into your registry as in [Step 2](/self-hosted/deploy-bare-metal#step-2-mirror-container-images). Atom and the portals carry their own tags and move independently. Update the values and `helm upgrade`; `eventdb-migrate` applies any schema change before the workloads roll.
+
+### Operator and dependency upgrades
+
+The chart pins every dependency exactly, so a new chart version may carry a new Rook or CloudNativePG. Helm installs CRDs on a release's first install but deliberately never upgrades them, so a chart release that bumps an operator documents the CRD change and the order to apply it. Follow the upstream ordering the chart README describes: upgrade Rook's operator before its Ceph cluster and confirm `HEALTH_OK` before continuing, and upgrade the CloudNativePG operator before the PostgreSQL instances. A single Helm transaction does not by itself prove a safe data-plane upgrade.
+
+### What cannot change in place
+
+A PersistentVolumeClaim's access mode, storage class, and size are immutable. Changing `eventdb.wal.*` on an existing release fails with `spec is immutable`. The migration is to scale down the six workloads that mount the WAL, delete the claim, and upgrade so the chart recreates it. Deleting the claim discards whatever the WAL had not flushed; flush first by gracefully restarting ingest, or accept the loss knowingly.
+
+Workload selectors are immutable too. The chart selects each workload by a single stable `app` label and never by anything that varies with the release, so ordinary upgrades do not hit this.
+
+## Scale and autoscale
+
+### Fixed counts
+
+In `multi` mode each component's replica count comes from `eventdb.<component>.replicasByMode.multi`, and `eventdb.<component>.replicas` overrides it. Scale the component the load lands on:
+
+| Load | Scale | Rule of thumb |
+| :--- | :--- | :--- |
+| Ingest rate | `eventdb.ingest` | One pod per 8,000 events per second; keep `maxConcurrentIngests` at 256 per CPU of the limit. |
+| Ingest rate | `eventdb.deltaCache` | One pod per 16,000 events per second; it grows with ingest, not with queries. |
+| Query concurrency | `eventdb.queryWorker` | Throughput is replicas × `maxInflightRequests`; one pod per four concurrent queries at the defaults. |
+| Query bursts | `eventdb.queryRunner` | `maxConcurrentQueries` is a per-pod cap and decides whether a burst queues or fails. Size it for the whole expected concurrency. |
+
+Wide time ranges are bound by object-storage bandwidth and by how much data the range covers, not by these knobs. Retention is part of sizing.
+
+### Autoscaling
+
+The four hot-path components, Atom, and the portals each take an `autoscaling` block that hands the replica count to a HorizontalPodAutoscaler on CPU utilisation, the way the hosted service runs them:
+
+```yaml
+eventdb:
+  queryWorker:
+    autoscaling:
+      enabled: true
+      minReplicas: null      # empty means the fixed count for the mode
+      maxReplicas: 24
+      targetCPUUtilizationPercentage: 100
+```
+
+Three rules apply:
+
+- **The floor is the fixed count.** An empty `minReplicas` means the tested sizing, so autoscaling only ever adds pods above it. A ceiling below the floor fails the render.
+- **Targets are utilisation of the request.** Changing a component's request moves the point at which pods are added.
+- **Decide it at install time.** Turning autoscaling on for a running release removes the `replicas` field from the workload, which resets the count to one until the autoscaler's first reconcile restores the floor, about fifteen seconds later. For ingest that is a window of rejected batches. Flip it at a quiet moment, not alongside a change you want to watch. Turning it off has no such gap.
+
+Ingest scales down slowly on purpose: thirty minutes of stabilisation and one pod a minute, because a pod that stops without flushing leaves data invisible to queries until the `scan-nfs` CronJob recovers it, about 25 hours later.
+
+Autoscaling reads the Metrics API, so the cluster needs `metrics-server`. Without it the HPA enforces the floor and the ceiling but never scales between them and reports `FailedGetResourceMetric`.
+
+### Storage growth
+
+- **Object storage.** Watch Ceph's raw usage and add OSDs, by adding devices to the `storage.nodes` inventory, before it passes 80%. Ceph rebalances onto new OSDs automatically.
+- **Shared WAL.** The CephFS class in the deployment guide allows volume expansion; edit `eventdb.wal.size` upward and upgrade. It cannot shrink.
+- **PostgreSQL.** Data and WAL volumes expand the same way through `postgresql.cluster.storage.size` and `walStorage.size`, if the block class supports expansion.
+
+## Monitor with Prometheus
+
+The chart integrates with Prometheus Operator and creates nothing until you opt in. Install the operator and its `ServiceMonitor` and `PrometheusRule` CRDs first, then:
+
+```yaml
+eventdb:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus-stack    # whatever your Prometheus selects on
+
+atom:
+  serviceMonitor:
+    enabled: true
+
+rookCephOperator:
+  monitoring:
+    enabled: true
+  csi:
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: prometheus-stack
+
+rookCephCluster:
+  monitoring:
+    enabled: true
+    createPrometheusRules: true
+    prometheusRule:
+      labels:
+        release: prometheus-stack
+```
+
+The EventDB switch scrapes `/metrics` on ingest, query runner, delta cache, dataset manager, and queue worker. Atom's switch scrapes its `/metrics`. Rook's cluster switch enables the Ceph manager and exporter metrics, whose ServiceMonitors the running operator creates as it reconciles the cluster, and the PrometheusRule installs Rook's maintained Ceph health and capacity alerts.
+
+CloudNativePG exposes PostgreSQL metrics on every instance; enable a `PodMonitor` for it through the upstream `cluster` chart's `cluster.monitoring` values.
+
+Set `eventdb.serviceMonitor.namespace` to place the monitors in a central monitoring namespace; their namespace selectors keep pointing at the release namespace.
+
+### What to alert on
+
+| Signal | Why |
+| :--- | :--- |
+| Shared WAL usage on the `eventdb-wal` claim | A full WAL stops ingest. Alert at 70%. |
+| PostgreSQL WAL volume usage | A full WAL volume takes the primary down, and with it Atom, ingest, and queries. Alert at 70%. |
+| Ceph health not `HEALTH_OK`, raw usage over 75% | The object store is the ceiling for everything. |
+| Ingest batch rejections and `Read request flood` responses from the query runner | The admission caps are being hit; scale the component. |
+| Bootstrap Job failures after an upgrade | `eventdb-migrate` or `axiom-atom-migrate` failing leaves the workloads crash-looping. |
+| `FailedGetResourceMetric` on any HPA | Autoscaling is not scaling. |
+
+## Portals
+
+Both portals are optional query front ends, off by default, and neither authenticates the credential it receives. They stay `ClusterIP` and belong behind an authenticating proxy.
+
+- **Splunk Portal** (`splunkPortal.enabled`) lets a Splunk search head run SPL against EventDB as a federated provider. By default it targets the bare query runner, which accepts any password. Point it at Atom instead so that the credential a search head sends is actually checked and dataset discovery works:
+
+  ```yaml
+  splunkPortal:
+    enabled: true
+    image:
+      repository: <registry-host>/splunk-portal
+      tag: <splunk-portal-commit>
+    queryUrl: http://axiom-atom:8080/v1/datasets/_apl?format=tabular
+    apiBase: http://axiom-atom:8080
+  ```
+
+  See [Axiom Portal for Splunk](/splunk/portal/overview) for the search-head side.
+
+- **Grafana Portal** (`grafanaPortal.enabled`) fronts Grafana's Loki and Tempo data sources. It only accepts HTTPS routes on `axiom.co` or on origins named in `grafanaPortal.axiomOriginAllowlist`, so against a self-hosted deployment its route points at the published Atom hostname. The Prometheus data source needs MetricsDB, which Atom does not include.
+
+Both images are tagged with their own repository's commit rather than the EventDB release tag.

--- a/content/docs/(documentation)/self-hosted/operate.mdx
+++ b/content/docs/(documentation)/self-hosted/operate.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Operate self-hosted EventDB'
 sidebarTitle: Operate
-description: 'Day-two operations for the axiom-eventdb Helm chart: publish Atom with an Ingress and OIDC, upgrade safely, scale and autoscale the hot-path components, monitor with Prometheus Operator, and enable the Splunk and Grafana portals.'
-keywords: ['self-hosted', 'eventdb', 'operate', 'upgrade', 'autoscaling', 'ingress', 'oidc', 'prometheus', 'servicemonitor', 'helm upgrade']
+description: 'Day-two operations for the axiom-eventdb Helm chart: publish Atom with an Ingress and OIDC, scale and autoscale the hot-path components, monitor with Prometheus Operator, and enable the Splunk and Grafana portals.'
+keywords: ['self-hosted', 'eventdb', 'operate', 'autoscaling', 'ingress', 'oidc', 'prometheus', 'servicemonitor', 'helm upgrade']
 ---
 
-This page covers what comes after [Deploy on bare metal](/self-hosted/deploy-bare-metal): publishing Atom, upgrading, scaling, and monitoring. Every change below is a `helm upgrade` with an edited values file. Keep the values file under version control; it is the whole definition of the release.
+This page covers what comes after [Deploy on bare metal](/self-hosted/deploy-bare-metal): publishing Atom, scaling, and monitoring. Upgrades have [their own page](/self-hosted/upgrade). Every change below is a `helm upgrade` with an edited values file. Keep the values file under version control; it is the whole definition of the release.
 
 ## Expose Atom
 
@@ -65,37 +65,11 @@ Atom requests the `openid`, `profile`, and `email` scopes. The first-boot owner 
 
 ## Upgrade
 
-### Chart upgrades
-
-Chart releases are OCI artifacts at `oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb`. Prereleases are versioned `0.0.1-alpha.<sha>`; Helm hides prereleases from version resolution, so always pass the exact `--version`. Upgrade with the same values file and the same command as the full install:
-
-```bash
-helm upgrade axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
-  --version $NEW_CHART_VERSION \
-  --namespace axiom-system \
-  --values values.yaml \
-  --timeout 15m
-```
-
-Every upgrade re-runs the revision-suffixed bootstrap Jobs, which are idempotent, and rolls any workload whose configuration changed. Wait for the Jobs and rollouts as in [Step 7](/self-hosted/deploy-bare-metal#wait-for-the-bootstrap-jobs-and-rollouts).
+Every change to the release, whether a values edit, new EventDB or Atom images, or a new chart version, is a `helm upgrade` of the same release with the same values file. What that does, the pre-flight checks, the ordering for Rook and CloudNativePG upgrades, the changes that need more than an upgrade, and how to roll back are on their own page: [Upgrade](/self-hosted/upgrade).
 
 <Warning>
-**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data. Those toggles are install-time decisions. The bootstrap pass in the deployment guide is the only time they are turned off, and only on a cluster with no release yet.
+**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data.
 </Warning>
-
-### EventDB image upgrades
-
-A new EventDB release is a new tag for the three `eventdb.image.*` entries, mirrored into your registry as in [Step 2](/self-hosted/deploy-bare-metal#step-2-mirror-container-images). Atom and the portals carry their own tags and move independently. Update the values and `helm upgrade`; `eventdb-migrate` applies any schema change before the workloads roll.
-
-### Operator and dependency upgrades
-
-The chart pins every dependency exactly, so a new chart version may carry a new Rook or CloudNativePG. Helm installs CRDs on a release's first install but deliberately never upgrades them, so a chart release that bumps an operator documents the CRD change and the order to apply it. Follow the upstream ordering the chart README describes: upgrade Rook's operator before its Ceph cluster and confirm `HEALTH_OK` before continuing, and upgrade the CloudNativePG operator before the PostgreSQL instances. A single Helm transaction does not by itself prove a safe data-plane upgrade.
-
-### What cannot change in place
-
-A PersistentVolumeClaim's access mode, storage class, and size are immutable. Changing `eventdb.wal.*` on an existing release fails with `spec is immutable`. The migration is to scale down the six workloads that mount the WAL, delete the claim, and upgrade so the chart recreates it. Deleting the claim discards whatever the WAL had not flushed; flush first by gracefully restarting ingest, or accept the loss knowingly.
-
-Workload selectors are immutable too. The chart selects each workload by a single stable `app` label and never by anything that varies with the release, so ordinary upgrades do not hit this.
 
 ## Scale and autoscale
 

--- a/content/docs/(documentation)/self-hosted/overview.mdx
+++ b/content/docs/(documentation)/self-hosted/overview.mdx
@@ -120,6 +120,7 @@ The multi-mode defaults are measured, not guessed. They hold 16,000 events per s
 | :--- | :--- |
 | [Requirements](/self-hosted/requirements) | Cluster, node, storage, object-storage, network, and credential requirements. |
 | [Deploy on bare metal](/self-hosted/deploy-bare-metal) | The step-by-step install: cluster preparation, image mirroring, storage, values, install, and verification. |
-| [Operate](/self-hosted/operate) | Expose Atom, upgrade, scale and autoscale, and monitor with Prometheus. |
+| [Operate](/self-hosted/operate) | Expose Atom, scale and autoscale, and monitor with Prometheus. |
+| [Upgrade](/self-hosted/upgrade) | What a Helm upgrade does, pre-flight checks, operator ordering, changes that need more than an upgrade, and rollback. |
 | [Back up and restore PostgreSQL](/self-hosted/backup-restore) | Continuous WAL archiving, scheduled base backups, and point-in-time recovery. |
 | [Troubleshoot](/self-hosted/troubleshoot) | Symptoms, causes, and fixes for the failure modes seen on real deployments. |

--- a/content/docs/(documentation)/self-hosted/overview.mdx
+++ b/content/docs/(documentation)/self-hosted/overview.mdx
@@ -1,0 +1,125 @@
+---
+title: 'Self-hosted EventDB'
+sidebarTitle: Overview
+description: 'Run Axiom EventDB on your own Kubernetes cluster with the axiom-eventdb Helm chart: what the chart deploys, what you provide, and how the guides in this section fit together.'
+keywords: ['self-hosted', 'eventdb', 'helm', 'kubernetes', 'bare metal', 'on-premises', 'atom', 'rook', 'ceph']
+---
+
+Self-hosted EventDB runs Axiom's event datastore on Kubernetes infrastructure that you operate: bare metal, an on-premises cluster, or a cloud account of your own. The deployment path is one Helm chart, `axiom-eventdb`, that packages the EventDB workloads together with pinned infrastructure dependencies and, optionally, [Atom](#atom), the management plane and console that gives the datastore an authenticated, Axiom-compatible API.
+
+This section covers a bare-metal deployment end to end. Start with [Requirements](/self-hosted/requirements), then follow [Deploy on bare metal](/self-hosted/deploy-bare-metal).
+
+<Note>
+Self-hosted EventDB is in early access. Chart versions are published as `0.0.1-alpha.<sha>` prereleases and the values interface can change between releases. Axiom provides registry credentials, image tags, and a licence configuration during onboarding.
+</Note>
+
+## What the chart deploys
+
+The chart installs one Helm release, in one namespace, that owns the whole stack.
+
+```mermaid
+flowchart LR
+    subgraph clients [Clients]
+        sdk[Axiom SDKs and CLI]
+        otel[OpenTelemetry Collector]
+        splunk[Splunk search head]
+    end
+
+    subgraph release [axiom-eventdb release]
+        atom[Atom<br/>API, console, auth]
+        portal[Splunk Portal<br/>optional]
+        subgraph eventdb [EventDB data plane]
+            ingest[Ingest]
+            runner[Query runner]
+            workers[Query workers]
+            delta[Delta cache]
+            dsm[Dataset manager<br/>Queue worker<br/>Admin]
+        end
+        wal[(Shared WAL<br/>RWX volume)]
+        pg[(PostgreSQL<br/>CloudNativePG)]
+        valkey[(Valkey)]
+    end
+
+    s3[(Object storage<br/>Rook/Ceph RGW or external S3)]
+
+    sdk --> atom
+    otel --> atom
+    splunk --> portal --> runner
+    atom --> ingest
+    atom --> runner
+    ingest --> wal
+    delta --> wal
+    ingest --> s3
+    workers --> s3
+    runner --> workers
+    runner --> delta
+    eventdb --> pg
+    eventdb --> valkey
+    atom --> pg
+```
+
+### First-party workloads
+
+| Component | Kind | Role |
+| :--- | :--- | :--- |
+| `eventdb-ingest` | StatefulSet | Accepts events, buffers them in the shared WAL, and flushes blocks to object storage. |
+| `eventdb-query-runner` | Deployment | Plans queries and fans them out to workers and the delta cache. |
+| `eventdb-query-worker` | Deployment | Scans blocks in object storage. |
+| `eventdb-delta-cache` | Deployment | Serves not-yet-flushed data from the WAL to queries. |
+| `eventdb-dataset-manager`, `eventdb-queue-worker`, `eventdb-admin` | Deployments | Dataset coordination, background jobs (deletes, trims, vacuums), and operator tooling. |
+| `eventdb-janitor`, `eventdb-scan-nfs` | CronJobs | Housekeeping and orphaned-WAL recovery. |
+| `axiom-atom` | Deployment | Optional. The management plane, authenticated API, and console. |
+| `axiom-splunk-portal`, `axiom-grafana-portal` | Deployments | Optional query front ends for Splunk and Grafana. |
+
+Every first-party container runs hardened: non-root UID 65534, all capabilities dropped, no privilege escalation, `RuntimeDefault` seccomp, a read-only root filesystem, and no Kubernetes API token.
+
+### Pinned dependencies
+
+| Function | Implementation | Chart |
+| :--- | :--- | :--- |
+| Object storage | Rook-managed Ceph with the RGW S3 gateway, or an S3-compatible store you already run | `rook-release/rook-ceph`, `rook-release/rook-ceph-cluster` `v1.20.3` |
+| Relational state | PostgreSQL 17, three instances, managed by CloudNativePG | `cnpg/cloudnative-pg` `0.29.0`, `cnpg/cluster` `0.8.1` |
+| Cache | Valkey with replication | `valkey/valkey` `0.11.0` |
+| Job queue | PostgreSQL (recommended), or NATS JetStream | `nats/nats` `2.14.2` when selected |
+
+Every dependency is pinned to an exact chart version and to the SHA-256 of its archive. Operator CRDs ship in companion subcharts so a release can create its Ceph and PostgreSQL custom resources in the same Helm transaction that installs the operators.
+
+## Atom
+
+EventDB itself has no notion of organizations, users, or API tokens. Its ingest, query, and admin endpoints are unauthenticated and must never be exposed beyond the cluster.
+
+Atom is the layer that turns the headless datastore into a product surface. It adds a PostgreSQL-backed management plane (datasets, API tokens, users, audit log), an Axiom-compatible ingest and APL query API in front of EventDB, and a web console at `/ui/`. Because Atom speaks Axiom's public API contracts, the Axiom SDKs, the CLI, OpenTelemetry exporters, and the Splunk and Grafana portals work against it unchanged.
+
+Atom is the only workload in the chart that is designed to be published outside the cluster, through an Ingress with TLS. The bare-metal guide enables it.
+
+## What you provide
+
+The chart deliberately installs nothing by default: a bare `helm install` creates no operators, claims no disks, and exposes no endpoints. A real deployment is a values file that opts into each section. You bring:
+
+- A conformant Kubernetes cluster with a block `StorageClass` and a ReadWriteMany-capable one for the shared WAL. See [Requirements](/self-hosted/requirements).
+- Dedicated raw disks for Ceph, or an external S3-compatible object store.
+- A private container registry that mirrors the EventDB, Atom, and dependency images.
+- Kubernetes Secrets holding the database, cache, object-storage, and Atom credentials.
+- An ingress controller and TLS certificate for Atom.
+- Optionally, Prometheus Operator for metrics and metrics-server for autoscaling.
+
+## Deployment modes
+
+The top-level `mode` value selects the topology of the EventDB workloads:
+
+| Mode | Use | Replicas |
+| :--- | :--- | :--- |
+| `single` | One-node development clusters | One replica of every service |
+| `multi` | Production | Four ingest, three delta cache, four query runner, six query worker pods by default, with PodDisruptionBudgets and optional autoscaling |
+
+The multi-mode defaults are measured, not guessed. They hold 16,000 events per second with 24 concurrent queries on the validation deployments and add up to about 15 cores and 21 GiB of requests for EventDB itself. See [Requirements](/self-hosted/requirements#sizing) for how to scale beyond that.
+
+## In this section
+
+| Page | Contents |
+| :--- | :--- |
+| [Requirements](/self-hosted/requirements) | Cluster, node, storage, object-storage, network, and credential requirements. |
+| [Deploy on bare metal](/self-hosted/deploy-bare-metal) | The step-by-step install: cluster preparation, image mirroring, storage, values, install, and verification. |
+| [Operate](/self-hosted/operate) | Expose Atom, upgrade, scale and autoscale, and monitor with Prometheus. |
+| [Back up and restore PostgreSQL](/self-hosted/backup-restore) | Continuous WAL archiving, scheduled base backups, and point-in-time recovery. |
+| [Troubleshoot](/self-hosted/troubleshoot) | Symptoms, causes, and fixes for the failure modes seen on real deployments. |

--- a/content/docs/(documentation)/self-hosted/requirements.mdx
+++ b/content/docs/(documentation)/self-hosted/requirements.mdx
@@ -1,0 +1,157 @@
+---
+title: 'Self-hosted EventDB requirements'
+sidebarTitle: Requirements
+description: 'Infrastructure requirements for running the axiom-eventdb Helm chart: Kubernetes version, node roles and sizing, block and ReadWriteMany storage, object storage, networking, credentials, and tooling.'
+keywords: ['self-hosted', 'eventdb', 'requirements', 'kubernetes', 'storage class', 'readwritemany', 'ceph', 'object storage', 'sizing']
+---
+
+This page is the reference for what a cluster must provide before you install the `axiom-eventdb` chart. [Deploy on bare metal](/self-hosted/deploy-bare-metal) walks through satisfying each requirement in order.
+
+## Tools
+
+| Tool | Version | Purpose |
+| :--- | :--- | :--- |
+| `kubectl` | Compatible with your cluster | Cluster access, Secrets, verification |
+| Helm | 3.18 or later | Installs the chart |
+| `skopeo` | Any recent | Mirrors container images into your registry |
+| `curl` and `jq` | Any recent | Verification requests |
+
+## Kubernetes cluster
+
+The chart runs on any conformant Kubernetes distribution, such as kubeadm, RKE2, or k3s.
+
+| Requirement | Details |
+| :--- | :--- |
+| Kubernetes version | A currently supported release. The chart's dependencies (Rook 1.20, CloudNativePG 1.30) require 1.28 or later. |
+| CNI | Any CNI providing standard IPv4 pod networking. |
+| Container runtime | Any CRI-compatible runtime, such as containerd. |
+| DNS | Working in-cluster DNS. CoreDNS is only required if you use the chart's `localDns` rewrite, which is intended for single-purpose development clusters. |
+| Metrics API | `metrics-server` or equivalent, required only when autoscaling is enabled. |
+| Ingress | An ingress controller and TLS issuance for publishing Atom. |
+| Prometheus Operator | Optional. Required for the chart's `ServiceMonitor` and `PrometheusRule` resources. |
+
+## Node roles and failure domains
+
+Ceph and PostgreSQL both place replicas by host, so a production cluster needs at least three nodes that can each hold one replica. Dedicate nodes to Ceph storage and keep the EventDB workloads on separate nodes so that object-storage I/O and query CPU do not compete.
+
+| Role | Count | Purpose |
+| :--- | :--- | :--- |
+| Storage | 3 or more | Ceph monitors, managers, and OSDs. Each holds one or more dedicated raw disks. |
+| EventDB | 3 or more | Ingest, query, cache, Atom, PostgreSQL, and Valkey pods. |
+| Control plane and add-ons | 1 or more | Operators, ingress, monitoring. |
+
+Ceph's `failureDomain: host` is the chart default, and its pools replicate three ways, so the loss of any one storage node leaves the object store readable and writable. Rack or zone failure domains are a Ceph configuration change under `rookCephCluster.cephClusterSpec`; use them when the storage nodes span real fault boundaries.
+
+Label the storage nodes so the Ceph inventory in your values can name them, and use `eventdb.scheduling` to keep EventDB pods off them. See [Step 1 of the bare-metal guide](/self-hosted/deploy-bare-metal#step-1-prepare-the-kubernetes-cluster).
+
+## Sizing
+
+The chart's multi-mode defaults are taken from a 24-hour load experiment on four validation deployments. They hold 16,000 events per second with 24 concurrent queries and request about 15 cores and 21 GiB for EventDB itself.
+
+| Component | Pods | Requests → limits per pod |
+| :--- | :--- | :--- |
+| Ingest | 4 | 500m / 1 GiB → 2 CPU / 3 GiB |
+| Delta cache | 3 | 2 CPU / 4 GiB → 6 CPU / 8 GiB |
+| Query runner | 4 | 250m / 512 MiB → 2 CPU / 2 GiB |
+| Query worker | 6 | 1 CPU / 512 MiB → 3 CPU / 3 GiB |
+
+Add the dependencies on top: three PostgreSQL instances at 500m / 1 GiB each, three Valkey pods, Atom at two replicas, and the Ceph daemons. Rook's monitors, managers, and OSDs run at Ceph's own defaults; budget roughly 4 GiB of memory and one core per OSD, plus 1 to 2 GiB for each monitor and manager, on the storage nodes.
+
+To scale past the tested envelope, scale the component the load lands on:
+
+- **Ingest rate.** One ingest pod carries about 8,000 events per second. Add ingest pods linearly, and add a delta-cache pod per further 16,000 events per second.
+- **Query concurrency.** Query throughput is bounded by the worker pool: query-worker replicas × `maxInflightRequests`. Twelve workers at 16 in-flight requests held 48 concurrent queries.
+- **Wide time ranges.** Queries over 24 hours are bound by object-storage bandwidth and by how much data the range covers. Retention is part of sizing.
+
+The chart ships a worked example for 30 TB per day, 100 concurrent queries, and 30 days of hot retention under `charts/axiom-eventdb/examples/`. Its header lists what such a cluster must provide: about 890 cores and 4.6 TiB at the floor, a cluster autoscaler, an object store and a WAL class with the bandwidth, and Prometheus alerts.
+
+## Storage
+
+Three kinds of storage are needed, and they are provisioned differently.
+
+### Raw disks for Ceph
+
+When the chart manages object storage, Rook creates one OSD per dedicated raw block device you list in `rookCephCluster.cephClusterSpec.storage.nodes`. Requirements:
+
+- Whole, unformatted, unpartitioned devices with no filesystem or LVM signature. Never list an OS or root disk.
+- Stable `/dev/disk/by-id/` paths, so a reboot cannot renumber a device into the inventory.
+- NVMe or SSD. Ceph's write path fsyncs; slow disks become slow ingest.
+- At least three devices across at least three nodes, so the three-way replicated pools can place every copy on a different host.
+- Capacity for your retention: EventDB compresses blocks roughly 10:1, so plan the raw pool at three times the compressed volume plus growth. Do not fill Ceph past 80%.
+
+### A block StorageClass
+
+PostgreSQL data and WAL volumes, Valkey persistence, and NATS (if used) claim ReadWriteOnce volumes from a StorageClass you name in the values. Any performant block provisioner works: a local-path provisioner on NVMe, OpenEBS, Longhorn, or a Ceph RBD class from a Rook cluster you already run.
+
+PostgreSQL's WAL volume defaults to 30 GiB. Do not shrink it: the operator's replication slots retain WAL for a diverged replica until it is re-cloned, and a full WAL volume takes the primary, Atom, ingest, and queries down together.
+
+### A ReadWriteMany StorageClass for the shared WAL
+
+Six EventDB workloads mount one write-ahead-log volume, `eventdb-wal`, and that is true in every mode. The claim is `ReadWriteMany` because a `ReadWriteOnce` volume binds to a node, not a pod, and the first node replacement strands every pod that lands elsewhere behind a `Multi-Attach` error that cannot be cleared without deleting the claim.
+
+No cluster's default StorageClass provides RWX, so the chart refuses to render without one. The WAL provider you choose sets where it comes from:
+
+| Provider | Backing | For |
+| :--- | :--- | :--- |
+| `cephfs` | A `CephFilesystem` on the same Rook cluster that serves object storage. The chart creates the StorageClass. | Bare metal and air-gapped installs. This is the path the bare-metal guide uses. |
+| `existing` | An RWX class the cluster already has: NFS, a CephFS from another Rook release, a vendor filer. | Clusters with their own shared filesystem. |
+| `filestore` | GKE Filestore. | Google Cloud only. |
+
+Size the WAL for hours of raw ingest, not minutes: 100 GiB from 16,000 events per second upward. It is what keeps ingest accepting batches through an object-storage outage.
+
+## Object storage
+
+EventDB stores every block in S3-compatible object storage. Choose one of:
+
+- **Chart-managed Rook/Ceph RGW** (`objectStorage.provider: rook`). Self-contained, no external service, and the path validated on bare metal. The chart creates the RGW user, the credentials Secret, and the bucket.
+- **An S3-compatible store you already run** (`objectStorage.provider: external`): MinIO, SeaweedFS, another Ceph, or AWS S3. Provide the endpoint, bucket, region, and a static access key pair. The endpoint must be HTTPS with a certificate the pods trust.
+
+Two rules apply to either:
+
+<Warning>
+Do not put lifecycle or expiration rules on the bucket. EventDB manages retention per dataset and deletes its own blocks. A lifecycle rule deletes objects that EventDB still references, which is data loss. Object versioning likewise leaves deleted data behind; leave it off.
+</Warning>
+
+<Note>
+EventDB only speaks plain HTTP to an endpoint whose hostname is `localhost`, `127.0.0.1`, `::1`, or a `*.localhost` name. Every other hostname must use TLS. An in-cluster RGW answers on its Service name over HTTP, so the chart maps a `*.localhost` alias onto it through `eventdb.hostAliases`. The bare-metal guide does this in [Step 7](/self-hosted/deploy-bare-metal#step-7-install-the-chart).
+</Note>
+
+Object-storage bandwidth is the ceiling for both ingest and wide queries. A Rook RGW sharing nodes with the EventDB workloads saturated near 30,000 events per second on the validation clusters; dedicated storage nodes with NVMe OSDs and 25 GbE or better raise that.
+
+## Networking
+
+- Every node must reach your private registry to pull images.
+- EventDB pods reach PostgreSQL, Valkey, and the object store by in-cluster Service names; no external egress is required.
+- Atom is published through an Ingress. The controller must allow request bodies of at least 64 MiB (ingest batches) and upstream read timeouts of at least 600 seconds (long queries).
+- The Splunk and Grafana portals, if enabled, stay `ClusterIP` and must sit behind an authenticating proxy.
+- Nothing else is exposed. The EventDB Services are unauthenticated and stay inside the cluster.
+
+## Credentials
+
+Production installs set `credentials.create: false` and create these Secrets in the release namespace before installing. Values are embedded into connection URLs, so they must be URL-safe: letters, digits, `-`, `_`, and `.`.
+
+| Secret | Keys | Used by |
+| :--- | :--- | :--- |
+| `axiom-postgresql-app` | `username`, `password` | Every EventDB workload. CloudNativePG creates the database owner from it. |
+| `axiom-valkey-auth` | `default` | Every EventDB workload and Valkey's ACL. |
+| `eventdb-s3-credentials` | `access-key`, `secret-key` | Every EventDB workload and the bucket-setup Job. With the Rook provider, they seed the RGW user. |
+| `axiom-postgresql-atom` | `username`, `password` (type `kubernetes.io/basic-auth`) | Atom's PostgreSQL role. |
+| `axiom-atom` | `token-hash-secret`, `admin-password` | Atom. `token-hash-secret` HMACs every API token and must never change. |
+| `axiom-postgresql-backup` | `ACCESS_KEY_ID`, `ACCESS_SECRET_KEY` | PostgreSQL backups, when enabled. A different credential to a different bucket. |
+
+## Images
+
+The chart references these first-party images. Axiom provides the registry, credentials, and the release tag during onboarding.
+
+| Value | Image | Tag |
+| :--- | :--- | :--- |
+| `eventdb.image.db` | `eventdb-db` | The EventDB release tag |
+| `eventdb.image.queryWorker` | `eventdb-query-worker` | The EventDB release tag |
+| `eventdb.image.admin` | `eventdb-admin` | The EventDB release tag |
+| `atom.image` | `atom` | Atom's own commit, not the EventDB tag |
+| `splunkPortal.image` | `splunk-portal` | The portal's own commit |
+| `grafanaPortal.image` | `grafana-portal` | The portal's own commit, as `sha-<commit>` |
+
+Pin digests in production. Setting `digest` on any image takes precedence over `tag`, and a digest cannot be repointed at different content.
+
+The dependency subcharts pull their own upstream images: Rook, Ceph `v20.2.2`, the Ceph CSI plugins, CloudNativePG and its PostgreSQL 17 image, Valkey, NATS, plus `busybox`, `amazon/aws-cli`, and `natsio/nats-box` for bootstrap Jobs. [Step 2 of the bare-metal guide](/self-hosted/deploy-bare-metal#step-2-mirror-container-images) shows how to enumerate the exact list for your values.

--- a/content/docs/(documentation)/self-hosted/requirements.mdx
+++ b/content/docs/(documentation)/self-hosted/requirements.mdx
@@ -25,7 +25,7 @@ The chart runs on any conformant Kubernetes distribution, such as kubeadm, RKE2,
 | Kubernetes version | A currently supported release. The chart's dependencies (Rook 1.20, CloudNativePG 1.30) require 1.28 or later. |
 | CNI | Any CNI providing standard IPv4 pod networking. |
 | Container runtime | Any CRI-compatible runtime, such as containerd. |
-| DNS | Working in-cluster DNS. CoreDNS is only required if you use the chart's `localDns` rewrite, which is intended for single-purpose development clusters. |
+| DNS | Working in-cluster DNS. The chart's optional `localDns` rewrite maps the object-storage hostname onto the in-cluster RGW through CoreDNS, but only k3s imports the ConfigMap it writes; every other distribution uses `eventdb.hostAliases` for the same mapping. |
 | Metrics API | `metrics-server` or equivalent, required only when autoscaling is enabled. |
 | Ingress | An ingress controller and TLS issuance for publishing Atom. |
 | Prometheus Operator | Optional. Required for the chart's `ServiceMonitor` and `PrometheusRule` resources. |
@@ -113,7 +113,7 @@ Do not put lifecycle or expiration rules on the bucket. EventDB manages retentio
 </Warning>
 
 <Note>
-EventDB only speaks plain HTTP to an endpoint whose hostname is `localhost`, `127.0.0.1`, `::1`, or a `*.localhost` name. Every other hostname must use TLS. An in-cluster RGW answers on its Service name over HTTP, so the chart maps a `*.localhost` alias onto it through `eventdb.hostAliases`. The bare-metal guide does this in [Step 7](/self-hosted/deploy-bare-metal#step-7-install-the-chart).
+EventDB only speaks plain HTTP to an endpoint whose hostname is `localhost`, `127.0.0.1`, `::1`, or a `*.localhost` name. Every other hostname must use TLS. An in-cluster RGW answers on its Service name over HTTP, so a `*.localhost` alias is mapped onto it: by the chart's CoreDNS rewrite on k3s, or through `eventdb.hostAliases` elsewhere. The bare-metal guide does this in [Step 7](/self-hosted/deploy-bare-metal#step-7-install-the-chart).
 </Note>
 
 Object-storage bandwidth is the ceiling for both ingest and wide queries. A Rook RGW sharing nodes with the EventDB workloads saturated near 30,000 events per second on the validation clusters; dedicated storage nodes with NVMe OSDs and 25 GbE or better raise that.

--- a/content/docs/(documentation)/self-hosted/troubleshoot.mdx
+++ b/content/docs/(documentation)/self-hosted/troubleshoot.mdx
@@ -34,11 +34,11 @@ helm test axiom-eventdb -n axiom-system --logs
 
 ### Custom resources fail validation on the first install
 
-**Symptom.** The first `helm upgrade --install` fails with `no matches for kind "CephCluster"` or `"Cluster" in version "postgresql.cnpg.io/v1"`.
+**Symptom.** An install fails with `no matches for kind "CephCluster"` or `"Cluster" in version "postgresql.cnpg.io/v1"`.
 
-**Cause.** On a cluster that has never seen the chart's CRDs, Helm cannot validate custom resources introduced in the same transaction.
+**Cause.** The operators' CRDs did not go through Helm's `crds/` phase, which registers them before the templates are validated. That happens when rendered manifests are applied with `kubectl` instead of `helm install`, when the release is installed with `--skip-crds`, or when a `--dry-run` is validated against a cluster that has never seen the CRDs.
 
-**Fix.** Run the bootstrap pass from [Step 7](/self-hosted/deploy-bare-metal#step-7-install-the-chart) first, with `eventdb.enabled=false` and `atom.enabled=false`. Never run that pass against an existing release.
+**Fix.** Install with `helm upgrade --install` and without `--skip-crds`. The chart's companion CRD subcharts carry the definitions, and one transaction is enough; there is no separate bootstrap step.
 
 ## Ceph and object storage
 

--- a/content/docs/(documentation)/self-hosted/troubleshoot.mdx
+++ b/content/docs/(documentation)/self-hosted/troubleshoot.mdx
@@ -1,0 +1,197 @@
+---
+title: 'Troubleshoot self-hosted EventDB'
+sidebarTitle: Troubleshoot
+description: 'Symptoms, causes, and fixes for the failure modes seen on real self-hosted EventDB deployments: stranded WAL volumes, Ceph OSDs that never appear, plain-HTTP object-storage endpoints, autoscalers without metrics, and crash-looping bootstrap.'
+keywords: ['self-hosted', 'eventdb', 'troubleshoot', 'multi-attach', 'pending pvc', 'osd', 'ceph', 'helm', 'hpa', 'atom', 'migrate']
+---
+
+Each entry names the symptom you see, why it happens, and what to do. Start with the release as a whole:
+
+```bash
+helm status axiom-eventdb -n axiom-system
+kubectl -n axiom-system get pods,jobs,pvc
+kubectl -n axiom-system get cephcluster,cephobjectstore,cephfilesystem,cluster
+helm test axiom-eventdb -n axiom-system --logs
+```
+
+## Install and render
+
+### The render fails with a schema error
+
+**Symptom.** `helm template` or `helm upgrade` fails with `values don't meet the specifications of the schema`, naming a key.
+
+**Cause.** The chart validates every first-party value against `values.schema.json` and rejects unknown keys, so a misspelling fails immediately instead of being silently ignored.
+
+**Fix.** Read the key path in the message and compare it with `values.yaml` in the chart.
+
+### The render demands an RWX storage class
+
+**Symptom.** `eventdb.wal.storageClass is required` or a message about ReadWriteMany.
+
+**Cause.** Six workloads mount the shared WAL in every mode, and no cluster's default class provides RWX, so the chart refuses to leave the claim `Pending` with nothing to explain it.
+
+**Fix.** Choose a WAL provider. On bare metal, `eventdb.wal.provider: cephfs` with a `CephFilesystem` under `rookCephCluster.cephFileSystems`, as in the deployment guide. With the `cephfs` provider, `eventdb.wal.storageClass` must be empty; an explicit class wins over derivation.
+
+### Custom resources fail validation on the first install
+
+**Symptom.** The first `helm upgrade --install` fails with `no matches for kind "CephCluster"` or `"Cluster" in version "postgresql.cnpg.io/v1"`.
+
+**Cause.** On a cluster that has never seen the chart's CRDs, Helm cannot validate custom resources introduced in the same transaction.
+
+**Fix.** Run the bootstrap pass from [Step 7](/self-hosted/deploy-bare-metal#step-7-install-the-chart) first, with `eventdb.enabled=false` and `atom.enabled=false`. Never run that pass against an existing release.
+
+## Ceph and object storage
+
+### No OSD is created on a storage node
+
+**Symptom.** The CephCluster stays in phase `Progressing`, the `rook-ceph-osd-prepare-<node>` Job completes, but no `rook-ceph-osd-N` Deployment appears for that node.
+
+**Cause.** One of: the device path in `storage.nodes` does not match the node's `/dev/disk/by-id/` entry; the device carries an old filesystem, partition table, or LVM signature; or the node name in the inventory differs from `kubectl get nodes`.
+
+**Fix.** Read the prepare Job's log:
+
+```bash
+kubectl -n axiom-system logs job/rook-ceph-osd-prepare-<node>
+```
+
+Correct the inventory or wipe the device (`sgdisk --zap-all`, `wipefs --all`, then zero the first 100 MiB), delete the prepare Job, and the operator retries on its next reconcile.
+
+### Ceph reports `HEALTH_WARN` after install
+
+**Symptom.** `HEALTH_WARN` with `1 pool(s) do not have an application enabled` or clock-skew messages.
+
+**Cause.** Usually transient while pools and daemons settle. Clock skew between storage nodes is real and Ceph will not tolerate more than a few tens of milliseconds.
+
+**Fix.** Wait ten minutes. For skew, run NTP on every node. Anything else: `kubectl -n axiom-system exec deploy/rook-ceph-tools -- ceph health detail` if the toolbox is enabled, or read the manager pod's log.
+
+### EventDB refuses the object-storage endpoint
+
+**Symptom.** Ingest and query pods crash-loop, and the log says the endpoint is insecure, or that TLS is required.
+
+**Cause.** EventDB only speaks plain HTTP to `localhost`, `127.0.0.1`, `::1`, or a `*.localhost` hostname. An in-cluster RGW's Service name is not one of those.
+
+**Fix.** Keep `objectStorage.endpoint` on a `*.localhost` name and map it to the RGW Service's ClusterIP with `eventdb.hostAliases`, as in Step 7. For an external store, use HTTPS with a certificate the pods trust.
+
+### The bucket-setup Job fails
+
+**Symptom.** `eventdb-bucket-setup-rN` fails with a connection or authentication error.
+
+**Cause.** With the Rook provider, the RGW user has not been created yet, or the `eventdb-s3-credentials` Secret does not match the user Rook created. With an external provider, the credentials cannot reach the endpoint or may not create buckets.
+
+**Fix.** Check `kubectl -n axiom-system get cephobjectstoreuser eventdb` reports `Ready` and that its status names `eventdb-s3-credentials`. For an external store that forbids bucket creation, create the bucket out of band and set `objectStorage.createBucket: false`. The Job re-runs on the next upgrade.
+
+## Volumes
+
+### `Multi-Attach error for volume "pvc-..."` on the WAL
+
+**Symptom.** After a node replacement, an EventDB pod stays `ContainerCreating` with `Multi-Attach error ... Volume is already used by pod(s) eventdb-dataset-manager, eventdb-delta-cache, ...`.
+
+**Cause.** The WAL claim is `ReadWriteOnce`, which binds the volume to one node. Deleting the stranded pod reschedules it onto a node the volume is not attached to; deleting the others inverts which side is stuck. This does not self-heal.
+
+**Fix.** Recovery means deleting the claim, which discards whatever the WAL had not flushed. Then change the WAL to a ReadWriteMany provider so it cannot happen again: scale down the six workloads that mount `eventdb-wal`, delete the claim, set `eventdb.wal.provider` and `size` in the values, and upgrade. A claim's access mode, class, and size are immutable, which is why the migration goes through deletion.
+
+### A CephFS claim stays `Pending` while everything reports healthy
+
+**Symptom.** `eventdb-wal` is `Pending` with no provisioner event, and the Ceph cluster, filesystem, and MDS are all `Ready`.
+
+**Cause.** Rook 1.20 hands CSI to the ceph-csi-operator but never creates the CephFS `Driver` resource. The chart renders it whenever a `CephFilesystem` is declared under `rookCephCluster.cephFileSystems`; a filesystem created any other way has no provisioner.
+
+**Fix.** Declare the filesystem in the chart values so the driver, its ServiceAccounts, and RBAC are rendered. If the nodes lack the `cephfs` kernel module, add `mounter: fuse` to the StorageClass parameters.
+
+### The PostgreSQL WAL volume fills up
+
+**Symptom.** The primary stops accepting writes; Atom, ingest, and queries fail together. The `postgresql-N-wal` claim is at 100%.
+
+**Cause.** The operator's replication slots retain WAL for a replica that has diverged after a failover storm until that replica is re-cloned.
+
+**Fix.** Re-clone the diverged replica: delete its PVCs and pod, and the operator rebuilds it from the primary, releasing the retained WAL. The chart's 30 GiB default is headroom to notice this, not a fix; alert on the volume at 70%.
+
+## Workloads
+
+### Atom crash-loops right after install
+
+**Symptom.** `axiom-atom` restarts several times in the first minutes with `database not migrated` or similar.
+
+**Cause.** By design. `atom serve` refuses to start on an unmigrated database and is restarted by its controller until the `axiom-atom-migrate` Job completes, which itself waits for PostgreSQL to be ready and for the operator to create Atom's role and database.
+
+**Fix.** Wait for the Job. If it fails, its log names the cause; the usual one is a missing `atom` role or database under `postgresql.cluster.roles` and `postgresql.databases`, which the render should have refused.
+
+### EventDB pods crash-loop behind `eventdb-migrate`
+
+**Symptom.** The same shape as above for the EventDB workloads.
+
+**Cause.** The same: the workloads start before `eventdb-migrate-rN` has applied the schema, and recover once it has.
+
+**Fix.** Wait for the Job. A Job that fails on credentials means the `axiom-postgresql-app` password does not match what CloudNativePG seeded the role with; both read the same Secret at install, so this only happens when the Secret was recreated after the database.
+
+### The console's generated admin password is gone
+
+**Symptom.** `atom.admin.email` was left empty, and the one-time password Atom logged at first boot has scrolled out of the pod log.
+
+**Cause.** Without an email, Atom creates `admin@atom.local` and logs a generated password once.
+
+**Fix.** Read it from the pod log if it is still there. Otherwise, sign in through OIDC if configured, or reset the database owner's password directly in PostgreSQL. Set `atom.admin.email` on new installs so the password lives in the `axiom-atom` Secret instead.
+
+### Every API token stopped working at once
+
+**Symptom.** Every request to Atom returns `401` after an upgrade or a Secret change.
+
+**Cause.** The `token-hash-secret` key of the `axiom-atom` Secret changed. It HMACs every token at rest, so a new value invalidates all of them.
+
+**Fix.** Restore the previous value from your Secret backup. There is no other recovery; a permanently lost value means reissuing every token.
+
+### The query runner answers `Read request flood`
+
+**Symptom.** Queries fail immediately under a burst while the workers are idle.
+
+**Cause.** `eventdb.queryRunner.maxConcurrentQueries` is a per-pod admission cap, and a client's keep-alive pool lands a burst on one or two runner pods.
+
+**Fix.** Size the cap for the whole expected concurrency rather than dividing it by the pod count, and scale `queryWorker` for throughput.
+
+### An autoscaler never scales
+
+**Symptom.** The HPA holds the floor and reports `FailedGetResourceMetric`.
+
+**Cause.** The Metrics API is missing; utilisation targets read it.
+
+**Fix.** Install `metrics-server`. The floor and ceiling are enforced regardless.
+
+### Ingest lost data after a scale-down or a crash
+
+**Symptom.** Events accepted just before a pod stopped are missing from queries.
+
+**Cause.** A pod that stops without flushing leaves its WAL directory behind. The data is on the shared volume but invisible until the `eventdb-scan-nfs` CronJob finds a heartbeat older than `eventdb.scanNfs.orphanedAge` (25 hours by default) and queues a flush.
+
+**Fix.** Wait, or lower `orphanedAge` for the next run. Prefer graceful stops: `kubectl rollout restart` flushes; `kubectl delete pod --force` does not.
+
+## Credentials
+
+### `helm template` rotates generated credentials
+
+**Symptom.** With `credentials.create: true` and no explicit values, every render mints new passwords.
+
+**Cause.** `helm template` and `--dry-run` cannot read the cluster, so the chart cannot read back the Secrets it created earlier.
+
+**Fix.** Do not apply rendered manifests as an upgrade path. Use `helm upgrade`, which can read the existing Secrets. Production installs should set `credentials.create: false` and manage Secrets themselves.
+
+### A credential with special characters breaks a connection URL
+
+**Symptom.** A workload fails to connect to PostgreSQL or Valkey with a parse error, while `psql` with the same password works.
+
+**Cause.** Credentials are embedded into connection URLs by environment-variable expansion, so they must be URL-safe.
+
+**Fix.** Use letters, digits, `-`, `_`, and `.` only. The deployment guide generates hex values for this reason.
+
+## Getting help
+
+When you contact Axiom, include:
+
+```bash
+helm get values axiom-eventdb -n axiom-system > values-live.yaml
+helm history axiom-eventdb -n axiom-system
+kubectl -n axiom-system get pods,jobs,pvc,cephcluster,cluster -o wide
+kubectl -n axiom-system describe pod <failing-pod>
+kubectl -n axiom-system logs <failing-pod> --previous
+```
+
+Redact the credentials in `values-live.yaml` before sending it; with `credentials.create: false` it contains none.

--- a/content/docs/(documentation)/self-hosted/upgrade.mdx
+++ b/content/docs/(documentation)/self-hosted/upgrade.mdx
@@ -25,7 +25,7 @@ Two things an upgrade never does:
 - **It never changes a PersistentVolumeClaim.** Access mode, storage class, and size are immutable. See [Changes that need more than an upgrade](#changes-that-need-more-than-an-upgrade).
 
 <Warning>
-**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, `valkey.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data. Those toggles are install-time decisions. The bootstrap pass in the [deployment guide](/self-hosted/deploy-bare-metal#step-7-install-the-chart) is the only time they are turned off, and only on a cluster with no release yet.
+**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, `valkey.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data. Those toggles are install-time decisions, and there is no reason to turn them off on a running release.
 </Warning>
 
 ## Kinds of upgrade

--- a/content/docs/(documentation)/self-hosted/upgrade.mdx
+++ b/content/docs/(documentation)/self-hosted/upgrade.mdx
@@ -1,0 +1,261 @@
+---
+title: 'Upgrade self-hosted EventDB'
+sidebarTitle: Upgrade
+description: 'How to upgrade a self-hosted EventDB release safely: what an upgrade of the axiom-eventdb Helm chart does, the pre-flight checks, the step-by-step procedure for values, image, chart, and operator upgrades, topology changes that need care, and how to roll back.'
+keywords: ['self-hosted', 'eventdb', 'upgrade', 'helm upgrade', 'rollback', 'crd', 'rook', 'cloudnativepg', 'migration', 'atom']
+---
+
+Every change to a running self-hosted EventDB deployment is a `helm upgrade` of the same release with an edited values file, a new chart version, or both. This page explains what that command does, what to check before running it, and which changes need more than one step.
+
+Keep the values file under version control. Together with the chart version, it is the whole definition of the release, and a diff of the values file is the review of an upgrade.
+
+## What an upgrade does
+
+One `helm upgrade` runs one Helm transaction, and inside it:
+
+1. **Bootstrap Jobs run again.** `eventdb-bucket-setup`, `eventdb-migrate`, and, with Atom enabled, `axiom-atom-migrate` are named after the release revision, so each upgrade creates fresh ones. They are idempotent: the bucket Job is a no-op on an existing bucket, and the migrate Jobs apply only schema changes that have not been applied yet. The migrate Jobs wait for PostgreSQL before starting and retry a handful of times.
+2. **Changed configuration rolls the workloads.** Every workload that reads the shared `eventdb-config` ConfigMap carries a checksum of it in its pod template. A value that changes the ConfigMap therefore rolls the long-running controllers; the janitor CronJob picks the change up at its next run.
+3. **Changed images roll the workloads.** Deployments roll with their surge and unavailability defaults. The ingest StatefulSet rolls one pod at a time, in order, and each pod gets 60 seconds to stop gracefully, which flushes its WAL into a block before the next pod starts.
+4. **Workloads that start too early recover on their own.** EventDB processes and Atom refuse to start on an unmigrated database and are restarted by their controllers until the migrate Job completes. A few restarts in the first minutes of an upgrade are expected.
+5. **Operators reconcile their data planes.** Changes under `rookCephCluster` and `postgresql` are applied to the custom resources; Rook and CloudNativePG then carry them out on their own schedule, outside the Helm transaction.
+
+Two things an upgrade never does:
+
+- **It never upgrades CRDs.** Helm installs the files under a chart's `crds/` directory on first install and deliberately leaves them alone afterwards. A chart release that bumps Rook or CloudNativePG needs its CRDs applied by hand first. See [Operator upgrades](#operator-upgrades).
+- **It never changes a PersistentVolumeClaim.** Access mode, storage class, and size are immutable. See [Changes that need more than an upgrade](#changes-that-need-more-than-an-upgrade).
+
+<Warning>
+**Never disable a data-plane section on an upgrade.** Setting `rookCephCluster.enabled`, `postgresql.enabled`, `valkey.enabled`, or `eventdb.enabled` to `false` on a running release deletes the Ceph cluster, the PostgreSQL cluster, or the EventDB workloads, with their data. Those toggles are install-time decisions. The bootstrap pass in the [deployment guide](/self-hosted/deploy-bare-metal#step-7-install-the-chart) is the only time they are turned off, and only on a cluster with no release yet.
+</Warning>
+
+## Kinds of upgrade
+
+| Change | What moves | Downtime |
+| :--- | :--- | :--- |
+| Values only | The workloads whose configuration changed | Rolling; none for the query path, brief per-pod ingest flushes |
+| EventDB images | `eventdb-migrate`, then every EventDB workload | Rolling |
+| Atom or portal images | `axiom-atom-migrate`, then Atom; the portals roll independently | Rolling |
+| Chart version, same dependencies | Whatever the chart changed; read its notes | Usually rolling |
+| Chart version with a new operator or dependency | CRDs, the operator, then its data plane under the operator's control | Rolling for PostgreSQL with a primary switchover; Ceph stays available throughout a healthy upgrade |
+
+Chart versions are OCI artifacts at `oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb`. Prereleases are versioned `0.0.1-alpha.<sha>` after the commit that built them, so the version string does not say which of two prereleases is newer. Take the version and its notes from Axiom, and always pass the exact `--version`: Helm hides prereleases from version resolution.
+
+## Before you upgrade
+
+Run these checks against the live release. Skip none of them for a chart or operator upgrade.
+
+### Record the current state
+
+```bash
+NAMESPACE=axiom-system
+
+helm history axiom-eventdb -n $NAMESPACE
+helm get values axiom-eventdb -n $NAMESPACE > values-before.yaml
+helm get metadata axiom-eventdb -n $NAMESPACE   # the chart version you run today
+```
+
+Keep `values-before.yaml` and the revision number. They are what a rollback returns to.
+
+### Check the data plane is healthy
+
+```bash
+kubectl -n $NAMESPACE get cephcluster eventdb-ceph          # PHASE Ready, HEALTH HEALTH_OK
+kubectl -n $NAMESPACE get cluster postgresql                 # Cluster in healthy state
+kubectl -n $NAMESPACE get pods | grep -v -E 'Running|Completed'
+kubectl -n $NAMESPACE get pvc                                # nothing Pending
+```
+
+Rook refuses to upgrade Ceph while the cluster is not `HEALTH_OK`, by design, and CloudNativePG needs a healthy standby to switch the primary over to. Fix health first; do not set `skipUpgradeChecks` or `continueUpgradeAfterChecksEvenIfNotHealthy` to get past it.
+
+### Take a PostgreSQL backup
+
+A schema migration is the one part of an upgrade that a rollback cannot undo. With [backups enabled](/self-hosted/backup-restore), trigger an on-demand base backup and confirm it completes:
+
+```bash
+kubectl -n $NAMESPACE apply -f - <<YAML
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: pre-upgrade-$(date +%Y%m%d)
+spec:
+  cluster:
+    name: postgresql
+  method: barmanObjectStore
+YAML
+
+kubectl -n $NAMESPACE get backups
+```
+
+Without backups, this is the moment to enable them. The recovery point after this is at most five minutes behind.
+
+### Read what changes
+
+Render the release as it is and as it will be, and diff the two. This shows every workload that will roll and every field that will change, before anything touches the cluster:
+
+```bash
+NEW_CHART_VERSION=0.0.1-alpha.<sha>
+
+helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $(helm get metadata axiom-eventdb -n $NAMESPACE -o json | jq -r .version) \
+  --namespace $NAMESPACE --values values-before.yaml > rendered-before.yaml
+
+helm template axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $NEW_CHART_VERSION \
+  --namespace $NAMESPACE --values values.yaml > rendered-after.yaml
+
+diff -u rendered-before.yaml rendered-after.yaml | less
+```
+
+The render also validates the new values file against the chart's schema, so an unknown key or a missing storage class fails here rather than mid-upgrade. If you use the `helm diff` plugin, `helm diff upgrade` gives the same picture in one command.
+
+Look for three things in the diff: a change to `rookCephCluster.cephImage` or to the CloudNativePG operator image, which means an [operator upgrade](#operator-upgrades); any `replicas` field disappearing from a workload, which means autoscaling is being turned on and needs a quiet moment; and any change under `eventdb.wal`, which the upgrade will refuse.
+
+### Mirror the new images
+
+New EventDB, Atom, or portal tags must be in your registry before the upgrade, or the rollout stalls on `ImagePullBackOff`. Mirror them as in [Step 2 of the deployment guide](/self-hosted/deploy-bare-metal#step-2-mirror-container-images). For a chart that bumps a dependency, render it and mirror every image it references, and mirror the new `cephImage` tag if Rook moved.
+
+## Upgrade procedure
+
+### Step 1: Update the values file
+
+Edit `values.yaml` in version control. For an image upgrade that is the three `eventdb.image.*` tags, or `atom.image.tag`; pin digests where you can. For a values change, the keys in question. Do not add flags on the command line that are not in the file: `helm upgrade` applies exactly the values it is given, and a flag forgotten on the next upgrade reverts the change.
+
+### Step 2: Apply CRDs if the operators moved
+
+Only for a chart release whose notes say Rook or CloudNativePG was bumped. See [Operator upgrades](#operator-upgrades) for the full sequence; the CRD step is:
+
+```bash
+helm show crds oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb --version $NEW_CHART_VERSION \
+  > crds-$NEW_CHART_VERSION.yaml
+
+kubectl diff -f crds-$NEW_CHART_VERSION.yaml | less     # review the schema change
+kubectl apply --server-side --force-conflicts -f crds-$NEW_CHART_VERSION.yaml
+```
+
+`helm show crds` prints the CRDs from the chart and from its companion CRD subcharts, which is where the pinned Rook, Ceph CSI, and CloudNativePG definitions live.
+
+### Step 3: Run the upgrade
+
+Same release, same namespace, same values file, new version:
+
+```bash
+helm upgrade axiom-eventdb oci://ghcr.io/axiomhq/helm-charts/axiom-eventdb \
+  --version $NEW_CHART_VERSION \
+  --namespace $NAMESPACE \
+  --values values.yaml \
+  --timeout 15m
+```
+
+For a values-only or image-only change, pass the version you already run. Do not add `--wait`: the Jobs and the operators' reconciliation take longer than Helm's wait covers, and the next step watches them properly.
+
+### Step 4: Watch the Jobs and rollouts
+
+```bash
+wait_job() {
+  job=$(kubectl -n $NAMESPACE get job -l "app=$1" \
+    --sort-by=.metadata.creationTimestamp -o name | tail -n1)
+  kubectl -n $NAMESPACE wait --for=condition=complete "$job" --timeout=600s
+}
+
+wait_job eventdb-bucket-setup
+wait_job eventdb-migrate
+wait_job axiom-atom-migrate      # with Atom enabled
+
+kubectl -n $NAMESPACE rollout status statefulset/eventdb-ingest-prod --timeout=900s
+for w in eventdb-delta-cache eventdb-query-runner eventdb-query-worker \
+         eventdb-dataset-manager eventdb-queue-worker eventdb-admin axiom-atom; do
+  kubectl -n $NAMESPACE rollout status deployment/$w --timeout=600s
+done
+```
+
+A migrate Job that fails carries the reason in its log and blocks the workloads behind it; see [Troubleshoot](/self-hosted/troubleshoot#eventdb-pods-crash-loop-behind-eventdb-migrate). Ingest rolls one pod at a time, so a four-pod StatefulSet takes several minutes.
+
+### Step 5: Verify
+
+```bash
+helm test axiom-eventdb -n $NAMESPACE --logs
+helm history axiom-eventdb -n $NAMESPACE      # the new revision is "deployed"
+```
+
+Then ingest and query through Atom as in [Step 8 of the deployment guide](/self-hosted/deploy-bare-metal#step-8-verify-the-installation), and confirm the dashboards you alert from are still reporting.
+
+## Operator upgrades
+
+The chart pins Rook, Ceph, and CloudNativePG exactly, so a chart release that moves one of them is an operator upgrade. Rook and CloudNativePG each document an order, and a single Helm transaction does not enforce it. Follow the upstream ordering:
+
+### Rook and Ceph
+
+1. **Apply the new CRDs** as in Step 2 above.
+2. **Upgrade the operator without moving Ceph.** Pin `rookCephCluster.cephImage.tag` in your values to the tag you run today, so the chart bump upgrades the Rook operator alone. Run the upgrade and wait for the operator to reconcile: `kubectl -n $NAMESPACE get cephcluster eventdb-ceph` returns to `Ready` and `HEALTH_OK`, and the OSD, monitor, and manager pods restart once with the new operator's sidecars.
+3. **Then move Ceph.** Set `rookCephCluster.cephImage.tag` to the release's Ceph tag and upgrade again. Rook upgrades the daemons in order, monitors first, then managers, OSDs, MDS, and RGW, and checks health between each. Watch it with:
+
+   ```bash
+   kubectl -n $NAMESPACE get cephcluster eventdb-ceph -o jsonpath='{.status.ceph.versions}' | jq
+   ```
+
+   The upgrade is complete when every daemon reports one version.
+
+Ceph stays available throughout: the pools are replicated three ways and Rook takes down one daemon at a time. Ingest and queries continue.
+
+### CloudNativePG and PostgreSQL
+
+1. **Apply the new CRDs** as in Step 2.
+2. **Upgrade the operator.** The chart bump does this; the two operator replicas roll. A new operator version rolls the instance manager inside every PostgreSQL pod, replicas first and the primary last through a switchover, because the chart keeps the upstream defaults of `primaryUpdateMethod: switchover` and `primaryUpdateStrategy: unsupervised`. The switchover is a few seconds during which connections are refused; EventDB and Atom reconnect on their own.
+3. **A PostgreSQL minor version** follows from the operator's default image for `postgresql.version.postgresql` (17) and rolls the same way. A major version change is a new cluster restored from backup, not an upgrade; Axiom will say so in the release notes if one is ever needed.
+
+Watch a PostgreSQL rollout with:
+
+```bash
+kubectl -n $NAMESPACE get cluster postgresql -w
+kubectl -n $NAMESPACE get pods -l cnpg.io/cluster=postgresql -w
+```
+
+### Valkey and NATS
+
+Their subcharts roll their StatefulSets on an image change. Valkey's replication keeps the cache available; a cache miss during the roll is a slower query, not an error. With the NATS queue backend, the three-server JetStream cluster keeps the stream available while one server restarts; the bootstrap Job reconciles the stream afterwards.
+
+## Changes that need more than an upgrade
+
+Some values changes are legal but have a cost or a sequence that the upgrade itself does not show.
+
+**Turning autoscaling on.** The workload stops carrying a `replicas` field, and the count resets to one until the autoscaler's first reconcile restores the floor about fifteen seconds later. For ingest that is a window of rejected batches; for the delta cache and the runner, failed queries. Turn it on at a quiet moment and not alongside a change you want to watch. Turning it off has no such gap. See [Operate](/self-hosted/operate#scale-and-autoscale).
+
+**Moving from `single` to `multi` mode.** Replica counts rise, PodDisruptionBudgets appear, and with the NATS backend the bootstrap Job raises the JetStream stream to three replicas online. The WAL is unaffected because it is `ReadWriteMany` in both modes. The cluster needs the nodes to hold the multi-mode counts before you flip it.
+
+**Switching the job-queue backend.** Jobs queued on the old backend do not move across the switch: what is pending there is lost. Drain first, by letting the queue worker idle, or accept the loss. Moving to `postgres` needs an EventDB build that has it and `nats.enabled: false` in the same upgrade, because the render refuses `postgres` with an idle NATS cluster. Moving to `nats` needs the subchart enabled and creates the stream on that upgrade.
+
+**Switching object-storage providers.** Nothing migrates the objects. A release moved from Rook to an external store starts with an empty bucket; every existing dataset's blocks stay where they were and are unreachable. Treat this as a new deployment with a data migration you plan separately.
+
+**Changing the WAL.** `eventdb.wal.size`, `storageClass`, `provider`, and `accessModes` describe an immutable claim. The upgrade fails with `spec is immutable`. The migration is:
+
+1. Gracefully restart ingest so every pod flushes its WAL: `kubectl rollout restart statefulset/eventdb-ingest-prod` and wait for it.
+2. Scale the six workloads that mount `eventdb-wal` to zero: the ingest StatefulSet, delta cache, dataset manager, queue worker, admin, and suspend the `eventdb-scan-nfs` CronJob.
+3. Delete the `eventdb-wal` claim. **This discards anything a pod did not flush.**
+4. `helm upgrade` with the new values; the chart recreates the claim and scales the workloads back.
+
+The one exception is size on a class that allows expansion, such as the CephFS class in the deployment guide: edit the claim's `spec.resources.requests.storage` directly with `kubectl`, then set the same `eventdb.wal.size` in the values so the chart agrees with the cluster.
+
+**Rotating credentials.** Update the Secret, then roll the consumers so they read it: every EventDB workload reads its credentials into environment variables at start. Rotate `axiom-postgresql-app` and `axiom-postgresql-atom` through PostgreSQL first, or CloudNativePG's managed roles will re-apply the old password from the Secret they still see. `token-hash-secret` in `axiom-atom` is the one credential that must never rotate: a new value invalidates every API token Atom has issued.
+
+**Renaming the environment.** `eventdb.environment` keys the ingest StatefulSet name, the service locator, and the default cache prefix. Changing it renames the StatefulSet, which means a new one with an empty WAL directory per pod. Leave it alone on a running release.
+
+## Roll back
+
+Helm can return the release to any earlier revision:
+
+```bash
+helm history axiom-eventdb -n $NAMESPACE
+helm rollback axiom-eventdb <revision> -n $NAMESPACE --timeout 15m
+```
+
+A rollback is itself a new revision and behaves like an upgrade: the bootstrap Jobs run again, workloads roll back to the earlier images and configuration, and the operators reconcile any change to their custom resources in reverse. Watch it with the same commands as [Step 4](#step-4-watch-the-jobs-and-rollouts).
+
+What a rollback does not undo:
+
+- **Schema migrations.** `eventdb-migrate` and `axiom-atom-migrate` move the database forward only. Rolling the images back after a migration works only if that migration is compatible with the earlier build, which the release notes state. When it is not, the recovery is a [restore from the pre-upgrade backup](/self-hosted/backup-restore#restore) followed by the earlier images.
+- **CRDs.** Helm does not touch them in either direction. Rolling an operator back to a version whose CRDs lack fields the newer operator wrote is unsupported by both Rook and CloudNativePG; roll operators forward, not back.
+- **Ceph daemon versions.** Rook does not downgrade Ceph. A `cephImage` rollback is refused.
+- **Deleted volumes.** A WAL claim deleted during a migration is gone. Rolling back the values recreates an empty one.
+- **Lost queue jobs.** Jobs dropped by a backend switch do not come back.
+
+For a values-only or image-only upgrade, rolling back is routine. For a chart release that moved an operator, plan the rollback as forward recovery instead: fix the cause, then upgrade again.

--- a/docs.json
+++ b/docs.json
@@ -259,6 +259,17 @@
             ]
           },
           {
+            "group": "Self-hosted",
+            "pages": [
+              "self-hosted/overview",
+              "self-hosted/requirements",
+              "self-hosted/deploy-bare-metal",
+              "self-hosted/operate",
+              "self-hosted/backup-restore",
+              "self-hosted/troubleshoot"
+            ]
+          },
+          {
             "group": "Miscellaneous",
             "pages": [
               {

--- a/docs.json
+++ b/docs.json
@@ -265,6 +265,7 @@
               "self-hosted/requirements",
               "self-hosted/deploy-bare-metal",
               "self-hosted/operate",
+              "self-hosted/upgrade",
               "self-hosted/backup-restore",
               "self-hosted/troubleshoot"
             ]


### PR DESCRIPTION
## Summary

Adds a **Self-hosted** section to the Documentation tab covering deployment of the `axiom-eventdb` Helm chart on a bare-metal or on-premises Kubernetes cluster. Modelled on ClickHouse Private's [Deploy on bare metal](https://clickhouse.com/docs/cloud/clickhouse-private/tutorials/deploy-bare-metal) tutorial (prerequisites, numbered steps from cluster preparation through verification, next steps). Content is sourced from the chart README, `values.yaml`, and the `values-*.example.yaml` profiles in `axiomhq/helm-charts`, plus the Atom README.

| Page | Contents |
| :--- | :--- |
| `self-hosted/overview` | What the chart deploys, architecture diagram, Atom, what the customer provides, deployment modes |
| `self-hosted/requirements` | Kubernetes, node roles and failure domains, sizing, Ceph disks, block and RWX storage classes, object storage rules, networking, Secrets, images |
| `self-hosted/deploy-bare-metal` | The tutorial: Steps 1–8 (cluster prep, mirror images, storage, object storage, Secrets, full values file, single-transaction install, endpoint bridging, verification) |
| `self-hosted/operate` | Expose Atom (Ingress, OIDC), scaling and autoscaling, Prometheus, portals |
| `self-hosted/upgrade` | What a `helm upgrade` does, pre-flight checks, step-by-step procedure with CRD application, Rook/Ceph and CloudNativePG operator ordering, changes that need more than an upgrade, rollback limits |
| `self-hosted/backup-restore` | CloudNativePG Barman backups and point-in-time restore |
| `self-hosted/troubleshoot` | Symptom / cause / fix entries for the failure modes documented in the chart README |

Navigation: new top-level "Self-hosted" group in `docs.json`, before "Miscellaneous".

## Open points

Tracked on AXM-12586:

- Navigation placement, and whether to gate the section until the chart carries a supported version.
- Onboarding-provided inputs are placeholders: release registry, EventDB and Atom image tags, chart version, licence configuration.
- The Step 6 values file (storage-node placement, CephFS WAL) and the single-transaction install with a follow-up hostAliases upgrade have not yet been run end to end on a real multi-node bare-metal cluster.
- The operator-upgrade sequence on the upgrade page follows the chart README and upstream Rook/CloudNativePG guidance; it has not been rehearsed against a live release.
- Vale is not installed locally, so no style pass has run.

## Checks

- `node scripts/audit-content.mjs`: 0 unresolved links, 0 missing assets
- `pnpm typecheck`: passes
- All seven pages render HTTP 200 on `pnpm dev` with the expected heading anchors

Refs AXM-12586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu9dhtjCLGuGaMv7HADbUy