### PR TITLE
docs: clarify Cursor MCP setup and cloud agent availability

### DIFF
--- a/content/docs/(documentation)/console/intelligence/mcp-server.mdx
+++ b/content/docs/(documentation)/console/intelligence/mcp-server.mdx
@@ -122,6 +122,8 @@ If you’re on the Free plan:
 1. [Install Axiom MCP Server](https://cursor.com/en/install-mcp?name=axiom&config=eyJ1cmwiOiJodHRwczovL21jcC5heGlvbS5jby9tY3AifQ%3D%3D).
 1. Authenticate the request in your browser.
 
+To add Axiom MCP Server for your Cursor team, go to **Dashboard > Integrations & MCP** in Cursor, and then add Axiom MCP Server using the URL `https://mcp.axiom.co/mcp`. To make it available to Cursor cloud agents, you must also make it available by default on **Dashboard > Plugins**.
+
 </Tab>
 <Tab title="Other clients">
 


### PR DESCRIPTION
## Overview

The Cursor setup on the Axiom MCP Server page only covered the one-click install, which adds the server to a single user's Cursor. It didn't explain how to add Axiom MCP Server for a Cursor team, or that cloud agents can't use it until it's made available by default.

This keeps the existing one-click install steps unchanged and adds a paragraph after them:

- For a Cursor team, add Axiom MCP Server on **Dashboard > Integrations & MCP** using the URL `https://mcp.axiom.co/mcp`.
- For Cursor cloud agents, make it available by default on **Dashboard > Plugins**.

Resolves CTRL-402.

## Changes

- `console/intelligence/mcp-server.mdx`: two lines added to the Cursor tab. No other content changed.

## Testing

- Ran `pnpm lint`, `pnpm typecheck`, `pnpm test` and `pnpm audit:content` locally. All pass, and the audit reports no unresolved links or missing assets. `pnpm build` wasn't run locally; CI runs it as part of `pnpm check`.
- Rendered the page with `pnpm dev` and checked that the Cursor tab contains the new text in both the HTML page and the processed Markdown output.
- Vale isn't installed locally, so the advisory Vale report from CI is the only prose lint on this change.
