### PR TITLE
Document storage tiers

### DIFF
--- a/content/docs/(documentation)/reference/optimize-usage.mdx
+++ b/content/docs/(documentation)/reference/optimize-usage.mdx
@@ -24,6 +24,26 @@ The amount of storage you use depends on the following:
 
 The data retention period defines how long Axiom stores your data. After this period, Axiom trims the data and it doesn’t count towards your storage costs. You can define a custom data retention period for each dataset. For more information, see [Specify data retention period](/reference/datasets#specify-data-retention-period).
 
+### Storage tiers
+
+On the Axiom Cloud and Enterprise Cloud plans, Axiom automatically places your data in one of three storage tiers based on how recently it was queried:
+
+| Tier | Data in this tier |
+|:-----|:------------------|
+| Frequent | Newly ingested data, and any data that has been queried in the last 30 days. |
+| Infrequent | Data that hasn’t been queried for 30 consecutive days. |
+| Archive | Data that hasn’t been queried for 90 consecutive days. |
+
+Data in the Infrequent and Archive tiers is billed at lower rates than data in the Frequent tier. For the rates of each tier, see the [Axiom pricing page](https://axiom.co/pricing).
+
+Tiering happens automatically and doesn’t affect query performance. You don’t need to restore data before you query it. When you query data in the Infrequent or Archive tier, Axiom moves it back to the Frequent tier, and it moves down through the tiers again after 30 and 90 days without being queried.
+
+<Tip>
+To keep old data in the lower-cost tiers, scope queries to the time range you need. A query over a long time range can read all data in that range, even if only a few events match your filters, and the data it reads moves back to the Frequent tier.
+</Tip>
+
+To see how much of your data is in each tier, go to <Icon icon="gear" iconType="solid"/> **Settings > Usage**. For more information, see [Usage](/reference/usage-billing#usage).
+
 ## Optimize queries
 
 Axiom measures the resources used to execute queries in terms of GB-hours.

--- a/content/docs/(documentation)/reference/usage-billing.mdx
+++ b/content/docs/(documentation)/reference/usage-billing.mdx
@@ -116,7 +116,6 @@ The Usage page displays:
 - **Ingest**: The total amount of data ingested to Axiom.
 - **Query**: The total amount of query compute resources used to run queries.
 - **Storage**: The amount of data stored in each of your datasets, broken down by [storage tier](/reference/optimize-usage#storage-tiers).
-- **Fields**: The number of fields in each of your datasets.
 
 ### Monitor usage in detail
 

--- a/content/docs/(documentation)/reference/usage-billing.mdx
+++ b/content/docs/(documentation)/reference/usage-billing.mdx
@@ -115,6 +115,7 @@ The Usage page displays:
 
 - **Ingest**: The total amount of data ingested to Axiom.
 - **Query**: The total amount of query compute resources used to run queries.
+- **Storage**: The amount of data stored in each of your datasets, broken down by [storage tier](/reference/optimize-usage#storage-tiers).
 - **Fields**: The number of fields in each of your datasets.
 
 ### Monitor usage in detail


### PR DESCRIPTION
## Overview

Tiered storage is going GA for Axiom Cloud and Enterprise Cloud orgs (flag `atlas-ga-tiered-storage`; automated reporting is already live for Enterprise Cloud customers). The docs currently don't mention it anywhere, so this adds the minimum a customer needs to understand their storage bill:

- **Optimize usage → Optimize storage**: new *Storage tiers* subsection describing the Frequent / Infrequent / Archive tiers, the 30- and 90-day no-access thresholds, that querying moves data back to Frequent, and a tip to scope queries by time range so old data stays in the cheaper tiers.
- **Usage and billing → Usage**: adds *Storage* to the list of what the Usage page shows (per dataset, by tier) — this shipped in axiomhq/ctrl#8589.

Prices are deliberately not quoted here; the section links to the pricing page, which needs the per-tier rates added separately.

Sources: S3 Intelligent-Tiering behaviour (30 / 90 consecutive days without access, access moves objects back to Frequent), `pkg/core/common/billing/usage/storage/storage.go` (tier names, plan gating), and console tier labels in `pages/org-settings/usage`.

## Testing

- `pnpm audit:content` — no unresolved links
- `pnpm typecheck` — passes

Draft until the GA flag is on for all Axiom Cloud orgs and the pricing page lists the tier rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmGF9KGPXdgzraHThZH4pV
